### PR TITLE
Changes in Query and SelectItemParser to use IN and LIKE operartors into lowercase and AVG, MIN, MAX... functions into lowercase

### DIFF
--- a/core/src/main/java/org/apache/metamodel/query/Query.java
+++ b/core/src/main/java/org/apache/metamodel/query/Query.java
@@ -297,6 +297,8 @@ public final class Query extends BaseObject implements Cloneable, Serializable {
     }
 
     private FilterItem findFilterItem(String expression) {
+        String _upperExpression = expression.toUpperCase();
+
         final QueryPartCollectionProcessor collectionProcessor = new QueryPartCollectionProcessor();
         new QueryPartParser(collectionProcessor, expression, " AND ", " OR ").parse();
 
@@ -329,7 +331,7 @@ public final class Query extends BaseObject implements Cloneable, Serializable {
                 } else {
                     searchStr = operatorCandidate.toSql();
                 }
-                final int operatorIndex = expression.indexOf(searchStr);
+                final int operatorIndex = _upperExpression.indexOf(searchStr);
                 if (operatorIndex > 0) {
                     operator = operatorCandidate;
                     leftSide = expression.substring(0, operatorIndex).trim();

--- a/core/src/main/java/org/apache/metamodel/query/parser/QueryParser.java
+++ b/core/src/main/java/org/apache/metamodel/query/parser/QueryParser.java
@@ -88,7 +88,7 @@ public class QueryParser {
 
         {
             String selectClause = getSubstring(getLastEndIndex(selectIndices), fromIndices[0]);
-            if (selectClause.startsWith("DISTINCT ")) {
+            if (selectClause.toUpperCase().startsWith("DISTINCT ")) {
                 query.selectDistinct();
                 selectClause = selectClause.substring("DISTINCT ".length());
             }

--- a/core/src/main/java/org/apache/metamodel/query/parser/SelectItemParser.java
+++ b/core/src/main/java/org/apache/metamodel/query/parser/SelectItemParser.java
@@ -110,7 +110,7 @@ public final class SelectItemParser implements QueryPartProcessor {
         final int startParenthesis = expression.indexOf('(');
         if (startParenthesis > 0 && expression.endsWith(")")) {
             String functionName = expression.substring(0, startParenthesis);
-            function = FunctionType.get(functionName);
+            function = FunctionType.get(functionName.toUpperCase());
             if (function != null) {
                 expression = expression.substring(startParenthesis + 1, expression.length() - 1).trim();
                 if (function == FunctionType.COUNT && "*".equals(expression)) {

--- a/core/src/test/java/org/apache/metamodel/query/parser/QueryParserTest.java
+++ b/core/src/test/java/org/apache/metamodel/query/parser/QueryParserTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.metamodel.query.parser;
 
+import java.lang.String;
 import java.util.Arrays;
 import java.util.List;
 
@@ -93,6 +94,21 @@ public class QueryParserTest extends TestCase {
     public void testSelectDistinct() throws Exception {
         Query q = MetaModelHelper.parseQuery(dc, "SELECT DISTINCT foo, bar AS f FROM sch.tbl");
         assertEquals("SELECT DISTINCT tbl.foo, tbl.bar AS f FROM sch.tbl", q.toSql());
+    }
+
+    public void testSelectDistinctInLowerCase() throws Exception {
+        Query q = MetaModelHelper.parseQuery(dc, "SELECT distinct foo, bar AS f FROM sch.tbl");
+        assertEquals("SELECT DISTINCT tbl.foo, tbl.bar AS f FROM sch.tbl", q.toSql());
+    }
+
+    public void testSelectMinInLowerCase() throws Exception {
+        Query q = MetaModelHelper.parseQuery(dc, "SELECT min(tbl.foo) FROM sch.tbl");
+        assertEquals("SELECT MIN(tbl.foo) FROM sch.tbl", q.toSql());
+    }
+
+    public void testSelectAvgInLowerCase() throws Exception {
+        Query q = MetaModelHelper.parseQuery(dc, "SELECT avg(tbl.foo) FROM sch.tbl");
+        assertEquals("SELECT AVG(tbl.foo) FROM sch.tbl", q.toSql());
     }
 
     public void testSimpleSelectFrom() throws Exception {
@@ -237,6 +253,30 @@ public class QueryParserTest extends TestCase {
         assertEquals("a", ((List<?>) operand).get(0));
         assertEquals("b", ((List<?>) operand).get(1));
         assertEquals(5, ((List<?>) operand).get(2));
+    }
+
+    public void testWhereInInLowerCase() throws Exception {
+        Query q = MetaModelHelper.parseQuery(dc, "SELECT foo FROM sch.tbl WHERE foo in ('a','b',5)");
+        assertEquals("SELECT tbl.foo FROM sch.tbl WHERE tbl.foo IN ('a' , 'b' , '5')", q.toSql());
+
+        FilterItem whereItem = q.getWhereClause().getItem(0);
+        assertEquals(OperatorType.IN, whereItem.getOperator());
+        Object operand = whereItem.getOperand();
+        assertTrue(operand instanceof List);
+        assertEquals("a", ((List<?>) operand).get(0));
+        assertEquals("b", ((List<?>) operand).get(1));
+        assertEquals(5, ((List<?>) operand).get(2));
+    }
+
+    public void testWhereLikeInLowerCase() throws Exception {
+        Query q = MetaModelHelper.parseQuery(dc, "SELECT foo FROM sch.tbl WHERE foo like 'a%'");
+        assertEquals("SELECT tbl.foo FROM sch.tbl WHERE tbl.foo LIKE 'a%'", q.toSql());
+
+        FilterItem whereItem = q.getWhereClause().getItem(0);
+        assertEquals(OperatorType.LIKE, whereItem.getOperator());
+        Object operand = whereItem.getOperand();
+        assertTrue(operand instanceof String);
+        assertEquals("a%", operand);
     }
 
     public void testSimpleSubQuery() throws Exception {


### PR DESCRIPTION
- Updated findFilterItem method in order to find either upper and lowercase filter operator types in core/src/main/java/org/apache/metamodel/query/Query.java

It fix "IllegalArgumentException: Expression-based filters cannot be manually evaluated" while using like and in operators into lowercase.

- Updated findSelectItem method in order to find either upper and lowercase function types in core/src/main/java/org/apache/metamodel/query/parser/SelectItemParser.java

It fix "org.apache.metamodel.query.parser.QueryParserException: Not capable of parsing SELECT token: ..." while using avg, min, max... functions into lowercase.