### PR TITLE
Remove hadoop-common dependency in MetaModel-jdbc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ### Apache MetaModel (latest)
 
  * [METAMODEL-173] - Improved CSV writing to non-file destinations. Added .write() and .append() methods to Resource interface.
+ * [METAMODEL-176] - Trimmed the transient dependencies of the JDBC module.
  * [METAMODEL-170] - Dropped support for Java 6.
  * [METAMODEL-178] - Added AggregateFunction and ScalarFunction interfaces. Changed FunctionType enum to be super-interface of those. Compatibility is retained but a recompile of code using FunctionType is needed.
 

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -106,6 +106,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hive</groupId>

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/DerbyTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/DerbyTest.java
@@ -140,6 +140,7 @@ public class DerbyTest extends TestCase {
         assertTrue(dataSet.next());
         assertTrue(dataSet.next());
         assertFalse(dataSet.next());
+        dataSet.close();
     }
 
     public void testGetSchemaNormalTableTypes() throws Exception {

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/JdbcTestTemplates.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/JdbcTestTemplates.java
@@ -156,42 +156,49 @@ public class JdbcTestTemplates {
         assertTrue(ds.next());
         assertEquals("1", ds.getRow().getValue(0).toString());
         assertFalse(ds.next());
+        ds.close();
 
         // regular NOT EQUALS
         ds = dc.query().from(schema.getTableByName("test_table")).selectCount().where("code").ne("C02").execute();
         assertTrue(ds.next());
         assertEquals("3", ds.getRow().getValue(0).toString());
         assertFalse(ds.next());
+        ds.close();
 
         // regular GREATER THAN
         ds = dc.query().from(schema.getTableByName("test_table")).selectCount().where("id").gt(2).execute();
         assertTrue(ds.next());
         assertEquals("2", ds.getRow().getValue(0).toString());
         assertFalse(ds.next());
+        ds.close();
 
         // regular LESS THAN
         ds = dc.query().from(schema.getTableByName("test_table")).selectCount().where("id").lt(2).execute();
         assertTrue(ds.next());
         assertEquals("1", ds.getRow().getValue(0).toString());
         assertFalse(ds.next());
+        ds.close();
 
         // IS NULL
         ds = dc.query().from(schema.getTableByName("test_table")).selectCount().where("code").isNull().execute();
         assertTrue(ds.next());
         assertEquals("1", ds.getRow().getValue(0).toString());
         assertFalse(ds.next());
+        ds.close();
 
         // IS NOT NULL
         ds = dc.query().from(schema.getTableByName("test_table")).selectCount().where("code").isNotNull().execute();
         assertTrue(ds.next());
         assertEquals("3", ds.getRow().getValue(0).toString());
         assertFalse(ds.next());
+        ds.close();
 
         // LIKE
         ds = dc.query().from(schema.getTableByName("test_table")).selectCount().where("code").like("C%").execute();
         assertTrue(ds.next());
         assertEquals("3", ds.getRow().getValue(0).toString());
         assertFalse(ds.next());
+        ds.close();
 
         // regular IN (with string)
         ds = dc.query().from(schema.getTableByName("test_table")).selectCount().where("code").in("C01", "C02")
@@ -199,12 +206,14 @@ public class JdbcTestTemplates {
         assertTrue(ds.next());
         assertEquals("2", ds.getRow().getValue(0).toString());
         assertFalse(ds.next());
+        ds.close();
 
         // regular IN (with decimals)
         ds = dc.query().from(schema.getTableByName("test_table")).selectCount().where("id").in(1.0, 2.0, 4.0).execute();
         assertTrue(ds.next());
         assertEquals("3", ds.getRow().getValue(0).toString());
         assertFalse(ds.next());
+        ds.close();
 
         // irregular IN (with null value) - (currently uses SQL's standard way
         // of understanding NULL - see ticket #1058)
@@ -217,6 +226,7 @@ public class JdbcTestTemplates {
         assertTrue(ds.next());
         assertEquals("0", ds.getRow().getValue(0).toString());
         assertFalse(ds.next());
+        ds.close();
     }
 
     public static void meaningOfOneSizeChar(Connection conn) throws Exception {
@@ -259,6 +269,7 @@ public class JdbcTestTemplates {
         assertTrue(ds.next());
         assertNull(ds.getRow().getValue(0));
         assertFalse(ds.next());
+        ds.close();
     }
 
     public static void automaticConversionWhenInsertingString(Connection conn) throws Exception {


### PR DESCRIPTION
METAMODEL-176: Fixed

Also added DataSet.close() to a few places where it was giving log
warnings during build/test