### PR TITLE
Adds ability to read folders to FileResource and HdfsResource

### DIFF
--- a/core/src/main/java/org/apache/metamodel/util/AbstractDirectoryInputStream.java
+++ b/core/src/main/java/org/apache/metamodel/util/AbstractDirectoryInputStream.java
@@ -1,0 +1,97 @@
+package org.apache.metamodel.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+public abstract class AbstractDirectoryInputStream<T> extends InputStream {
+    protected T[] _files;
+    private int _currentFileIndex = -1;
+    private InputStream _currentInputStream;
+
+
+    @Override
+    public int read(final byte[] b, final int off, final int len) throws IOException {
+        if (_currentInputStream != null) {
+            final int byteCount = _currentInputStream.read(b, off, len);
+            if (byteCount > 0) {
+                return byteCount;
+            }
+        }
+
+        if (!openNextFile()){
+            return -1; // No more files.
+        }
+
+        return read(b, off, len);
+    }
+
+    @Override
+    public int read(final byte[] b) throws IOException {
+        return read(b, 0, b.length);
+    }
+
+    @Override
+    public int read() throws IOException {
+        final byte[] b = new byte[1];
+        int count = read(b, 0 , 1);
+        if(count < 0){
+            return -1;
+        }
+        return (int) b[0];
+    }
+
+    @Override
+    public int available() throws IOException {
+        if(_currentInputStream != null){
+            return _currentInputStream.available();
+        } else {
+            return 0;
+        }
+    }
+
+    private boolean openNextFile() throws IOException {
+        if(_currentInputStream != null){
+            FileHelper.safeClose(_currentInputStream);
+            _currentInputStream = null;
+        }
+        _currentFileIndex++;
+        if (_currentFileIndex >= _files.length) {
+            return false;
+        }
+
+        _currentInputStream = openStream(_currentFileIndex);
+        return true;
+    }
+
+    abstract InputStream openStream(int index) throws IOException;
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if(_currentInputStream != null){
+            FileHelper.safeClose(_currentInputStream);
+        }
+    }
+}

--- a/core/src/main/java/org/apache/metamodel/util/AbstractDirectoryInputStream.java
+++ b/core/src/main/java/org/apache/metamodel/util/AbstractDirectoryInputStream.java
@@ -1,8 +1,3 @@
-package org.apache.metamodel.util;
-
-import java.io.IOException;
-import java.io.InputStream;
-
 /**
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,6 +16,11 @@ import java.io.InputStream;
  * specific language governing permissions and limitations
  * under the License.
  */
+package org.apache.metamodel.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+
 public abstract class AbstractDirectoryInputStream<T> extends InputStream {
     protected T[] _files;
     private int _currentFileIndex = -1;
@@ -36,7 +36,7 @@ public abstract class AbstractDirectoryInputStream<T> extends InputStream {
             }
         }
 
