### PR TITLE
Feature/metamodel 170 drop java6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 jdk:
-  - openjdk6
   - openjdk7
   - oraclejdk8
 

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -57,27 +57,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>jdk6</id>
-            <activation>
-                <jdk>1.6</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.18.1</version>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/CassandraDataContextTest.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/elasticsearch/pom.xml
+++ b/elasticsearch/pom.xml
@@ -20,8 +20,7 @@
 	<name>MetaModel module for Elasticsearch analytics engine</name>
 
 	<properties>
-		<elasticsearch.latest.version>1.4.4</elasticsearch.latest.version>
-		<elasticsearch.jdk6.version>0.90.13</elasticsearch.jdk6.version>
+		<elasticsearch.version>1.4.4</elasticsearch.version>
 	</properties>
 
 	<dependencies>
@@ -34,6 +33,14 @@
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 		</dependency>
+		
+		<!-- elasticsearch -->
+		<dependency>
+			<groupId>org.elasticsearch</groupId>
+			<artifactId>elasticsearch</artifactId>
+			<version>${elasticsearch.version}</version>
+		</dependency>
+		
 		<!-- test -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -47,36 +54,4 @@
 		</dependency>
 	</dependencies>
 
-	<profiles>
-		<profile>
-			<id>latest</id>
-			<activation>
-				<jdk>!1.6</jdk>
-			</activation>
-			<dependencies>
-				<!-- elasticsearch -->
-				<dependency>
-					<groupId>org.elasticsearch</groupId>
-					<artifactId>elasticsearch</artifactId>
-					<version>${elasticsearch.latest.version}</version>
-				</dependency>
-			</dependencies>
-		</profile>
-
-		<profile>
-			<id>jdk6</id>
-			<activation>
-				<jdk>1.6</jdk>
-			</activation>
-			<dependencies>
-				<!-- elasticsearch -->
-				<dependency>
-					<groupId>org.elasticsearch</groupId>
-					<artifactId>elasticsearch</artifactId>
-					<version>${elasticsearch.jdk6.version}</version>
-				</dependency>
-			</dependencies>
-		</profile>
-
-	</profiles>
 </project>

--- a/elasticsearch/src/test/java/org/apache/metamodel/elasticsearch/ElasticSearchDataContextTest.java
+++ b/elasticsearch/src/test/java/org/apache/metamodel/elasticsearch/ElasticSearchDataContextTest.java
@@ -525,13 +525,6 @@ public class ElasticSearchDataContextTest {
 
     @Test
     public void testNonDynamicMapingTableNames() throws Exception {
-        if (Version.CURRENT.major == 0) {
-            // this test is omitted on v. 0.x versions of ElasticSearch since
-            // the put mapping API is incompatible with 1.x so we cannot create
-            // the same prerequisites in the test.
-            return;
-        }
-
         createIndex();
 
         ElasticSearchDataContext dataContext2 = new ElasticSearchDataContext(client, indexName2);

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@ under the License.
 	<build>
 		<plugins>
 			<plugin>
-				<!-- Ensures java 6 compatibility -->
+				<!-- Ensures java 7 compatibility -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -168,8 +168,8 @@ under the License.
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 					<encoding>utf-8</encoding>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
My attempt at fixing METAMODEL-170: Drop Java 6 support.

Do not merge before the release process of MetaModel 4.3.6 has finished completely.