### PR TITLE
Apache Hive support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Apache MetaModel (work in progress)
+
+ * [METAMODEL-160] - Added support for Apache Hive via the JDBC module of MetaModel.
+
 ### Apache MetaModel 4.3.5
 
  * [METAMODEL-148] - Added a 'hadoop' module with a HdfsResource class to allow CSV, Excel and Fixed-width file access on HDFS.

--- a/example-metamodel-integrationtest-configuration.properties
+++ b/example-metamodel-integrationtest-configuration.properties
@@ -78,6 +78,11 @@
 #jdbc.sqlserver.microsoft_driver.username=
 #jdbc.sqlserver.microsoft_driver.password=
 
+#jdbc.hive.driver=org.apache.hive.jdbc.HiveDriver
+#jdbc.hive.url=jdbc:hive2://localhost:10000
+#jdbc.hive.username=
+#jdbc.hive.password=
+
 # -----------------------------
 # Salesforce module properties:
 # -----------------------------

--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -19,10 +19,6 @@
 	<artifactId>MetaModel-hadoop</artifactId>
 	<name>MetaModel module for Apache Hadoop, HDFS, YARN integration</name>
 
-	<properties>
-		<hadoop.version>2.6.0</hadoop.version>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.metamodel</groupId>
@@ -31,102 +27,11 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-client</artifactId>
-			<version>${hadoop.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>jdk.tools</groupId>
-					<artifactId>jdk.tools</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.slf4j</groupId>
-					<artifactId>slf4j-log4j12</artifactId>
-				</exclusion>
-				<exclusion>
-					<artifactId>log4j</artifactId>
-					<groupId>log4j</groupId>
-				</exclusion>
-				<exclusion>
-					<artifactId>commons-logging</artifactId>
-					<groupId>commons-logging</groupId>
-				</exclusion>
-				<exclusion>
-					<artifactId>jetty</artifactId>
-					<groupId>org.mortbay.jetty</groupId>
-				</exclusion>
-				<exclusion>
-					<artifactId>jetty-util</artifactId>
-					<groupId>org.mortbay.jetty</groupId>
-				</exclusion>
-				<exclusion>
-					<groupId>tomcat</groupId>
-					<artifactId>jasper-runtime</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>tomcat</groupId>
-					<artifactId>jasper-compiler</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>javax.servlet</groupId>
-					<artifactId>servlet-api</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>google-collections</groupId>
-					<artifactId>google-collections</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>net.sourceforge.collections</groupId>
-					<artifactId>collections-generic</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jersey</groupId>
-					<artifactId>jersey-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jersey</groupId>
-					<artifactId>jersey-server</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.mortbay.jetty</groupId>
-					<artifactId>jsp-2.1</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jersey</groupId>
-					<artifactId>jersey-json</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.mortbay.jetty</groupId>
-					<artifactId>jsp-api-2.1</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>io.netty</groupId>
-					<artifactId>netty</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-httpclient</groupId>
-					<artifactId>commons-httpclient</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.codehaus.jackson</groupId>
-					<artifactId>jackson-mapper-asl</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.codehaus.jackson</groupId>
-					<artifactId>jackson-core</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.codehaus.jackson</groupId>
-					<artifactId>jackson-core-asl</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.codehaus.jackson</groupId>
-					<artifactId>jackson-jaxrs</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.codehaus.jackson</groupId>
-					<artifactId>jackson-xc</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -9,7 +9,8 @@
 	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
 	OF ANY KIND, either express or implied. See the License for the specific 
 	language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<parent>
 		<artifactId>MetaModel</artifactId>
 		<groupId>org.apache.metamodel</groupId>
@@ -28,6 +29,10 @@
 			<groupId>org.apache.metamodel</groupId>
 			<artifactId>MetaModel-hadoop</artifactId>
 			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
@@ -99,10 +104,6 @@
 					<artifactId>jsp-api-2.1</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>commons-cli</groupId>
-					<artifactId>commons-cli</artifactId>
-				</exclusion>
-				<exclusion>
 					<groupId>io.netty</groupId>
 					<artifactId>netty</artifactId>
 				</exclusion>
@@ -121,6 +122,14 @@
 				<exclusion>
 					<groupId>org.codehaus.jackson</groupId>
 					<artifactId>jackson-core-asl</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.codehaus.jackson</groupId>
+					<artifactId>jackson-jaxrs</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.codehaus.jackson</groupId>
+					<artifactId>jackson-xc</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -17,7 +17,8 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<parent>
 		<artifactId>MetaModel</artifactId>
 		<groupId>org.apache.metamodel</groupId>
@@ -102,6 +103,22 @@ under the License.
 			<artifactId>jtds</artifactId>
 			<version>1.2.4</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-common</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.hive</groupId>
+			<artifactId>hive-jdbc</artifactId>
+			<version>1.2.1</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>jdk.tools</groupId>
+					<artifactId>jdk.tools</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 </project>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -118,7 +118,16 @@ under the License.
 					<groupId>jdk.tools</groupId>
 					<artifactId>jdk.tools</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jcl-over-slf4j</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataContext.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataContext.java
@@ -44,6 +44,7 @@ import org.apache.metamodel.data.MaxRowsDataSet;
 import org.apache.metamodel.jdbc.dialects.DB2QueryRewriter;
 import org.apache.metamodel.jdbc.dialects.DefaultQueryRewriter;
 import org.apache.metamodel.jdbc.dialects.H2QueryRewriter;
+import org.apache.metamodel.jdbc.dialects.HiveQueryRewriter;
 import org.apache.metamodel.jdbc.dialects.HsqldbQueryRewriter;
 import org.apache.metamodel.jdbc.dialects.IQueryRewriter;
 import org.apache.metamodel.jdbc.dialects.MysqlQueryRewriter;
@@ -81,6 +82,7 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
     public static final String DATABASE_PRODUCT_DB2 = "DB2";
     public static final String DATABASE_PRODUCT_DB2_PREFIX = "DB2/";
     public static final String DATABASE_PRODUCT_ORACLE = "Oracle";
+    public static final String DATABASE_PRODUCT_HIVE = "Apache Hive";
 
     public static final ColumnType COLUMN_TYPE_CLOB_AS_STRING = new ColumnTypeImpl("CLOB",
             SuperColumnType.LITERAL_TYPE, String.class, true);
@@ -226,6 +228,8 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
             setQueryRewriter(new HsqldbQueryRewriter(this));
         } else if (DATABASE_PRODUCT_H2.equals(_databaseProductName)) {
             setQueryRewriter(new H2QueryRewriter(this));
+        } else if (DATABASE_PRODUCT_HIVE.equals(_databaseProductName)) {
+            setQueryRewriter(new HiveQueryRewriter(this));
         } else {
             setQueryRewriter(new DefaultQueryRewriter(this));
         }

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/AbstractQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/AbstractQueryRewriter.java
@@ -58,6 +58,11 @@ public abstract class AbstractQueryRewriter implements IQueryRewriter {
     public JdbcDataContext getDataContext() {
         return _dataContext;
     }
+    
+    @Override
+    public boolean isTransactional() {
+        return true;
+    }
 
     @Override
     public ColumnType getColumnType(int jdbcType, String nativeType, Integer columnSize) {

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/HiveQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/HiveQueryRewriter.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.jdbc.dialects;
+
+import org.apache.metamodel.jdbc.JdbcDataContext;
+import org.apache.metamodel.schema.ColumnType;
+
+/**
+ * Query rewriter for Apache Hive
+ */
+public class HiveQueryRewriter extends DefaultQueryRewriter implements IQueryRewriter {
+
+    public HiveQueryRewriter(JdbcDataContext dataContext) {
+        super(dataContext);
+    }
+
+    @Override
+    public String rewriteColumnType(ColumnType columnType, Integer columnSize) {
+        if (columnType == ColumnType.INTEGER) {
+            return "INT";
+        }
+        return super.rewriteColumnType(columnType, columnSize);
+    }
+    
+    @Override
+    public boolean isTransactional() {
+        return false;
+    }
+}

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/IQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/IQueryRewriter.java
@@ -37,58 +37,70 @@ import org.apache.metamodel.schema.ColumnType;
  */
 public interface IQueryRewriter {
 
-	public String rewriteFromItem(FromItem item);
+    public String rewriteFromItem(FromItem item);
 
-	public String rewriteQuery(Query query);
+    public String rewriteQuery(Query query);
 
-	public String rewriteFilterItem(FilterItem whereItem);
+    public String rewriteFilterItem(FilterItem whereItem);
 
-	/**
-	 * Gets whether this query rewriter is able to write the "Max rows" query
-	 * property to the query string.
-	 * 
-	 * @return whether this query rewriter is able to write the "Max rows" query
-	 *         property to the query string.
-	 */
-	public boolean isMaxRowsSupported();
+    /**
+     * Gets whether this query rewriter is able to write the "Max rows" query
+     * property to the query string.
+     * 
+     * @return whether this query rewriter is able to write the "Max rows" query
+     *         property to the query string.
+     */
+    public boolean isMaxRowsSupported();
 
-	/**
-	 * Gets whether this query rewriter is able to write the "First row" query
-	 * property to the query string.
-	 * 
-	 * @return whether this query rewriter is able to write the "First row"
-	 *         query property to the query string.
-	 */
-	public boolean isFirstRowSupported();
+    /**
+     * Gets whether this query rewriter is able to write the "First row" query
+     * property to the query string.
+     * 
+     * @return whether this query rewriter is able to write the "First row"
+     *         query property to the query string.
+     */
+    public boolean isFirstRowSupported();
 
-	/**
-	 * Escapes the quotes within a String literal of a query item.
-	 * 
-	 * @return String item with quotes escaped.
-	 */
-	public String escapeQuotes(String item);
+    /**
+     * Escapes the quotes within a String literal of a query item.
+     * 
+     * @return String item with quotes escaped.
+     */
+    public String escapeQuotes(String item);
 
-	/**
-	 * Rewrites the name of a column type, as it is written in CREATE TABLE
-	 * statements. Some databases dont support all column types, or have
-	 * different names for them. The implementation of this method will do that
-	 * conversion.
-	 * 
-	 * @param columnType the (non-null) {@link ColumnType} to rewrite
-	 * @param columnSize the (possibly null) column size that may or may not have been specified
-	 * @return
-	 */
-	public String rewriteColumnType(ColumnType columnType, Integer columnSize);
+    /**
+     * Rewrites the name of a column type, as it is written in CREATE TABLE
+     * statements. Some databases dont support all column types, or have
+     * different names for them. The implementation of this method will do that
+     * conversion.
+     * 
+     * @param columnType
+     *            the (non-null) {@link ColumnType} to rewrite
+     * @param columnSize
+     *            the (possibly null) column size that may or may not have been
+     *            specified
+     * @return
+     */
+    public String rewriteColumnType(ColumnType columnType, Integer columnSize);
 
-	/**
-	 * Gets the column type for a specific JDBC type (as defined in
-	 * {@link Types}), native type name and column size.
-	 * 
-	 * @param jdbcType
-	 * @param nativeType
-	 * @param columnSize
-	 * @return
-	 */
-	public ColumnType getColumnType(int jdbcType, String nativeType, Integer columnSize);
+    /**
+     * Gets the column type for a specific JDBC type (as defined in
+     * {@link Types}), native type name and column size.
+     * 
+     * @param jdbcType
+     * @param nativeType
+     * @param columnSize
+     * @return
+     */
+    public ColumnType getColumnType(int jdbcType, String nativeType, Integer columnSize);
 
+    /**
+     * Determines if the JDBC data source supports transactions or not. Usually
+     * this is the case since JDBC is designed for ACID compliant databases, but
+     * in some cases the JDBC interface is used also to facilitate connectivity
+     * to non-transactional data source such as Apache Hive and others.
+     * 
+     * @return
+     */
+    public boolean isTransactional();
 }

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/HiveIntegrationTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/HiveIntegrationTest.java
@@ -1,0 +1,83 @@
+package org.apache.metamodel.jdbc.integrationtests;
+
+import org.apache.metamodel.UpdateCallback;
+import org.apache.metamodel.UpdateScript;
+import org.apache.metamodel.create.CreateTable;
+import org.apache.metamodel.data.DataSet;
+import org.apache.metamodel.drop.DropTable;
+import org.apache.metamodel.jdbc.JdbcDataContext;
+import org.apache.metamodel.jdbc.dialects.HiveQueryRewriter;
+import org.apache.metamodel.schema.ColumnType;
+import org.apache.metamodel.schema.Schema;
+import org.apache.metamodel.schema.Table;
+
+public class HiveIntegrationTest extends AbstractJdbIntegrationTest {
+
+    @Override
+    protected String getPropertyPrefix() {
+        return "hive";
+    }
+
+    public void testGetSchema() throws Exception {
+        if (!isConfigured()) {
+            return;
+        }
+        final JdbcDataContext dataContext = getDataContext();
+
+        final Schema schema = dataContext.getSchemaByName("default");
+        assertEquals("Schema[name=default]", schema.toString());
+    }
+    
+    public void testUseCorrectRewriter() throws Exception {
+        if (!isConfigured()) {
+            return;
+        }
+        final JdbcDataContext dataContext = getDataContext();
+
+        assertTrue(dataContext.getQueryRewriter() instanceof HiveQueryRewriter);
+    }
+
+    public void testCreateInsertQueryAndDrop() throws Exception {
+        if (!isConfigured()) {
+            return;
+        }
+        final JdbcDataContext dataContext = getDataContext();
+
+        final String tableName = "metamodel_" + System.currentTimeMillis();
+        final Schema schema = dataContext.getDefaultSchema();
+
+        dataContext.executeUpdate(new CreateTable(schema, tableName).withColumn("foo").ofType(ColumnType.STRING)
+                .withColumn("bar").ofType(ColumnType.INTEGER));
+        try {
+            final Table table = dataContext.getTableByQualifiedLabel(tableName);
+            assertNotNull(table);
+            
+            dataContext.executeUpdate(new UpdateScript() {
+                
+                @Override
+                public void run(UpdateCallback callback) {
+                    callback.insertInto(table).value("foo", "Hello world").value("bar", 42).execute();
+                    callback.insertInto(table).value("foo", "Lorem ipsum").value("bar", 42).execute();
+                    callback.insertInto(table).value("foo", "Apache").value("bar", 43).execute();
+                    callback.insertInto(table).value("foo", "MetaModel").value("bar", 44).execute();
+                }
+            });
+            
+            final DataSet ds1 = dataContext.query().from(table).selectCount().execute();
+            assertTrue(ds1.next());
+            assertEquals(4l, ds1.getRow().getValue(0));
+            assertFalse(ds1.next());
+            ds1.close();
+            
+            final DataSet ds2 = dataContext.query().from(table).selectAll().where("bar").eq(42).execute();
+            assertTrue(ds2.next());
+            assertEquals("Row[values=[Hello world, 42]]", ds2.getRow().toString());
+            assertTrue(ds2.next());
+            assertEquals("Row[values=[Lorem ipsum, 42]]", ds2.getRow().toString());
+            assertFalse(ds2.next());
+            ds2.close();
+        } finally {
+            dataContext.executeUpdate(new DropTable(schema, tableName));
+        }
+    }
+}

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/HiveIntegrationTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/HiveIntegrationTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.metamodel.jdbc.integrationtests;
 
 import org.apache.metamodel.UpdateCallback;

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,8 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -26,6 +27,7 @@ under the License.
 		<slf4j.version>1.7.7</slf4j.version>
 		<junit.version>4.11</junit.version>
 		<guava.version>16.0</guava.version>
+		<hadoop.version>2.6.0</hadoop.version>
 		<easymock.version>3.2</easymock.version>
 		<httpcomponents.version>4.3.1</httpcomponents.version>
 		<checksum-maven-plugin.version>1.2</checksum-maven-plugin.version>
@@ -342,7 +344,8 @@ under the License.
 					<artifactId>apache-rat-plugin</artifactId>
 					<configuration>
 						<licenses>
-							<license implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
+							<license
+								implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
 								<licenseFamilyCategory>ASL20</licenseFamilyCategory>
 								<licenseFamilyName>Apache Software License, 2.0</licenseFamilyName>
 								<notes>Single licensed ASL v2.0</notes>
@@ -485,6 +488,143 @@ under the License.
 				<groupId>hsqldb</groupId>
 				<artifactId>hsqldb</artifactId>
 				<version>1.8.0.10</version>
+			</dependency>
+			
+			<!-- Hadoop -->
+			<dependency>
+				<groupId>org.apache.hadoop</groupId>
+				<artifactId>hadoop-client</artifactId>
+				<version>${hadoop.version}</version>
+				<exclusions>
+					<exclusion>
+						<artifactId>jetty-util</artifactId>
+						<groupId>org.mortbay.jetty</groupId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.codehaus.jackson</groupId>
+						<artifactId>jackson-mapper-asl</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.codehaus.jackson</groupId>
+						<artifactId>jackson-core</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.codehaus.jackson</groupId>
+						<artifactId>jackson-core-asl</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.codehaus.jackson</groupId>
+						<artifactId>jackson-jaxrs</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.codehaus.jackson</groupId>
+						<artifactId>jackson-xc</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.hadoop</groupId>
+				<artifactId>hadoop-mapreduce-client-core</artifactId>
+				<version>${hadoop.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.hadoop</groupId>
+				<artifactId>hadoop-common</artifactId>
+				<version>${hadoop.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>jdk.tools</groupId>
+						<artifactId>jdk.tools</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.slf4j</groupId>
+						<artifactId>slf4j-log4j12</artifactId>
+					</exclusion>
+					<exclusion>
+						<artifactId>log4j</artifactId>
+						<groupId>log4j</groupId>
+					</exclusion>
+					<exclusion>
+						<artifactId>commons-logging</artifactId>
+						<groupId>commons-logging</groupId>
+					</exclusion>
+					<exclusion>
+						<artifactId>jetty</artifactId>
+						<groupId>org.mortbay.jetty</groupId>
+					</exclusion>
+					<exclusion>
+						<artifactId>jetty-util</artifactId>
+						<groupId>org.mortbay.jetty</groupId>
+					</exclusion>
+					<exclusion>
+						<groupId>tomcat</groupId>
+						<artifactId>jasper-runtime</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>tomcat</groupId>
+						<artifactId>jasper-compiler</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>javax.servlet</groupId>
+						<artifactId>servlet-api</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>google-collections</groupId>
+						<artifactId>google-collections</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>net.sourceforge.collections</groupId>
+						<artifactId>collections-generic</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.sun.jersey</groupId>
+						<artifactId>jersey-core</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.sun.jersey</groupId>
+						<artifactId>jersey-server</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.mortbay.jetty</groupId>
+						<artifactId>jsp-2.1</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.sun.jersey</groupId>
+						<artifactId>jersey-json</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.mortbay.jetty</groupId>
+						<artifactId>jsp-api-2.1</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>io.netty</groupId>
+						<artifactId>netty</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>commons-httpclient</groupId>
+						<artifactId>commons-httpclient</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.codehaus.jackson</groupId>
+						<artifactId>jackson-mapper-asl</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.codehaus.jackson</groupId>
+						<artifactId>jackson-core</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.codehaus.jackson</groupId>
+						<artifactId>jackson-core-asl</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.codehaus.jackson</groupId>
+						<artifactId>jackson-jaxrs</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.codehaus.jackson</groupId>
+						<artifactId>jackson-xc</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 
 			<!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -501,6 +501,10 @@ under the License.
 						<groupId>org.mortbay.jetty</groupId>
 					</exclusion>
 					<exclusion>
+						<groupId>commons-logging</groupId>
+						<artifactId>commons-logging</artifactId>
+					</exclusion>
+					<exclusion>
 						<groupId>org.codehaus.jackson</groupId>
 						<artifactId>jackson-mapper-asl</artifactId>
 					</exclusion>


### PR DESCRIPTION
This PR adds support for Apache Hive via the existing JDBC module.

To do this I had to introduce a new "isTransactional()" flag on IQueryRewriter since commit calls on Hive is not supported.

I also did some cleanup of Hadoop dependencies because I saw Hadoop version conflicts inbetween the "hadoop", "hbase" and now the "jdbc" modules. This caused the Hive connection to fail with class loading issues.