### PR TITLE
METAMODEL-109: CassandraDataContext throws IllegalArgumentException with

### DIFF
--- a/cassandra/src/main/java/org/apache/metamodel/cassandra/CassandraDataContext.java
+++ b/cassandra/src/main/java/org/apache/metamodel/cassandra/CassandraDataContext.java
@@ -105,6 +105,9 @@ public class CassandraDataContext extends QueryPostprocessDataContext implements
     public static SimpleTableDef[] detectSchema(Cluster cluster, String keyspaceName) {
         final Metadata metadata = cluster.getMetadata();
         final KeyspaceMetadata keyspace = metadata.getKeyspace(keyspaceName);
+        if (keyspace == null) {
+            throw new IllegalArgumentException("Keyspace '" + keyspaceName + "' does not exist in the database");
+        }
         final Collection<TableMetadata> tables = keyspace.getTables();
         final SimpleTableDef[] result = new SimpleTableDef[tables.size()];
         int i = 0;

--- a/cassandra/src/test/java/org/apache/metamodel/cassandra/CassandraDataContextTest.java
+++ b/cassandra/src/test/java/org/apache/metamodel/cassandra/CassandraDataContextTest.java
@@ -197,6 +197,19 @@ public class CassandraDataContextTest extends CassandraTestCase {
         assertTrue(thrown);
     }
 
+    public void testNonExistentKeystore() {
+        if (!isConfigured()) {
+            System.err.println(getInvalidConfigurationMessage());
+            return;
+        }
+        try {
+            new CassandraDataContext(cluster, "nonExistentKeyspace");
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertNotNull(e);
+        }
+    }
+
     private void createCassandraKeySpaceAndTable(Session session) {
         session.execute("CREATE KEYSPACE IF NOT EXISTS " + getKeyspaceName() + " WITH replication "
                 + "= {'class':'SimpleStrategy', 'replication_factor':1};");


### PR DESCRIPTION
proper message instead of NPE when keystore does not exist.