### PR TITLE
changing select(expression) method of Query to support multiple columns ...

### DIFF
--- a/core/src/main/java/org/apache/metamodel/query/Query.java
+++ b/core/src/main/java/org/apache/metamodel/query/Query.java
@@ -122,14 +122,14 @@ public final class Query extends BaseObject implements Cloneable, Serializable {
      * @return
      */
     public Query select(String expression) {
-        if ("*".equals(expression)) {
-            return selectAll();
-        }
-        
         String[] possibleSelectItems = splitExpressionByComma(expression);
         for(String possibleSelectItem : possibleSelectItems) {
-              SelectItem selectItem = findSelectItem(possibleSelectItem, true);
-              select(selectItem);
+            if ("*".equals(possibleSelectItem)) {
+                selectAll();
+                continue;
+            }
+            SelectItem selectItem = findSelectItem(possibleSelectItem, true);
+            select(selectItem);
         }
         return this;
     }

--- a/core/src/main/java/org/apache/metamodel/query/Query.java
+++ b/core/src/main/java/org/apache/metamodel/query/Query.java
@@ -125,9 +125,35 @@ public final class Query extends BaseObject implements Cloneable, Serializable {
         if ("*".equals(expression)) {
             return selectAll();
         }
-
-        SelectItem selectItem = findSelectItem(expression, true);
-        return select(selectItem);
+        
+        String[] possibleSelectItems = splitExpressionByComma(expression);
+        for(String possibleSelectItem : possibleSelectItems) {
+              SelectItem selectItem = findSelectItem(possibleSelectItem, true);
+              select(selectItem);
+        }
+        return this;
+    }
+   
+    /**
+     * If multiple columns or expressions are given in comma seperated string, this methods splits and generates
+     * string array of expressions representing single column.
+     * @param expression
+     * @return
+     */
+    public String[] splitExpressionByComma(String expression) {
+              String[] intermediateSplit = expression.split(",");
+       List<String> expressionList = new ArrayList<String>();
+       for(int i=0 ; i < intermediateSplit.length ; i++) {
+              String token = intermediateSplit[i];
+              int openParanthesisIndex = token.lastIndexOf("(");
+              int closeParanthesisIndex = token.lastIndexOf(")");
+              if(openParanthesisIndex > -1 && (closeParanthesisIndex < 0 || openParanthesisIndex > closeParanthesisIndex)) {
+                     intermediateSplit[i+1] = token + "," + intermediateSplit[i+1];
+                     continue;
+              }
+              expressionList.add(token);
+       }
+       return expressionList.toArray(new String[expressionList.size()]);
     }
 
     private SelectItem findSelectItem(String expression, boolean allowExpressionBasedSelectItem) {

--- a/core/src/main/java/org/apache/metamodel/query/Query.java
+++ b/core/src/main/java/org/apache/metamodel/query/Query.java
@@ -122,38 +122,9 @@ public final class Query extends BaseObject implements Cloneable, Serializable {
      * @return
      */
     public Query select(String expression) {
-        String[] possibleSelectItems = splitExpressionByComma(expression);
-        for(String possibleSelectItem : possibleSelectItems) {
-            if ("*".equals(possibleSelectItem)) {
-                selectAll();
-                continue;
-            }
-            SelectItem selectItem = findSelectItem(possibleSelectItem, true);
-            select(selectItem);
-        }
+    	QueryPartParser clauseParser = new QueryPartParser(new SelectItemParser(this, true), expression, ",");
+        clauseParser.parse();
         return this;
-    }
-   
-    /**
-     * If multiple columns or expressions are given in comma seperated string, this methods splits and generates
-     * string array of expressions representing single column.
-     * @param expression
-     * @return
-     */
-    public String[] splitExpressionByComma(String expression) {
-              String[] intermediateSplit = expression.split(",");
-       List<String> expressionList = new ArrayList<String>();
-       for(int i=0 ; i < intermediateSplit.length ; i++) {
-              String token = intermediateSplit[i];
-              int openParanthesisIndex = token.lastIndexOf("(");
-              int closeParanthesisIndex = token.lastIndexOf(")");
-              if(openParanthesisIndex > -1 && (closeParanthesisIndex < 0 || openParanthesisIndex > closeParanthesisIndex)) {
-                     intermediateSplit[i+1] = token + "," + intermediateSplit[i+1];
-                     continue;
-              }
-              expressionList.add(token);
-       }
-       return expressionList.toArray(new String[expressionList.size()]);
     }
 
     private SelectItem findSelectItem(String expression, boolean allowExpressionBasedSelectItem) {

--- a/core/src/test/java/org/apache/metamodel/QueryPostprocessDataContextTest.java
+++ b/core/src/test/java/org/apache/metamodel/QueryPostprocessDataContextTest.java
@@ -1026,12 +1026,12 @@ public class QueryPostprocessDataContextTest extends MetaModelTestCase {
     public void testQueryWithMultipleColumnsInExpression() {
         Query query1 = new Query().from(table1).select("contributor_id,name");
         DataSet set = getDataContext().executeQuery(query1);
-        assertEquals(set.next(), true);
-        assertEquals(set.getRow().toString(), "Row[values=[1, kasper]]");
+        assertEquals(true,set.next());
+        assertEquals("Row[values=[1, kasper]]",set.getRow().toString());
         Query query2 = new Query().from(table1).select("Greatest(1,2,3),max(contributer_id)");
-        assertEquals(query2.toString(), "SELECT Greatest(1,2,3), MAX(contributer_id) FROM MetaModelSchema.contributor");
+        assertEquals("SELECT Greatest(1,2,3), MAX(contributer_id) FROM MetaModelSchema.contributor",query2.toString());
         Query query3 = new Query().from(table1).select("*,count(*)");
-        assertEquals(query3.toString(), "SELECT contributor.contributor_id, contributor.name, contributor.country, COUNT(*)"
-                      + " FROM MetaModelSchema.contributor");
+        assertEquals("SELECT contributor.contributor_id, contributor.name, contributor.country, COUNT(*)"
+                + " FROM MetaModelSchema.contributor",query3.toString());
     }
 }

--- a/core/src/test/java/org/apache/metamodel/QueryPostprocessDataContextTest.java
+++ b/core/src/test/java/org/apache/metamodel/QueryPostprocessDataContextTest.java
@@ -1022,4 +1022,16 @@ public class QueryPostprocessDataContextTest extends MetaModelTestCase {
 
         assertEquals("file.csv.foo = 'bar'", item.toSql());
     }
+    
+    public void testQueryWithMultipleColumnsInExpression() {
+        Query query1 = new Query().from(table1).select("contributor_id,name");
+        DataSet set = getDataContext().executeQuery(query1);
+        assertEquals(set.next(), true);
+        assertEquals(set.getRow().toString(), "Row[values=[1, kasper]]");
+        Query query2 = new Query().from(table1).select("Greatest(1,2,3),max(contributer_id)");
+        assertEquals(query2.toString(), "SELECT Greatest(1,2,3), MAX(contributer_id) FROM MetaModelSchema.contributor");
+        Query query3 = new Query().from(table1).select("*,count(*)");
+        assertEquals(query3.toString(), "SELECT contributor.contributor_id, contributor.name, contributor.country, COUNT(*)"
+                      + " FROM MetaModelSchema.contributor");
+    }
 }


### PR DESCRIPTION
This commit is related to issue METAMODEL - 125. This might not be the issue but it's annoying to have multiple select methods for each expression (ex. query.select("col1").select("max(col2)") especially if there are multiple such columns. This commit fixes this issue and now the above query can be specified as query.select("col1,max(col2)").