### PR TITLE
METAMODEL-198: Implemented timestamp literal based on JDBC spec

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -72,9 +72,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>postgresql</groupId>
+			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>9.1-901.jdbc4</version>
+			<version>9.3-1104-jdbc4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataContext.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataContext.java
@@ -54,6 +54,7 @@ import org.apache.metamodel.jdbc.dialects.MysqlQueryRewriter;
 import org.apache.metamodel.jdbc.dialects.OracleQueryRewriter;
 import org.apache.metamodel.jdbc.dialects.PostgresqlQueryRewriter;
 import org.apache.metamodel.jdbc.dialects.SQLServerQueryRewriter;
+import org.apache.metamodel.jdbc.dialects.SQLiteQueryRewriter;
 import org.apache.metamodel.query.CompiledQuery;
 import org.apache.metamodel.query.Query;
 import org.apache.metamodel.query.SelectItem;
@@ -87,6 +88,7 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
     public static final String DATABASE_PRODUCT_DB2_PREFIX = "DB2/";
     public static final String DATABASE_PRODUCT_ORACLE = "Oracle";
     public static final String DATABASE_PRODUCT_HIVE = "Apache Hive";
+    public static final String DATABASE_PRODUCT_SQLITE = "SQLite";
 
     public static final ColumnType COLUMN_TYPE_CLOB_AS_STRING = new ColumnTypeImpl("CLOB", SuperColumnType.LITERAL_TYPE,
             String.class, true);
