### PR TITLE
Added HdfsResource integration test

### DIFF
--- a/example-metamodel-integrationtest-configuration.properties
+++ b/example-metamodel-integrationtest-configuration.properties
@@ -22,6 +22,15 @@
 #mongodb.databaseName=metamodel_test
 #mongodb.collectionName=my_collection
 
+# -------------------------
+# Hadoop module properties:
+# -------------------------
+
+#hadoop.hdfs.hostname=localhost
+#hadoop.hdfs.port=9000
+#hadoop.hdfs.file.path=/apache_metamodel_testfile.txt
+
+
 # ------------------------
 # HBase module properties:
 # ------------------------

--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -119,6 +119,14 @@
 					<groupId>org.codehaus.jackson</groupId>
 					<artifactId>jackson-core-asl</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.codehaus.jackson</groupId>
+					<artifactId>jackson-jaxrs</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.codehaus.jackson</groupId>
+					<artifactId>jackson-xc</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>

--- a/hadoop/src/main/java/org/apache/metamodel/util/HdfsResource.java
+++ b/hadoop/src/main/java/org/apache/metamodel/util/HdfsResource.java
@@ -18,7 +18,6 @@
  */
 package org.apache.metamodel.util;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -35,16 +34,13 @@ import org.apache.metamodel.MetaModelException;
  * A {@link Resource} implementation that connects to Apache Hadoop's HDFS
  * distributed file system.
  */
