### PR TITLE
METAMODEL-152

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ### Apache MetaModel (unreleased work)
 
  * [METAMODEL-148] - Added a 'hadoop' module with a HdfsResource class to allow CSV, Excel and Fixed-width file access on HDFS.
+ * [METAMODEL-152] - Fixed an issue of not clearing schema cache when refreshSchemas() is invoked.
  * [METAMODEL-149] - Added support for COUNTER data type in Cassandra.
  * [METAMODEL-151] - Added support for DOUBLE data type mapping in PostgreSQL
 

--- a/core/src/main/java/org/apache/metamodel/AbstractDataContext.java
+++ b/core/src/main/java/org/apache/metamodel/AbstractDataContext.java
@@ -54,7 +54,16 @@ public abstract class AbstractDataContext implements DataContext {
     public final DataContext refreshSchemas() {
         _schemaCache.clear();
         _schemaNameCache = null;
+        onSchemaCacheRefreshed();
         return this;
+    }
+
+    /**
+     * Method invoked when schemas have been refreshed using
+     * {@link #refreshSchemas()}. Can be overridden to add callback
+     * functionality in subclasses.
+     */
+    protected void onSchemaCacheRefreshed() {
     }
 
     /**
@@ -111,12 +120,12 @@ public abstract class AbstractDataContext implements DataContext {
     @Override
     public final Schema getDefaultSchema() throws MetaModelException {
         Schema result = null;
-        String defaultSchemaName = getDefaultSchemaName();
+        final String defaultSchemaName = getDefaultSchemaName();
         if (defaultSchemaName != null) {
             result = getSchemaByName(defaultSchemaName);
         }
         if (result == null) {
-            Schema[] schemas = getSchemas();
+            final Schema[] schemas = getSchemas();
             if (schemas.length == 1) {
                 result = schemas[0];
             } else {
@@ -126,7 +135,7 @@ public abstract class AbstractDataContext implements DataContext {
                     String name = schema.getName();
                     if (schema != null) {
                         name = name.toLowerCase();
-                        boolean isInformationSchema = name.startsWith("information") && name.endsWith("schema");
+                        final boolean isInformationSchema = name.startsWith("information") && name.endsWith("schema");
                         if (!isInformationSchema && schema.getTableCount() > highestTableCount) {
                             highestTableCount = schema.getTableCount();
                             result = schema;

--- a/core/src/main/java/org/apache/metamodel/QueryPostprocessDataContext.java
+++ b/core/src/main/java/org/apache/metamodel/QueryPostprocessDataContext.java
@@ -76,8 +76,6 @@ public abstract class QueryPostprocessDataContext extends AbstractDataContext im
 
     private final Map<Column, TypeConverter<?, ?>> _converters;
 
-    private Schema _mainSchema;
-
     public QueryPostprocessDataContext() {
         super();
         _converters = new HashMap<Column, TypeConverter<?, ?>>();
@@ -432,7 +430,7 @@ public abstract class QueryPostprocessDataContext extends AbstractDataContext im
         schemaNames[1] = getMainSchemaName();
         return schemaNames;
     }
-
+    
     @Override
     protected String getDefaultSchemaName() throws MetaModelException {
         return getMainSchemaName();
@@ -449,7 +447,7 @@ public abstract class QueryPostprocessDataContext extends AbstractDataContext im
         }
 
         if (name.equalsIgnoreCase(mainSchemaName)) {
-            return getMainSchemaInternal();
+            return getMainSchema();
         } else if (name.equals(INFORMATION_SCHEMA_NAME)) {
             return getInformationSchema();
         }
@@ -513,7 +511,7 @@ public abstract class QueryPostprocessDataContext extends AbstractDataContext im
         final String tableName = table.getName();
         final SelectItem[] columnSelectItems = MetaModelHelper.createSelectItems(table.getColumns());
         final SimpleDataSetHeader header = new SimpleDataSetHeader(columnSelectItems);
-        final Table[] tables = getMainSchemaInternal().getTables();
+        final Table[] tables = getDefaultSchema().getTables();
         final List<Row> data = new ArrayList<Row>();
         if ("tables".equals(tableName)) {
             // "tables" columns: name, type, num_columns, remarks
@@ -541,7 +539,7 @@ public abstract class QueryPostprocessDataContext extends AbstractDataContext im
         } else if ("relationships".equals(tableName)) {
             // "relationships" columns: primary_table, primary_column,
             // foreign_table, foreign_column
-            for (Relationship r : getMainSchemaInternal().getRelationships()) {
+            for (Relationship r : getDefaultSchema().getRelationships()) {
                 Column[] primaryColumns = r.getPrimaryColumns();
                 Column[] foreignColumns = r.getForeignColumns();
                 Table pTable = r.getPrimaryTable();
@@ -571,13 +569,15 @@ public abstract class QueryPostprocessDataContext extends AbstractDataContext im
         return dataSet;
     }
 
+    /**
+     * 
+     * @return
+     * 
+     * @deprecated use {@link #getDefaultSchema()} instead
+     */
+    @Deprecated
     protected Schema getMainSchemaInternal() {
-        Schema schema = _mainSchema;
-        if (schema == null) {
-            schema = getMainSchema();
-            _mainSchema = schema;
-        }
-        return schema;
+        return getDefaultSchema();
     }
 
     /**

--- a/excel/pom.xml
+++ b/excel/pom.xml
@@ -40,7 +40,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>3.9</version>
+			<version>3.12</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-logging</groupId>

--- a/excel/src/main/java/org/apache/metamodel/excel/ExcelDataContext.java
+++ b/excel/src/main/java/org/apache/metamodel/excel/ExcelDataContext.java
@@ -74,9 +74,9 @@ public final class ExcelDataContext extends QueryPostprocessDataContext implemen
      * Constructs an Excel DataContext based on a resource and a custom
      * configuration.
      *
-     * The file provided can be either existing or non-existing. In the
-     * case of non-existing files, a file will be automatically created
-     * when a CREATE TABLE update is executed on the DataContext.
+     * The file provided can be either existing or non-existing. In the case of
+     * non-existing files, a file will be automatically created when a CREATE
+     * TABLE update is executed on the DataContext.
      * 
      * @param file
      * @param configuration
@@ -151,10 +151,10 @@ public final class ExcelDataContext extends QueryPostprocessDataContext implemen
         try {
             SpreadsheetReaderDelegate delegate = getSpreadsheetReaderDelegate(inputStreamRef);
             inputStream = inputStreamRef.get();
-            
+
             // METAMODEL-47: Ensure that we have loaded the schema at this point
             getDefaultSchema();
-            
+
             DataSet dataSet = delegate.executeQuery(inputStream, table, columns, maxRows);
             return dataSet;
         } catch (Exception e) {
@@ -191,6 +191,12 @@ public final class ExcelDataContext extends QueryPostprocessDataContext implemen
         }
     }
 
+    @Override
+    protected void onSchemaCacheRefreshed() {
+        super.onSchemaCacheRefreshed();
+        _spreadsheetReaderDelegate = null;
+    }
+
     /**
      * Convenient method for testing and inspecting internal state.
      * 
@@ -203,7 +209,8 @@ public final class ExcelDataContext extends QueryPostprocessDataContext implemen
         return null;
     }
 
-    private SpreadsheetReaderDelegate getSpreadsheetReaderDelegate(Ref<InputStream> inputStream) throws MetaModelException {
+    private SpreadsheetReaderDelegate getSpreadsheetReaderDelegate(Ref<InputStream> inputStream)
+            throws MetaModelException {
         if (_spreadsheetReaderDelegate == null) {
             synchronized (this) {
                 if (_spreadsheetReaderDelegate == null) {

--- a/excel/src/test/java/org/apache/metamodel/excel/ExcelDataContextTest.java
+++ b/excel/src/test/java/org/apache/metamodel/excel/ExcelDataContextTest.java
@@ -586,10 +586,15 @@ public class ExcelDataContextTest extends TestCase {
         assertFalse(ds.next());
     }
 
-    public void testCreateTable() throws Exception {
+    public void testCreateTableXls() throws Exception {
         // run the same test with both XLS and XLSX (because of different
         // workbook implementations)
         runCreateTableTest(new File("target/xls_people_created.xls"));
+    }
+
+    public void testCreateTableXlsx() throws Exception {
+        // run the same test with both XLS and XLSX (because of different
+        // workbook implementations)
         runCreateTableTest(new File("target/xls_people_created.xlsx"));
     }
 
@@ -680,8 +685,7 @@ public class ExcelDataContextTest extends TestCase {
 
         dc.refreshSchemas();
 
-        assertEquals("[my_table_2]", Arrays.toString(schema.getTableNames()));
-
+        assertEquals("[my_table_2]", Arrays.toString(dc.getDefaultSchema().getTableNames()));
         assertEquals(1, dc.getDefaultSchema().getTableCount());
     }
 


### PR DESCRIPTION
This fixes the pretty critical caching issue we have where even a ```refreshSchemas()``` call does not clear the cache of the "main schema" in QueryPostprocessDataContext.

I simplified the QueryPostprocessDataContext a bit by not having any cache at all. That's because there already is a schema cache in it's superclass, AbstractDataContext.