### PR TITLE
CSV writing using Resource.write() and Resource.append()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### Apache MetaModel (latest)
 
+ * [METAMODEL-173] - Improved CSV writing to non-file destinations. Added .write() and .append() methods to Resource interface.
  * [METAMODEL-170] - Dropped support for Java 6.
 
 ### Apache MetaModel 4.3.6

--- a/core/src/main/java/org/apache/metamodel/util/AbstractResource.java
+++ b/core/src/main/java/org/apache/metamodel/util/AbstractResource.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.util;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Abstract implementation of many methods in {@link Resource}
+ */
+public abstract class AbstractResource implements Resource {
+    
+
+    @Override
+    public final void read(Action<InputStream> readCallback) {
+        final InputStream in = read();
+        try {
+            readCallback.run(in);
+        } catch (Exception e) {
+            throw new ResourceException(this, "Error occurred in read callback", e);
+        } finally {
+            FileHelper.safeClose(in);
+        }
+    }
+
+    @Override
+    public final <E> E read(Func<InputStream, E> readCallback) {
+        final InputStream in = read();
+        try {
+            final E result = readCallback.eval(in);
+            return result;
+        } catch (Exception e) {
+            throw new ResourceException(this, "Error occurred in read callback", e);
+        } finally {
+            FileHelper.safeClose(in);
+        }
+    }
+
+    @Override
+    public final void write(Action<OutputStream> writeCallback) throws ResourceException {
+        final OutputStream out = write();
+        try {
+            writeCallback.run(out);
+        } catch (Exception e) {
+            throw new ResourceException(this, "Error occurred in write callback", e);
+        } finally {
+            FileHelper.safeClose(out);
+        }
+    }
+
+    @Override
+    public final void append(Action<OutputStream> appendCallback) throws ResourceException {
+        final OutputStream out = append();
+        try {
+            appendCallback.run(out);
+        } catch (Exception e) {
+            throw new ResourceException(this, "Error occurred in append callback", e);
+        } finally {
+            FileHelper.safeClose(out);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[" + getQualifiedPath() + "]";
+    }
+}

--- a/core/src/main/java/org/apache/metamodel/util/ClasspathResource.java
+++ b/core/src/main/java/org/apache/metamodel/util/ClasspathResource.java
@@ -26,7 +26,7 @@ import java.net.URL;
 /**
  * A {@link Resource} based on a classpath entry
  */
-public class ClasspathResource implements Resource, Serializable {
+public class ClasspathResource extends AbstractResource implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -90,6 +90,16 @@ public class ClasspathResource implements Resource, Serializable {
         }
         return new UrlResource(url);
     }
+    
+    @Override
+    public OutputStream append() throws ResourceException {
+        return getUrlResourceDelegate().append();
+    }
+    
+    @Override
+    public OutputStream write() throws ResourceException {
+        return getUrlResourceDelegate().write();
+    }
 
     @Override
     public boolean isReadOnly() {
@@ -124,28 +134,8 @@ public class ClasspathResource implements Resource, Serializable {
     }
 
     @Override
-    public void write(Action<OutputStream> writeCallback) throws ResourceException {
-        getUrlResourceDelegate().write(writeCallback);
-    }
-
-    @Override
-    public void append(Action<OutputStream> appendCallback) throws ResourceException {
-        getUrlResourceDelegate().append(appendCallback);
-    }
-
-    @Override
     public InputStream read() throws ResourceException {
         return getUrlResourceDelegate().read();
-    }
-
-    @Override
-    public void read(Action<InputStream> readCallback) throws ResourceException {
-        getUrlResourceDelegate().read(readCallback);
-    }
-
-    @Override
-    public <E> E read(Func<InputStream, E> readCallback) throws ResourceException {
-        return getUrlResourceDelegate().read(readCallback);
     }
 
 }

--- a/core/src/main/java/org/apache/metamodel/util/FileResource.java
+++ b/core/src/main/java/org/apache/metamodel/util/FileResource.java
@@ -29,7 +29,7 @@ import java.util.Arrays;
 /**
  * {@link File} based {@link Resource} implementation.
  */
-public class FileResource implements Resource, Serializable {
+public class FileResource extends AbstractResource implements Serializable {
 
     private class DirectoryInputStream extends AbstractDirectoryInputStream<File> {
 
@@ -95,52 +95,13 @@ public class FileResource implements Resource, Serializable {
     }
 
     @Override
-    public void write(Action<OutputStream> writeCallback) throws ResourceException {
-        final OutputStream out = FileHelper.getOutputStream(_file);
-        try {
-            writeCallback.run(out);
-        } catch (Exception e) {
-            throw new ResourceException(this, "Error occurred in write callback", e);
-        } finally {
-            FileHelper.safeClose(out);
-        }
+    public OutputStream write() throws ResourceException {
+        return FileHelper.getOutputStream(_file);
     }
 
     @Override
-    public void append(Action<OutputStream> appendCallback) {
-        final OutputStream out = FileHelper.getOutputStream(_file, true);
-        try {
-            appendCallback.run(out);
-        } catch (Exception e) {
-            throw new ResourceException(this, "Error occurred in append callback", e);
-        } finally {
-            FileHelper.safeClose(out);
-        }
-    }
-
-    @Override
-    public void read(Action<InputStream> readCallback) {
-        final InputStream in = read();
-        try {
-            readCallback.run(in);
-        } catch (Exception e) {
-            throw new ResourceException(this, "Error occurred in read callback", e);
-        } finally {
-            FileHelper.safeClose(in);
-        }
-    }
-
-    @Override
-    public <E> E read(Func<InputStream, E> readCallback) {
-        final InputStream in = read();
-        try {
-            final E result = readCallback.eval(in);
-            return result;
-        } catch (Exception e) {
-            throw new ResourceException(this, "Error occurred in read callback", e);
-        } finally {
-            FileHelper.safeClose(in);
-        }
+    public OutputStream append() throws ResourceException {
+        return FileHelper.getOutputStream(_file, true);
     }
 
     public File getFile() {

--- a/core/src/main/java/org/apache/metamodel/util/Resource.java
+++ b/core/src/main/java/org/apache/metamodel/util/Resource.java
@@ -88,6 +88,19 @@ public interface Resource extends HasName {
     public void write(Action<OutputStream> writeCallback) throws ResourceException;
 
     /**
+     * Opens up an {@link OutputStream} to write to the resource. Consumers of
+     * this method are expected to invoke the {@link OutputStream#close()}
+     * method manually.
+     * 
+     * If possible, the other write(...) method is preferred over this one,
+     * since it guarantees proper closing of the resource's handles.
+     * 
+     * @return
+     * @throws ResourceException
+     */
+    public OutputStream write() throws ResourceException;
+
+    /**
      * Opens up an {@link InputStream} to append (write at the end of the
      * existing stream) to the resource.
      * 
@@ -97,6 +110,19 @@ public interface Resource extends HasName {
      *             if an error occurs while appending
      */
     public void append(Action<OutputStream> appendCallback) throws ResourceException;
+
+    /**
+     * Opens up an {@link OutputStream} to append to the resource. Consumers of
+     * this method are expected to invoke the {@link OutputStream#close()}
+     * method manually.
+     * 
+     * If possible, the other append(...) method is preferred over this one,
+     * since it guarantees proper closing of the resource's handles.
+     * 
+     * @return
+     * @throws ResourceException
+     */
+    public OutputStream append() throws ResourceException;
 
     /**
      * Opens up an {@link InputStream} to read from the resource. Consumers of

--- a/core/src/main/java/org/apache/metamodel/util/UrlResource.java
+++ b/core/src/main/java/org/apache/metamodel/util/UrlResource.java
@@ -28,7 +28,7 @@ import java.net.URL;
 /**
  * Resource based on URL or URI.
  */
-public class UrlResource implements Resource, Serializable {
+public class UrlResource extends AbstractResource implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -94,38 +94,13 @@ public class UrlResource implements Resource, Serializable {
     }
 
     @Override
-    public void write(Action<OutputStream> writeCallback) throws ResourceException {
+    public OutputStream write() throws ResourceException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void append(Action<OutputStream> appendCallback) throws ResourceException {
+    public OutputStream append() throws ResourceException {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void read(Action<InputStream> readCallback) throws ResourceException {
-        final InputStream in = read();
-        try {
-            readCallback.run(in);
-        } catch (Exception e) {
-            throw new ResourceException(this, "Error occurred in read callback", e);
-        } finally {
-            FileHelper.safeClose(in);
-        }
-    }
-
-    @Override
-    public <E> E read(Func<InputStream, E> readCallback) throws ResourceException {
-        final InputStream in = read();
-        try {
-            E result = readCallback.eval(in);
-            return result;
-        } catch (Exception e) {
-            throw new ResourceException(this, "Error occurred in read callback", e);
-        } finally {
-            FileHelper.safeClose(in);
-        }
     }
 
     @Override

--- a/spring/src/main/java/org/apache/metamodel/spring/SpringResource.java
+++ b/spring/src/main/java/org/apache/metamodel/spring/SpringResource.java
@@ -22,9 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import org.apache.metamodel.util.Action;
-import org.apache.metamodel.util.FileHelper;
-import org.apache.metamodel.util.Func;
+import org.apache.metamodel.util.AbstractResource;
 import org.apache.metamodel.util.Resource;
 import org.apache.metamodel.util.ResourceException;
 import org.slf4j.Logger;
@@ -34,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * A {@link Resource} implementation based on spring's similar
  * {@link org.springframework.core.io.Resource} concept.
  */
-public class SpringResource implements Resource {
+public class SpringResource extends AbstractResource implements Resource {
 
     private static final Logger logger = LoggerFactory.getLogger(SpringResource.class);
 
@@ -43,12 +41,17 @@ public class SpringResource implements Resource {
     public SpringResource(org.springframework.core.io.Resource resource) {
         _resource = resource;
     }
-
+    
     @Override
-    public void append(Action<OutputStream> arg0) throws ResourceException {
+    public OutputStream append() throws ResourceException {
         throw new UnsupportedOperationException();
     }
-
+    
+    @Override
+    public OutputStream write() throws ResourceException {
+        throw new UnsupportedOperationException();
+    }
+    
     @Override
     public long getLastModified() {
         try {
@@ -99,35 +102,6 @@ public class SpringResource implements Resource {
         } catch (IOException e) {
             throw new IllegalStateException("Failed to get input stream of resource: " + _resource, e);
         }
-    }
-
-    @Override
-    public void read(Action<InputStream> action) throws ResourceException {
-        final InputStream in = read();
-        try {
-            action.run(in);
-        } catch (Exception e) {
-            throw new ResourceException(this, "Error occurred in read callback", e);
-        } finally {
-            FileHelper.safeClose(in);
-        }
-    }
-
-    @Override
-    public <E> E read(Func<InputStream, E> func) throws ResourceException {
-        final InputStream in = read();
-        try {
-            return func.eval(in);
-        } catch (Exception e) {
-            throw new ResourceException(this, "Error occurred in read callback", e);
-        } finally {
-            FileHelper.safeClose(in);
-        }
-    }
-
-    @Override
-    public void write(Action<OutputStream> arg0) throws ResourceException {
-        throw new UnsupportedOperationException();
     }
 
     /**


### PR DESCRIPTION
Fixes METAMODEL-173

See also previous PR #36 which had a different approach. This approach is in my opinion better since it tries to improve the way the CsvUpdateCallback remembers the output stream (in form of a Writer) and reuses it for each line it writes.