### PR TITLE
METAMODEL-164: Fixed and refactored ES mapping parser to use real map.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
  * [METAMODEL-162] - Made HdfsResource Serializable and added property getters
  * [METAMODEL-163] - Made FileResource and HdfsResource work with folders containing file chunks instead of only single files
  * [METAMODEL-104] - Added 'hadoop' and 'hbase' modules to dependencies of 'MetaModel-full'.
+ * [METAMODEL-164] - Fixed a bug in data type parsing of ElasticSearch mapping document.
 
 ### Apache MetaModel 4.3.5
 

--- a/elasticsearch/src/test/java/org/apache/metamodel/elasticsearch/ElasticSearchMetaDataParserTest.java
+++ b/elasticsearch/src/test/java/org/apache/metamodel/elasticsearch/ElasticSearchMetaDataParserTest.java
@@ -18,24 +18,31 @@
  */
 package org.apache.metamodel.elasticsearch;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import junit.framework.TestCase;
+
 import org.apache.metamodel.schema.ColumnType;
+import org.elasticsearch.common.collect.MapBuilder;
 
 public class ElasticSearchMetaDataParserTest extends TestCase {
 
     public void testParseMetadataInfo() throws Exception {
-        String metaDataInfo = "{message={type=long}, " +
-                "postDate={type=date, format=dateOptionalTime}, " +
-                "anotherDate={type=date, format=dateOptionalTime}, " +
-                "user={type=string}, " +
-                "critical={type=boolean}, " +
-                "income={type=double}}";
-
-        ElasticSearchMetaData metaData = ElasticSearchMetaDataParser.parse(metaDataInfo);
+        Map<String, Object> metadata = new LinkedHashMap<String, Object>();
+        metadata.put("message", MapBuilder.newMapBuilder().put("type", "long").immutableMap());
+        metadata.put("postDate", MapBuilder.newMapBuilder().put("type", "date").put("format", "dateOptionalTime").immutableMap());
+        metadata.put("anotherDate", MapBuilder.newMapBuilder().put("type", "date").put("format", "dateOptionalTime").immutableMap());
+        metadata.put("user", MapBuilder.newMapBuilder().put("type", "string").immutableMap());
+        metadata.put("critical", MapBuilder.newMapBuilder().put("type", "boolean").immutableMap());
+        metadata.put("income", MapBuilder.newMapBuilder().put("type", "double").immutableMap());
+        metadata.put("untypedthingie", MapBuilder.newMapBuilder().put("foo", "bar").immutableMap());
+        
+        ElasticSearchMetaData metaData = ElasticSearchMetaDataParser.parse(metadata);
         String[] columnNames = metaData.getColumnNames();
         ColumnType[] columnTypes = metaData.getColumnTypes();
 
-        assertTrue(columnNames.length == 7);
+        assertTrue(columnNames.length == 8);
         assertEquals(columnNames[0], "_id");
         assertEquals(columnNames[1], "message");
         assertEquals(columnNames[2], "postDate");
@@ -43,7 +50,9 @@ public class ElasticSearchMetaDataParserTest extends TestCase {
         assertEquals(columnNames[4], "user");
         assertEquals(columnNames[5], "critical");
         assertEquals(columnNames[6], "income");
-        assertTrue(columnTypes.length == 7);
+        assertEquals(columnNames[7], "untypedthingie");
+        
+        assertTrue(columnTypes.length == 8);
         assertEquals(columnTypes[0], ColumnType.STRING);
         assertEquals(columnTypes[1], ColumnType.BIGINT);
         assertEquals(columnTypes[2], ColumnType.DATE);
@@ -51,5 +60,6 @@ public class ElasticSearchMetaDataParserTest extends TestCase {
         assertEquals(columnTypes[4], ColumnType.STRING);
         assertEquals(columnTypes[5], ColumnType.BOOLEAN);
         assertEquals(columnTypes[6], ColumnType.DOUBLE);
+        assertEquals(columnTypes[7], ColumnType.STRING);
     }
 }


### PR DESCRIPTION
Previously the parser was (by accident I think) using the toString()
representation of that same map which made it very vulnerable towards
parsing issues.

Fixes METAMODEL-164