### PR TITLE
Let ElasticSearchDataContext read changes

### DIFF
--- a/core/src/main/java/org/apache/metamodel/util/SimpleTableDef.java
+++ b/core/src/main/java/org/apache/metamodel/util/SimpleTableDef.java
@@ -81,6 +81,9 @@ public class SimpleTableDef implements Serializable, HasName {
      *            the column types of the columns specified.
      */
     public SimpleTableDef(String name, String[] columnNames, ColumnType[] columnTypes) {
+        if(name == null){
+            throw new NullPointerException("Table name cannot be null");
+        }
         _name = name;
         _columnNames = columnNames;
         if (columnTypes == null) {

--- a/elasticsearch/src/main/java/org/apache/metamodel/elasticsearch/ElasticSearchCreateTableBuilder.java
+++ b/elasticsearch/src/main/java/org/apache/metamodel/elasticsearch/ElasticSearchCreateTableBuilder.java
@@ -59,7 +59,7 @@ final class ElasticSearchCreateTableBuilder extends AbstractTableCreationBuilder
         final IndicesAdminClient indicesAdmin = dataContext.getElasticSearchClient().admin().indices();
         final String indexName = dataContext.getIndexName();
 
-        final List<Object> sourceProperties = new ArrayList<Object>();
+        final List<Object> sourceProperties = new ArrayList<>();
         for (Column column : table.getColumns()) {
             // each column is defined as a property pair of the form: ("field1",
             // "type=string,store=true")
@@ -87,7 +87,6 @@ final class ElasticSearchCreateTableBuilder extends AbstractTableCreationBuilder
 
         final MutableSchema schema = (MutableSchema) getSchema();
         schema.addTable(table);
-
         return table;
     }
 

--- a/elasticsearch/src/main/java/org/apache/metamodel/elasticsearch/ElasticSearchInsertBuilder.java
+++ b/elasticsearch/src/main/java/org/apache/metamodel/elasticsearch/ElasticSearchInsertBuilder.java
@@ -47,7 +47,7 @@ final class ElasticSearchInsertBuilder extends AbstractRowInsertionBuilder<Elast
         final String documentType = getTable().getName();
         final IndexRequestBuilder requestBuilder = new IndexRequestBuilder(client, indexName).setType(documentType);
 
-        final Map<String, Object> valueMap = new HashMap<String, Object>();
+        final Map<String, Object> valueMap = new HashMap<>();
         final Column[] columns = getColumns();
         final Object[] values = getValues();
         for (int i = 0; i < columns.length; i++) {


### PR DESCRIPTION
This adds the ability for ElasticSearchDataContext to read  tables on
 updates, to assure that an outside change is registered. To
 keep the ability to specify own mappings, any static mappings will
 be left alone.

Fixes METAMODEL-197