-        if (!openNextFile()){
+        if (!openNextFile()) {
             return -1; // No more files.
         }
 
@@ -51,8 +51,8 @@ public abstract class AbstractDirectoryInputStream<T> extends InputStream {
     @Override
     public int read() throws IOException {
         final byte[] b = new byte[1];
-        int count = read(b, 0 , 1);
-        if(count < 0){
+        int count = read(b, 0, 1);
+        if (count < 0) {
             return -1;
         }
         return (int) b[0];
@@ -60,7 +60,7 @@ public abstract class AbstractDirectoryInputStream<T> extends InputStream {
 
     @Override
     public int available() throws IOException {
-        if(_currentInputStream != null){
+        if (_currentInputStream != null) {
             return _currentInputStream.available();
         } else {
             return 0;
@@ -68,7 +68,7 @@ public abstract class AbstractDirectoryInputStream<T> extends InputStream {
     }
 
     private boolean openNextFile() throws IOException {
-        if(_currentInputStream != null){
+        if (_currentInputStream != null) {
             FileHelper.safeClose(_currentInputStream);
             _currentInputStream = null;
         }
@@ -90,7 +90,7 @@ public abstract class AbstractDirectoryInputStream<T> extends InputStream {
 
     @Override
     public void close() throws IOException {
-        if(_currentInputStream != null){
+        if (_currentInputStream != null) {
             FileHelper.safeClose(_currentInputStream);
         }
     }

--- a/core/src/main/java/org/apache/metamodel/util/FileResource.java
+++ b/core/src/main/java/org/apache/metamodel/util/FileResource.java
@@ -25,7 +25,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Comparator;
 
 /**
  * {@link File} based {@link Resource} implementation.
@@ -34,7 +33,7 @@ public class FileResource implements Resource, Serializable {
 
     private class DirectoryInputStream extends AbstractDirectoryInputStream<File> {
 
-        public DirectoryInputStream(){
+        public DirectoryInputStream() {
             final File[] unsortedFiles = _file.listFiles(new FileFilter() {
                 @Override
                 public boolean accept(final File pathname) {
@@ -42,7 +41,7 @@ public class FileResource implements Resource, Serializable {
                 }
             });
 
-            if(unsortedFiles == null){
+            if (unsortedFiles == null) {
                 _files = new File[0];
             } else {
                 Arrays.sort(unsortedFiles);
@@ -66,7 +65,7 @@ public class FileResource implements Resource, Serializable {
     public FileResource(File file) {
         _file = file;
     }
-    
+
     @Override
     public String toString() {
         return "FileResource[" + _file.getPath() + "]";
@@ -169,7 +168,7 @@ public class FileResource implements Resource, Serializable {
 
     @Override
     public InputStream read() throws ResourceException {
-        if(_file.isDirectory()){
+        if (_file.isDirectory()) {
             return new DirectoryInputStream();
         }
         final InputStream in = FileHelper.getInputStream(_file);

--- a/core/src/test/java/org/apache/metamodel/util/FileResourceTest.java
+++ b/core/src/test/java/org/apache/metamodel/util/FileResourceTest.java
@@ -20,28 +20,28 @@ package org.apache.metamodel.util;
 
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class FileResourceTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
     @Test
     public void testReadDirectory() throws Exception {
         final String contentString = "fun and games with Apache MetaModel and Hadoop is what we do";
         final String[] contents = new String[] { "fun ", "and ", "games ", "with ", "Apache ", "MetaModel ", "and ", "Hadoop ", "is ", "what ", "we ", "do" };
 
-        Path path = Files.createTempDirectory("test");
-
         // Reverse both filename and contents to make sure it is the name and not the creation order that is sorted on.
         int i = contents.length;
         Collections.reverse(Arrays.asList(contents));
         for(final String contentPart : contents){
-            final FileResource partResource = new FileResource(path + "/part-" + String.format("%02d", i--));
+            final FileResource partResource = new FileResource(folder.newFile("/part-" + String.format("%02d", i--)));
             partResource.write(new Action<OutputStream>() {
                 @Override
                 public void run(OutputStream out) throws Exception {
@@ -50,8 +50,7 @@ public class FileResourceTest {
             });
         }
 
-
-        final FileResource res1 = new FileResource(path.toFile());
+        final FileResource res1 = new FileResource(folder.getRoot());
 
         final String str1 = res1.read(new Func<InputStream, String>() {
             @Override

--- a/core/src/test/java/org/apache/metamodel/util/FileResourceTest.java
+++ b/core/src/test/java/org/apache/metamodel/util/FileResourceTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.metamodel.util;
 
 import java.io.InputStream;

--- a/core/src/test/java/org/apache/metamodel/util/FileResourceTest.java
+++ b/core/src/test/java/org/apache/metamodel/util/FileResourceTest.java
@@ -1,0 +1,56 @@
+package org.apache.metamodel.util;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FileResourceTest {
+
+    @Test
+    public void testReadDirectory() throws Exception {
+        final String contentString = "fun and games with Apache MetaModel and Hadoop is what we do";
+        final String[] contents = new String[] { "fun ", "and ", "games ", "with ", "Apache ", "MetaModel ", "and ", "Hadoop ", "is ", "what ", "we ", "do" };
+
+        Path path = Files.createTempDirectory("test");
+
+        // Reverse both filename and contents to make sure it is the name and not the creation order that is sorted on.
+        int i = contents.length;
+        Collections.reverse(Arrays.asList(contents));
+        for(final String contentPart : contents){
+            final FileResource partResource = new FileResource(path + "/part-" + String.format("%02d", i--));
+            partResource.write(new Action<OutputStream>() {
+                @Override
+                public void run(OutputStream out) throws Exception {
+                    out.write(contentPart.getBytes());
+                }
+            });
+        }
+
+
+        final FileResource res1 = new FileResource(path.toFile());
+
+        final String str1 = res1.read(new Func<InputStream, String>() {
+            @Override
+            public String eval(InputStream in) {
+                return FileHelper.readInputStreamAsString(in, "UTF8");
+            }
+        });
+
+        Assert.assertEquals(contentString, str1);
+
+        final String str2 = res1.read(new Func<InputStream, String>() {
+            @Override
+            public String eval(InputStream in) {
+                return FileHelper.readInputStreamAsString(in, "UTF8");
+            }
+        });
+        Assert.assertEquals(str1, str2);
+    }
+
+}

--- a/hadoop/src/main/java/org/apache/metamodel/util/HdfsResource.java
+++ b/hadoop/src/main/java/org/apache/metamodel/util/HdfsResource.java
@@ -18,13 +18,11 @@
  */
 package org.apache.metamodel.util;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 


### PR DESCRIPTION
This will allow FileResource and HdfsResource to use a folder as a complete resource. It will skip any subfolder and only use files in the folder. Before opening files, they will be sorted them alphabetically by name (actually it uses the natural ordering of the File/FileStatus object, but that is the path/url sorted alphabetically).

Fixes METAMODEL-163