-public class HdfsResource implements Resource, Closeable {
+public class HdfsResource implements Resource {
 
     private static final Pattern URL_PATTERN = Pattern.compile("hdfs://(.+):([0-9]+)/(.*)");
 
     private final String _hostname;
     private final int _port;
     private final String _filepath;
-
-    private FileSystem _fileSystem;
-
     private Path _path;
 
     /**
@@ -214,14 +210,11 @@ public class HdfsResource implements Resource, Closeable {
     }
 
     public FileSystem getHadoopFileSystem() {
-        if (_fileSystem == null) {
-            try {
-                _fileSystem = FileSystem.get(getHadoopConfiguration());
-            } catch (IOException e) {
-                throw new MetaModelException("Could not connect to HDFS: " + e.getMessage(), e);
-            }
+        try {
+            return FileSystem.get(getHadoopConfiguration());
+        } catch (IOException e) {
+            throw new MetaModelException("Could not connect to HDFS: " + e.getMessage(), e);
         }
-        return _fileSystem;
     }
 
     public Path getHadoopPath() {
@@ -229,23 +222,6 @@ public class HdfsResource implements Resource, Closeable {
             _path = new Path(_filepath);
         }
         return _path;
-    }
-
-    @Override
-    public void close() throws IOException {
-        if (_fileSystem != null) {
-            try {
-                _fileSystem.close();
-            } finally {
-                _fileSystem = null;
-            }
-        }
-    }
-
-    @Override
-    protected void finalize() throws Throwable {
-        super.finalize();
-        close();
     }
 
     @Override

--- a/hadoop/src/main/java/org/apache/metamodel/util/HdfsResource.java
+++ b/hadoop/src/main/java/org/apache/metamodel/util/HdfsResource.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.metamodel.util;
 
 import java.io.Closeable;

--- a/hadoop/src/test/java/org/apache/metamodel/util/HdfsResourceIntegrationTest.java
+++ b/hadoop/src/test/java/org/apache/metamodel/util/HdfsResourceIntegrationTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.metamodel.util;
 
 import java.io.File;

--- a/hadoop/src/test/java/org/apache/metamodel/util/HdfsResourceIntegrationTest.java
+++ b/hadoop/src/test/java/org/apache/metamodel/util/HdfsResourceIntegrationTest.java
@@ -80,9 +80,6 @@ public class HdfsResourceIntegrationTest extends TestCase {
         final HdfsResource res1 = new HdfsResource(_hostname, _port, _filePath);
         logger.info(stopwatch.elapsed(TimeUnit.MILLISECONDS) + " - start");
 
-        assertFalse(res1.isExists());
-        logger.info(stopwatch.elapsed(TimeUnit.MILLISECONDS) + " - exists");
-
         res1.write(new Action<OutputStream>() {
             @Override
             public void run(OutputStream out) throws Exception {

--- a/hadoop/src/test/java/org/apache/metamodel/util/HdfsResourceIntegrationTest.java
+++ b/hadoop/src/test/java/org/apache/metamodel/util/HdfsResourceIntegrationTest.java
@@ -1,0 +1,81 @@
+package org.apache.metamodel.util;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Properties;
+
+import junit.framework.TestCase;
+
+public class HdfsResourceIntegrationTest extends TestCase {
+
+    private boolean _configured;
+    private Properties _properties;
+    private String _filePath;
+    private String _hostname;
+    private int _port;
+
+    @Override
+    protected final void setUp() throws Exception {
+        super.setUp();
+
+        _properties = new Properties();
+        final File file = new File(getPropertyFilePath());
+        if (file.exists()) {
+            _properties.load(new FileReader(file));
+            _filePath = _properties.getProperty("hadoop.hdfs.file.path");
+            _hostname = _properties.getProperty("hadoop.hdfs.hostname");
+            final String portString = _properties.getProperty("hadoop.hdfs.port");
+            _configured = _filePath != null && _hostname != null && portString != null;
+            if (_configured) {
+                _port = Integer.parseInt(portString);
+            }
+        } else {
+            _configured = false;
+        }
+    }
+
+    private String getPropertyFilePath() {
+        String userHome = System.getProperty("user.home");
+        return userHome + "/metamodel-integrationtest-configuration.properties";
+    }
+
+    public void testReadOnRealHdfsInstall() throws Exception {
+        if (!_configured) {
+            System.err.println("!!! WARN !!! Hadoop HDFS integration test ignored\r\n"
+                    + "Please configure Hadoop HDFS test-properties (" + getPropertyFilePath()
+                    + "), to run integration tests");
+            return;
+        }
+        final String contentString = "fun and games with Apache MetaModel and Hadoop is what we do";
+        final HdfsResource res1 = new HdfsResource(_hostname, _port, _filePath);
+        try {
+            assertFalse(res1.isExists());
+
+            res1.write(new Action<OutputStream>() {
+                @Override
+                public void run(OutputStream out) throws Exception {
+                    out.write(contentString.getBytes());
+                }
+            });
+
+            assertTrue(res1.isExists());
+
+            final String str = res1.read(new Func<InputStream, String>() {
+                @Override
+                public String eval(InputStream in) {
+                    return FileHelper.readInputStreamAsString(in, "UTF8");
+                }
+            });
+
+            assertEquals(contentString, str);
+            res1.getHadoopFileSystem().delete(res1.getHadoopPath(), false);
+
+            assertFalse(res1.isExists());
+
+        } finally {
+            res1.close();
+        }
+    }
+}

--- a/hadoop/src/test/java/org/apache/metamodel/util/HdfsResourceTest.java
+++ b/hadoop/src/test/java/org/apache/metamodel/util/HdfsResourceTest.java
@@ -38,9 +38,5 @@ public class HdfsResourceTest extends TestCase {
         assertEquals("apache.txt", res3.getName());
 
         assertFalse(res3.equals(res1));
-
-        res1.close();
-        res2.close();
-        res3.close();
     }
 }

--- a/hadoop/src/test/java/org/apache/metamodel/util/HdfsResourceTest.java
+++ b/hadoop/src/test/java/org/apache/metamodel/util/HdfsResourceTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.metamodel.util;
 
 import junit.framework.TestCase;

--- a/hadoop/src/test/resources/log4j.xml
+++ b/hadoop/src/test/resources/log4j.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+	<appender name="consoleAppender" class="org.apache.log4j.ConsoleAppender">
+		<param name="Target" value="System.out" />
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern" value="%-5p %d{HH:mm:ss} %c{1} - %m%n" />
+		</layout>
+	</appender>
+
+	<logger name="org.apache.metamodel">
+		<level value="info" />
+	</logger>
+
+	<root>
+		<priority value="fatal" />
+		<appender-ref ref="consoleAppender" />
+	</root>
+
+</log4j:configuration>


### PR DESCRIPTION
Trying to make the story more complete wrt. the HdfsResource testability. I made it use our normal integration test approach of having properties in ${user.home}/metamodel-integrationtest-configuration.properties that drive the setup of the test.