@@ -234,6 +236,8 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
             setQueryRewriter(new H2QueryRewriter(this));
         } else if (DATABASE_PRODUCT_HIVE.equals(_databaseProductName)) {
             setQueryRewriter(new HiveQueryRewriter(this));
+        } else if (DATABASE_PRODUCT_SQLITE.equals(_databaseProductName)) {
+            setQueryRewriter(new SQLiteQueryRewriter(this));
         } else {
             setQueryRewriter(new DefaultQueryRewriter(this));
         }

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcUtils.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcUtils.java
@@ -25,6 +25,8 @@ import java.sql.Clob;
 import java.sql.NClob;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -126,13 +128,11 @@ public final class JdbcUtils {
                 cal.setTime((Date) value);
                 st.setDate(valueIndex, new java.sql.Date(cal.getTimeInMillis()), cal);
             } else if (type == ColumnType.TIME && value instanceof Date) {
-                Calendar cal = Calendar.getInstance();
-                cal.setTime((Date) value);
-                st.setTime(valueIndex, new java.sql.Time(cal.getTimeInMillis()), cal);
+                final Time time = toTime((Date) value);
+                st.setTime(valueIndex, time);
             } else if (type == ColumnType.TIMESTAMP && value instanceof Date) {
-                Calendar cal = Calendar.getInstance();
-                cal.setTime((Date) value);
-                st.setTimestamp(valueIndex, new java.sql.Timestamp(cal.getTimeInMillis()), cal);
+                final Timestamp ts = toTimestamp((Date) value);
+                st.setTimestamp(valueIndex, ts);
             } else if (type == ColumnType.CLOB || type == ColumnType.NCLOB) {
                 if (value instanceof InputStream) {
                     InputStream inputStream = (InputStream) value;
@@ -182,6 +182,24 @@ public final class JdbcUtils {
         }
     }
 
+    private static Time toTime(Date value) {
+        if (value instanceof Time) {
+            return (Time) value;
+        }
+        final Calendar cal = Calendar.getInstance();
+        cal.setTime((Date) value);
+        return new java.sql.Time(cal.getTimeInMillis());
+    }
+
+    private static Timestamp toTimestamp(Date value) {
+        if (value instanceof Timestamp) {
+            return (Timestamp) value;
+        }
+        final Calendar cal = Calendar.getInstance();
+        cal.setTime((Date) value);
+        return new Timestamp(cal.getTimeInMillis());
+    }
+
     public static String getValueAsSql(Column column, Object value, IQueryRewriter queryRewriter) {
         if (value == null) {
             return "NULL";
@@ -211,7 +229,8 @@ public final class JdbcUtils {
             if (!inlineValues) {
                 if (isPreparedParameterCandidate(whereItem)) {
                     // replace operator with parameter
-                    whereItem = new FilterItem(whereItem.getSelectItem(), whereItem.getOperator(), new QueryParameter());
+                    whereItem = new FilterItem(whereItem.getSelectItem(), whereItem.getOperator(),
+                            new QueryParameter());
                 }
             }
             final String whereItemLabel = queryRewriter.rewriteFilterItem(whereItem);

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/DefaultQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/DefaultQueryRewriter.java
@@ -18,6 +18,7 @@
  */
 package org.apache.metamodel.jdbc.dialects;
 
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -114,6 +115,9 @@ public class DefaultQueryRewriter extends AbstractQueryRewriter {
                     FilterItem replacementFilterItem = new FilterItem(item.getSelectItem(), item.getOperator(), str);
                     return super.rewriteFilterItem(replacementFilterItem);
                 }
+            } else if (operand instanceof Timestamp) {
+                final String timestampLiteral = rewriteTimestamp((Timestamp) operand);
+                return rewriteFilterItemWithOperandLiteral(item, timestampLiteral);
             } else if (operand instanceof Iterable || operand.getClass().isArray()) {
                 // operand is a set of values (typically in combination with an
                 // IN operator). Each individual element must be escaped.
@@ -145,7 +149,39 @@ public class DefaultQueryRewriter extends AbstractQueryRewriter {
         }
         return super.rewriteFilterItem(item);
     }
-    
+
+    /**
+     * Rewrites a (non-compound) {@link FilterItem} when it's operand has
+     * already been rewritten into a SQL literal.
+     * 
+     * @param item
+     * @param operandLiteral
+     * @return
+     */
+    protected String rewriteFilterItemWithOperandLiteral(FilterItem item, String operandLiteral) {
+        final OperatorType operator = item.getOperator();
+        final SelectItem selectItem = item.getSelectItem();
+        final StringBuilder sb = new StringBuilder();
+        sb.append(selectItem.getSameQueryAlias(false));
+        FilterItem.appendOperator(sb, item.getOperand(), operator);
+        sb.append(operandLiteral);
+        return sb.toString();
+    }
+
+    /**
+     * Rewrites a {@link Timestamp} into it's literal representation as known by
+     * this SQL dialect.
+     * 
+     * This default implementation returns the JDBC spec's escape syntax for a
+     * timestamp: {ts 'yyyy-mm-dd hh:mm:ss.f . . .'}
+     * 
+     * @param ts
+     * @return
+     */
+    protected String rewriteTimestamp(Timestamp ts) {
+        return "{ts '" + ts.toString() + "'}";
+    }
+
     @Override
     public boolean isScalarFunctionSupported(ScalarFunction function) {
         return false;

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/SQLiteQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/SQLiteQueryRewriter.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.jdbc.dialects;
+
+import java.sql.Timestamp;
+
+import org.apache.metamodel.jdbc.JdbcDataContext;
+
+/**
+ * Query rewriter for SQLite database
+ */
+public class SQLiteQueryRewriter extends DefaultQueryRewriter {
+
+    public SQLiteQueryRewriter(JdbcDataContext dataContext) {
+        super(dataContext);
+    }
+
+    @Override
+    protected String rewriteTimestamp(Timestamp ts) {
+        // SQLite's driver does not support the JDBC escape syntax.
+        // see http://www.sqlite.org/lang_datefunc.html
+        return "'" + ts.toString() + "'";
+    }
+}

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/DerbyTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/DerbyTest.java
@@ -78,7 +78,7 @@ public class DerbyTest extends TestCase {
 
     public void testTimestampValueInsertSelect() throws Exception {
         Connection conn = DriverManager.getConnection("jdbc:derby:target/temp_derby;create=true");
-        JdbcTestTemplates.timestampValueInsertSelect(conn, TimeUnit.MILLISECONDS);
+        JdbcTestTemplates.timestampValueInsertSelect(conn, TimeUnit.NANOSECONDS);
     }
 
     public void testCreateInsertAndUpdate() throws Exception {

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/DerbyTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/DerbyTest.java
@@ -59,8 +59,8 @@ public class DerbyTest extends TestCase {
         File dbFile = new File("src/test/resources/derby_testdb.jar");
         assertTrue(dbFile.exists());
         Class.forName("org.apache.derby.jdbc.EmbeddedDriver");
-        _connection = DriverManager.getConnection("jdbc:derby:jar:(" + dbFile.getAbsolutePath()
-                + ")derby_testdb;territory=en");
+        _connection = DriverManager
+                .getConnection("jdbc:derby:jar:(" + dbFile.getAbsolutePath() + ")derby_testdb;territory=en");
     }
 
     @Override
@@ -73,6 +73,11 @@ public class DerbyTest extends TestCase {
         if (logFile.exists()) {
             logFile.delete();
         }
+    }
+
+    public void testTimestampValueInsertSelect() throws Exception {
+        Connection conn = DriverManager.getConnection("jdbc:derby:target/temp_derby;create=true");
+        JdbcTestTemplates.timestampValueInsertSelect(conn);
     }
 
     public void testCreateInsertAndUpdate() throws Exception {
@@ -89,7 +94,7 @@ public class DerbyTest extends TestCase {
 
     public void testDifferentOperators() throws Exception {
         Connection conn = DriverManager.getConnection("jdbc:derby:target/temp_derby;create=true");
-        
+
         JdbcTestTemplates.differentOperatorsTest(conn);
     }
 
@@ -118,7 +123,8 @@ public class DerbyTest extends TestCase {
     }
 
     public void testQueryWithFilter() throws Exception {
-        JdbcDataContext dc = new JdbcDataContext(_connection, new TableType[] { TableType.TABLE, TableType.VIEW }, null);
+        JdbcDataContext dc = new JdbcDataContext(_connection, new TableType[] { TableType.TABLE, TableType.VIEW },
+                null);
         Query q = dc.query().from("APP", "CUSTOMERS").select("CUSTOMERNUMBER").where("ADDRESSLINE2").isNotNull()
                 .toQuery();
         assertEquals(25000, dc.getFetchSizeCalculator().getFetchSize(q));
@@ -180,8 +186,7 @@ public class DerbyTest extends TestCase {
         assertEquals(11, schemas.length);
         assertEquals("Schema[name=APP]", schemas[0].toString());
         assertEquals(13, schemas[0].getTableCount());
-        assertEquals("[Table[name=CUSTOMERS,type=TABLE,remarks=], "
-                + "Table[name=CUSTOMER_W_TER,type=TABLE,remarks=], "
+        assertEquals("[Table[name=CUSTOMERS,type=TABLE,remarks=], " + "Table[name=CUSTOMER_W_TER,type=TABLE,remarks=], "
                 + "Table[name=DEPARTMENT_MANAGERS,type=TABLE,remarks=], "
                 + "Table[name=EMPLOYEES,type=TABLE,remarks=], " + "Table[name=OFFICES,type=TABLE,remarks=], "
                 + "Table[name=ORDERDETAILS,type=TABLE,remarks=], " + "Table[name=ORDERFACT,type=TABLE,remarks=], "
@@ -239,7 +244,8 @@ public class DerbyTest extends TestCase {
     }
 
     public void testQueryRewriterQuoteAliases() throws Exception {
-        JdbcDataContext dc = new JdbcDataContext(_connection, new TableType[] { TableType.TABLE, TableType.VIEW }, null);
+        JdbcDataContext dc = new JdbcDataContext(_connection, new TableType[] { TableType.TABLE, TableType.VIEW },
+                null);
         IQueryRewriter queryRewriter = dc.getQueryRewriter();
         assertSame(DefaultQueryRewriter.class, queryRewriter.getClass());
 
@@ -304,7 +310,8 @@ public class DerbyTest extends TestCase {
                         .ofType(ColumnType.INTEGER).execute();
                 writtenTableRef.set(writtenTable);
                 String sql = createTableBuilder.createSqlStatement();
-                assertEquals("CREATE TABLE APP.test_table (id INTEGER, name VARCHAR(255), age INTEGER, PRIMARY KEY(id))",
+                assertEquals(
+                        "CREATE TABLE APP.test_table (id INTEGER, name VARCHAR(255), age INTEGER, PRIMARY KEY(id))",
                         sql.replaceAll("\"", "|"));
                 assertNotNull(writtenTable);
             }
@@ -393,7 +400,7 @@ public class DerbyTest extends TestCase {
 
         JdbcTestTemplates.convertClobToString(dc);
     }
-    
+
     public void testInterpretationOfNull() throws Exception {
         Connection conn = DriverManager.getConnection("jdbc:derby:target/temp_derby;create=true");
         JdbcTestTemplates.interpretationOfNulls(conn);

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/DerbyTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/DerbyTest.java
@@ -23,6 +23,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 import junit.framework.TestCase;
 
@@ -77,7 +78,7 @@ public class DerbyTest extends TestCase {
 
     public void testTimestampValueInsertSelect() throws Exception {
         Connection conn = DriverManager.getConnection("jdbc:derby:target/temp_derby;create=true");
-        JdbcTestTemplates.timestampValueInsertSelect(conn);
+        JdbcTestTemplates.timestampValueInsertSelect(conn, TimeUnit.MILLISECONDS);
     }
 
     public void testCreateInsertAndUpdate() throws Exception {

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/H2databaseTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/H2databaseTest.java
@@ -24,6 +24,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import junit.framework.TestCase;
 
@@ -82,7 +83,7 @@ public class H2databaseTest extends TestCase {
     }
     
     public void testTimestampValueInsertSelect() throws Exception {
-        JdbcTestTemplates.timestampValueInsertSelect(conn);
+        JdbcTestTemplates.timestampValueInsertSelect(conn, TimeUnit.MILLISECONDS);
     }
 
     public void testUsingSingleUpdates() throws Exception {

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/H2databaseTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/H2databaseTest.java
@@ -80,6 +80,10 @@ public class H2databaseTest extends TestCase {
         JdbcDataContext dc = new JdbcDataContext(conn);
         JdbcTestTemplates.compositeKeyCreation(dc, "metamodel_test_composite_keys");
     }
+    
+    public void testTimestampValueInsertSelect() throws Exception {
+        JdbcTestTemplates.timestampValueInsertSelect(conn);
+    }
 
     public void testUsingSingleUpdates() throws Exception {
         final JdbcDataContext dc = new JdbcDataContext(conn);

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/H2databaseTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/H2databaseTest.java
@@ -83,7 +83,7 @@ public class H2databaseTest extends TestCase {
     }
     
     public void testTimestampValueInsertSelect() throws Exception {
-        JdbcTestTemplates.timestampValueInsertSelect(conn, TimeUnit.MILLISECONDS);
+        JdbcTestTemplates.timestampValueInsertSelect(conn, TimeUnit.NANOSECONDS);
     }
 
     public void testUsingSingleUpdates() throws Exception {

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/HsqldbTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/HsqldbTest.java
@@ -74,7 +74,7 @@ public class HsqldbTest extends TestCase {
     
     public void testTimestampValueInsertSelect() throws Exception {
         Connection connection = DriverManager.getConnection("jdbc:hsqldb:mem:" + getName(), USERNAME, PASSWORD);
-        JdbcTestTemplates.timestampValueInsertSelect(connection, TimeUnit.MILLISECONDS);
+        JdbcTestTemplates.timestampValueInsertSelect(connection, TimeUnit.NANOSECONDS);
     }
 
     public void testCreateInsertAndUpdate() throws Exception {

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/HsqldbTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/HsqldbTest.java
@@ -70,6 +70,11 @@ public class HsqldbTest extends TestCase {
         super.tearDown();
         _connection.close();
     }
+    
+    public void testTimestampValueInsertSelect() throws Exception {
+        Connection connection = DriverManager.getConnection("jdbc:hsqldb:mem:" + getName(), USERNAME, PASSWORD);
+        JdbcTestTemplates.timestampValueInsertSelect(connection);
+    }
 
     public void testCreateInsertAndUpdate() throws Exception {
         Connection connection = DriverManager.getConnection("jdbc:hsqldb:mem:" + getName(), USERNAME, PASSWORD);

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/HsqldbTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/HsqldbTest.java
@@ -23,6 +23,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.Statement;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 import javax.swing.table.TableModel;
 
@@ -73,7 +74,7 @@ public class HsqldbTest extends TestCase {
     
     public void testTimestampValueInsertSelect() throws Exception {
         Connection connection = DriverManager.getConnection("jdbc:hsqldb:mem:" + getName(), USERNAME, PASSWORD);
-        JdbcTestTemplates.timestampValueInsertSelect(connection);
+        JdbcTestTemplates.timestampValueInsertSelect(connection, TimeUnit.MILLISECONDS);
     }
 
     public void testCreateInsertAndUpdate() throws Exception {

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/JdbcTestTemplates.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/JdbcTestTemplates.java
@@ -546,9 +546,9 @@ public class JdbcTestTemplates {
             dataContext.executeUpdate(new DropTable(defaultSchema, testTableName));
         }
 
-        dataContext.executeUpdate(
-                new CreateTable(defaultSchema, testTableName).withColumn("mykey").ofType(ColumnType.INTEGER)
-                        .nullable(false).asPrimaryKey().withColumn("name").ofType(ColumnType.VARCHAR).ofSize(20));
+        dataContext.executeUpdate(new CreateTable(defaultSchema, testTableName).withColumn("mykey")
+                .ofType(ColumnType.INTEGER).nullable(false).asPrimaryKey().withColumn("name")
+                .ofType(ColumnType.VARCHAR).ofSize(20));
         try {
             final Table table = defaultSchema.getTableByName(testTableName);
             assertNotNull(table);
@@ -587,10 +587,10 @@ public class JdbcTestTemplates {
             dataContext.executeUpdate(new DropTable(defaultSchema, testTableName));
         }
 
-        dataContext.executeUpdate(
-                new CreateTable(defaultSchema, testTableName).withColumn("mykey1").ofType(ColumnType.INTEGER)
-                        .nullable(false).asPrimaryKey().withColumn("mykey2").ofType(ColumnType.INTEGER).nullable(false)
-                        .asPrimaryKey().withColumn("name").ofType(ColumnType.VARCHAR).ofSize(20));
+        dataContext.executeUpdate(new CreateTable(defaultSchema, testTableName).withColumn("mykey1")
+                .ofType(ColumnType.INTEGER).nullable(false).asPrimaryKey().withColumn("mykey2")
+                .ofType(ColumnType.INTEGER).nullable(false).asPrimaryKey().withColumn("name")
+                .ofType(ColumnType.VARCHAR).ofSize(20));
         try {
             final Table table = defaultSchema.getTableByName(testTableName);
             assertNotNull(table);
@@ -645,7 +645,8 @@ public class JdbcTestTemplates {
      * @param databasePrecision
      *            the precision with which the database can handle timestamp
      *            values. Expected values: {@link TimeUnit#SECONDS},
-     *            {@link TimeUnit#MILLISECONDS} or {@link TimeUnit#NANOSECONDS}.
+     *            {@link TimeUnit#MILLISECONDS}, {@link TimeUnit#MICROSECONDS}
+     *            or {@link TimeUnit#NANOSECONDS}.
      * 
      * @throws Exception
      */
@@ -675,6 +676,9 @@ public class JdbcTestTemplates {
         case MILLISECONDS:
             timestamp1 = Timestamp.valueOf("2015-10-16 16:33:33.456");
             break;
+        case MICROSECONDS:
+            timestamp1 = Timestamp.valueOf("2015-10-16 16:33:33.456001");
+            break;
         case NANOSECONDS:
             timestamp1 = Timestamp.valueOf("2015-10-16 16:33:33.456001234");
             break;
@@ -689,6 +693,9 @@ public class JdbcTestTemplates {
             break;
         case MILLISECONDS:
             timestamp2 = Timestamp.valueOf("2015-10-16 16:33:34.683");
+            break;
+        case MICROSECONDS:
+            timestamp2 = Timestamp.valueOf("2015-10-16 16:33:34.683005");
             break;
         case NANOSECONDS:
             timestamp2 = Timestamp.valueOf("2015-10-16 16:33:34.683005678");
@@ -718,6 +725,9 @@ public class JdbcTestTemplates {
         case MILLISECONDS:
             assertEquals("Row[values=[1, 2015-10-16 16:33:33.456]]", ds.getRow().toString());
             break;
+        case MICROSECONDS:
+            assertEquals("Row[values=[1, 2015-10-16 16:33:33.456001]]", ds.getRow().toString());
+            break;
         case NANOSECONDS:
             assertEquals("Row[values=[1, 2015-10-16 16:33:33.456001234]]", ds.getRow().toString());
             break;
@@ -734,6 +744,9 @@ public class JdbcTestTemplates {
         case MILLISECONDS:
             assertEquals("Row[values=[2, 2015-10-16 16:33:34.683]]", ds.getRow().toString());
             break;
+        case MICROSECONDS:
+            assertEquals("Row[values=[2, 2015-10-16 16:33:34.683005]]", ds.getRow().toString());
+            break;
         case NANOSECONDS:
             assertEquals("Row[values=[2, 2015-10-16 16:33:34.683005678]]", ds.getRow().toString());
             break;
@@ -744,7 +757,8 @@ public class JdbcTestTemplates {
         ds.close();
 
         if (databasePrecision != TimeUnit.SECONDS) {
-            Query query = dc.query().from("test_table").select("id").where("insertiontime").lessThan(timestamp2).toQuery();
+            Query query = dc.query().from("test_table").select("id").where("insertiontime").lessThan(timestamp2)
+                    .toQuery();
             try {
                 ds = dc.executeQuery(query);
             } catch (Exception e) {
@@ -755,20 +769,20 @@ public class JdbcTestTemplates {
             assertEquals("Row[values=[1]]", ds.getRow().toString());
             assertFalse(ds.next());
             ds.close();
-            
+
             ds = dc.query().from("test_table").select("id").where("insertiontime").greaterThan(timestamp1).execute();
             assertTrue(ds.next());
             assertEquals("Row[values=[2]]", ds.getRow().toString());
             assertFalse(ds.next());
             ds.close();
-            
+
             dc.executeUpdate(new UpdateScript() {
                 @Override
                 public void run(UpdateCallback callback) {
                     callback.deleteFrom("test_table").where("insertiontime").eq(timestamp1).execute();
                 }
             });
-            
+
             ds = dc.query().from("test_table").selectCount().execute();
             assertTrue(ds.next());
             assertEquals("Row[values=[1]]", ds.getRow().toString());

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/SqliteTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/SqliteTest.java
@@ -69,6 +69,10 @@ public class SqliteTest extends TestCase {
         super.tearDown();
         _connection.close();
     }
+    
+    public void testTimestampValueInsertSelect() throws Exception {
+        JdbcTestTemplates.timestampValueInsertSelect(_connection);
+    }
 
     public void testCreateInsertAndUpdate() throws Exception {
         JdbcDataContext dc = new JdbcDataContext(_connection);

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/SqliteTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/SqliteTest.java
@@ -24,6 +24,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import junit.framework.TestCase;
 
@@ -71,7 +72,7 @@ public class SqliteTest extends TestCase {
     }
     
     public void testTimestampValueInsertSelect() throws Exception {
-        JdbcTestTemplates.timestampValueInsertSelect(_connection);
+        JdbcTestTemplates.timestampValueInsertSelect(_connection, TimeUnit.SECONDS);
     }
 
     public void testCreateInsertAndUpdate() throws Exception {

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/SqliteTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/SqliteTest.java
@@ -32,6 +32,7 @@ import org.apache.metamodel.DataContext;
 import org.apache.metamodel.UpdateCallback;
 import org.apache.metamodel.UpdateScript;
 import org.apache.metamodel.data.DataSet;
+import org.apache.metamodel.jdbc.dialects.SQLiteQueryRewriter;
 import org.apache.metamodel.query.OperatorType;
 import org.apache.metamodel.query.Query;
 import org.apache.metamodel.schema.Column;
@@ -70,7 +71,7 @@ public class SqliteTest extends TestCase {
         super.tearDown();
         _connection.close();
     }
-    
+
     public void testTimestampValueInsertSelect() throws Exception {
         JdbcTestTemplates.timestampValueInsertSelect(_connection, TimeUnit.SECONDS);
     }
@@ -89,6 +90,11 @@ public class SqliteTest extends TestCase {
         JdbcTestTemplates.differentOperatorsTest(_connection);
     }
 
+    public void testGetQueryRewriter() throws Exception {
+        JdbcDataContext dc = new JdbcDataContext(_connection);
+        assertTrue(dc.getQueryRewriter() instanceof SQLiteQueryRewriter);
+    }
+
     public void testGetSchemas() throws Exception {
         DataContext dc = new JdbcDataContext(_connection);
         String[] schemaNames = dc.getSchemaNames();
@@ -104,9 +110,8 @@ public class SqliteTest extends TestCase {
                 + "Table[name=auth_cookie,type=TABLE,remarks=null], " + "Table[name=session,type=TABLE,remarks=null], "
                 + "Table[name=session_attribute,type=TABLE,remarks=null], "
                 + "Table[name=attachment,type=TABLE,remarks=null], " + "Table[name=wiki,type=TABLE,remarks=null], "
-                + "Table[name=revision,type=TABLE,remarks=null], "
-                + "Table[name=node_change,type=TABLE,remarks=null], " + "Table[name=ticket,type=TABLE,remarks=null], "
-                + "Table[name=ticket_change,type=TABLE,remarks=null], "
+                + "Table[name=revision,type=TABLE,remarks=null], " + "Table[name=node_change,type=TABLE,remarks=null], "
+                + "Table[name=ticket,type=TABLE,remarks=null], " + "Table[name=ticket_change,type=TABLE,remarks=null], "
                 + "Table[name=ticket_custom,type=TABLE,remarks=null], " + "Table[name=enum,type=TABLE,remarks=null], "
                 + "Table[name=component,type=TABLE,remarks=null], " + "Table[name=milestone,type=TABLE,remarks=null], "
                 + "Table[name=version,type=TABLE,remarks=null], " + "Table[name=report,type=TABLE,remarks=null]]",
@@ -142,8 +147,8 @@ public class SqliteTest extends TestCase {
 
         Table wikiTable = schema.getTableByName("WIKI");
 
-        Query q = new Query().selectCount().from(wikiTable)
-                .where(wikiTable.getColumnByName("name"), OperatorType.LIKE, "Trac%");
+        Query q = new Query().selectCount().from(wikiTable).where(wikiTable.getColumnByName("name"), OperatorType.LIKE,
+                "Trac%");
         assertEquals("SELECT COUNT(*) FROM wiki WHERE wiki.name LIKE 'Trac%'", q.toString());
         assertEquals(1, dc.getFetchSizeCalculator().getFetchSize(q));
         assertEquals(37, dc.executeQuery(q).toObjectArrays().get(0)[0]);
@@ -170,8 +175,8 @@ public class SqliteTest extends TestCase {
         assertEquals("wiki.name", nameColumn.getQualifiedLabel());
 
         assertEquals(
-                "Column[name=name,columnNumber=0,type=VARCHAR,nullable=true,nativeType=TEXT,columnSize=2000000000]", dc
-                        .getColumnByQualifiedLabel("wiki.name").toString());
+                "Column[name=name,columnNumber=0,type=VARCHAR,nullable=true,nativeType=TEXT,columnSize=2000000000]",
+                dc.getColumnByQualifiedLabel("wiki.name").toString());
         assertEquals("Table[name=wiki,type=TABLE,remarks=null]", dc.getTableByQualifiedLabel("WIKI").toString());
     }
 

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/DB2Test.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/DB2Test.java
@@ -45,12 +45,12 @@ public class DB2Test extends AbstractJdbIntegrationTest {
 
         JdbcTestTemplates.simpleCreateInsertUpdateAndDrop(getDataContext(), "metamodel_db2_test");
     }
-    
+
     public void testCompositePrimaryKeyCreation() throws Exception {
         if (!isConfigured()) {
             return;
         }
-        
+
         JdbcTestTemplates.compositeKeyCreation(getDataContext(), "metamodel_test_composite_keys");
     }
 

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/MysqlTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/MysqlTest.java
@@ -18,11 +18,13 @@
  */
 package org.apache.metamodel.jdbc.integrationtests;
 
+import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import javax.swing.table.TableModel;
 
@@ -72,6 +74,15 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
         }
 
         JdbcTestTemplates.compositeKeyCreation(getDataContext(), "metamodel_test_composite_keys");
+    }
+    
+    public void testTimestampValueInsertSelect() throws Exception {
+        if (!isConfigured()) {
+            return;
+        }
+        
+        final Connection connection = getConnection();
+        JdbcTestTemplates.timestampValueInsertSelect(connection, TimeUnit.MICROSECONDS, "TIMESTAMP(6)");
     }
 
     public void testInterpretationOfNull() throws Exception {

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/OracleTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/OracleTest.java
@@ -18,8 +18,10 @@
  */
 package org.apache.metamodel.jdbc.integrationtests;
 
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 import javax.swing.table.TableModel;
 
@@ -86,6 +88,15 @@ public class OracleTest extends AbstractJdbIntegrationTest {
         }
 
         JdbcTestTemplates.simpleCreateInsertUpdateAndDrop(getDataContext(), "metamodel_test_simple");
+    }
+    
+    public void testTimestampValueInsertSelect() throws Exception {
+        if (!isConfigured()) {
+            return;
+        }
+        
+        final Connection connection = getConnection();
+        JdbcTestTemplates.timestampValueInsertSelect(connection, TimeUnit.MICROSECONDS, null);
     }
 
     public void testCompositePrimaryKeyCreation() throws Exception {

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
@@ -23,6 +23,7 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import javax.swing.table.TableModel;
 
@@ -63,6 +64,11 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
     @Override
     protected String getPropertyPrefix() {
         return "postgresql";
+    }
+    
+    public void testTimestampValueInsertSelect() throws Exception {
+        final Connection connection = getConnection();
+        JdbcTestTemplates.timestampValueInsertSelect(connection, TimeUnit.MILLISECONDS);
     }
 
     public void testCreateInsertAndUpdate() throws Exception {

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
@@ -67,6 +67,10 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
     }
     
     public void testTimestampValueInsertSelect() throws Exception {
+        if (!isConfigured()) {
+            return;
+        }
+        
         final Connection connection = getConnection();
         JdbcTestTemplates.timestampValueInsertSelect(connection, TimeUnit.MILLISECONDS);
     }

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
@@ -72,7 +72,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         }
         
         final Connection connection = getConnection();
-        JdbcTestTemplates.timestampValueInsertSelect(connection, TimeUnit.MILLISECONDS);
+        JdbcTestTemplates.timestampValueInsertSelect(connection, TimeUnit.MICROSECONDS);
     }
 
     public void testCreateInsertAndUpdate() throws Exception {

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/SQLServerJtdsDriverTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/SQLServerJtdsDriverTest.java
@@ -21,6 +21,7 @@ package org.apache.metamodel.jdbc.integrationtests;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.metamodel.UpdateCallback;
@@ -60,6 +61,15 @@ public class SQLServerJtdsDriverTest extends AbstractJdbIntegrationTest {
             return;
         }
         JdbcTestTemplates.simpleCreateInsertUpdateAndDrop(getDataContext(), "metamodel_test_simple");
+    }
+
+    public void testTimestampValueInsertSelect() throws Exception {
+        if (!isConfigured()) {
+            return;
+        }
+
+        final Connection connection = getConnection();
+        JdbcTestTemplates.timestampValueInsertSelect(connection, TimeUnit.NANOSECONDS, "datetime");
     }
 
     public void testCreateTableInUpdateScript() throws Exception {


### PR DESCRIPTION
Inspired by #58 I decided to make this PR to show what I had in mind as an alternative patch which aligns closer to the JDBC spec instead of taking the literalization of timestamps into MetaModel's codebase.