### PR TITLE
Upgrading hbase-client to 1.0.0 and downgrading Guava to 16.0

### DIFF
--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -20,7 +20,7 @@
 	<name>MetaModel module for Apache HBase</name>
 
 	<properties>
-		<hbase.version>0.95.1-hadoop1</hbase.version>
+		<hbase.version>1.0.0</hbase.version>
 	</properties>
 
 	<dependencies>
@@ -113,6 +113,10 @@
 				<exclusion>
 					<groupId>org.codehaus.jackson</groupId>
 					<artifactId>jackson-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.codehaus.jackson</groupId>
+					<artifactId>jackson-core-asl</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ under the License.
 		<javadoc.version>2.9.1</javadoc.version>
 		<slf4j.version>1.7.7</slf4j.version>
 		<junit.version>4.11</junit.version>
-		<guava.version>18.0</guava.version>
+		<guava.version>16.0</guava.version>
 		<easymock.version>3.2</easymock.version>
 		<httpcomponents.version>4.3.1</httpcomponents.version>
 		<checksum-maven-plugin.version>1.2</checksum-maven-plugin.version>


### PR DESCRIPTION
Issue: METAMODEL-93.

Tested on Ubuntu 14.04.2 with HBase 1.0.0 installed.