### PR TITLE
METAMODEL-200: Added query syntax support for "function approximation"

### DIFF
--- a/core/src/main/java/org/apache/metamodel/query/SelectItem.java
+++ b/core/src/main/java/org/apache/metamodel/query/SelectItem.java
@@ -47,7 +47,8 @@ import org.slf4j.LoggerFactory;
  */
 public class SelectItem extends BaseObject implements QueryItem, Cloneable {
 
-    public static final char FUNCTION_APPROXIMATION_PREFIX = '~';
+    public static final String FUNCTION_APPROXIMATION_PREFIX = "APPROXIMATE ";
+    
     private static final long serialVersionUID = 317475105509663973L;
     private static final Logger logger = LoggerFactory.getLogger(SelectItem.class);
 

--- a/core/src/main/java/org/apache/metamodel/query/SelectItem.java
+++ b/core/src/main/java/org/apache/metamodel/query/SelectItem.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SelectItem extends BaseObject implements QueryItem, Cloneable {
 
+    public static final char FUNCTION_APPROXIMATION_PREFIX = '~';
     private static final long serialVersionUID = 317475105509663973L;
     private static final Logger logger = LoggerFactory.getLogger(SelectItem.class);
 
@@ -331,7 +332,10 @@ public class SelectItem extends BaseObject implements QueryItem, Cloneable {
         } else if (_column != null) {
             final StringBuilder sb = new StringBuilder();
             if (_function != null) {
-                sb.append(_function.toString());
+                if (_functionApproximationAllowed) {
+                    sb.append(FUNCTION_APPROXIMATION_PREFIX);
+                }
+                sb.append(_function.getFunctionName());
                 sb.append('(');
             }
             if (includeQuotes) {
@@ -364,7 +368,11 @@ public class SelectItem extends BaseObject implements QueryItem, Cloneable {
             sb.append(columnPrefix);
             sb.append(_column.getQuotedName());
             if (_function != null) {
-                sb.insert(0, _function + "(");
+                if (_functionApproximationAllowed) {
+                    sb.insert(0, FUNCTION_APPROXIMATION_PREFIX + _function.getFunctionName() + "(");
+                } else {
+                    sb.insert(0, _function.getFunctionName() + "(");
+                }
                 sb.append(")");
             }
             return sb.toString();
@@ -412,7 +420,11 @@ public class SelectItem extends BaseObject implements QueryItem, Cloneable {
             sb.append(_subQuerySelectItem.getSuperQueryAlias());
         }
         if (_function != null) {
-            sb.insert(0, _function.getFunctionName() + "(");
+            if (_functionApproximationAllowed) {
+                sb.insert(0, FUNCTION_APPROXIMATION_PREFIX + _function.getFunctionName() + "(");
+            } else {
+                sb.insert(0, _function.getFunctionName() + "(");
+            }
             sb.append(")");
         }
         return sb;

--- a/core/src/main/java/org/apache/metamodel/query/parser/SelectItemParser.java
+++ b/core/src/main/java/org/apache/metamodel/query/parser/SelectItemParser.java
@@ -110,8 +110,8 @@ public final class SelectItemParser implements QueryPartProcessor {
         final FunctionType function;
         final int startParenthesis = expression.indexOf('(');
         if (startParenthesis > 0 && expression.endsWith(")")) {
-            functionApproximation = (expression.charAt(0) == SelectItem.FUNCTION_APPROXIMATION_PREFIX);
-            final String functionName = expression.substring((functionApproximation ? 1 : 0), startParenthesis);
+            functionApproximation = (expression.startsWith(SelectItem.FUNCTION_APPROXIMATION_PREFIX));
+            final String functionName = expression.substring((functionApproximation ? SelectItem.FUNCTION_APPROXIMATION_PREFIX.length() : 0), startParenthesis);
             function = FunctionTypeFactory.get(functionName.toUpperCase());
             if (function != null) {
                 expression = expression.substring(startParenthesis + 1, expression.length() - 1).trim();

--- a/core/src/main/java/org/apache/metamodel/query/parser/SelectItemParser.java
+++ b/core/src/main/java/org/apache/metamodel/query/parser/SelectItemParser.java
@@ -106,19 +106,24 @@ public final class SelectItemParser implements QueryPartProcessor {
 
         final String unmodifiedExpression = expression;
 
+        final boolean functionApproximation;
         final FunctionType function;
         final int startParenthesis = expression.indexOf('(');
         if (startParenthesis > 0 && expression.endsWith(")")) {
-            String functionName = expression.substring(0, startParenthesis);
+            functionApproximation = (expression.charAt(0) == SelectItem.FUNCTION_APPROXIMATION_PREFIX);
+            final String functionName = expression.substring((functionApproximation ? 1 : 0), startParenthesis);
             function = FunctionTypeFactory.get(functionName.toUpperCase());
             if (function != null) {
                 expression = expression.substring(startParenthesis + 1, expression.length() - 1).trim();
                 if (function instanceof CountAggregateFunction && "*".equals(expression)) {
-                    return SelectItem.getCountAllItem();
+                    final SelectItem selectItem = SelectItem.getCountAllItem();
+                    selectItem.setFunctionApproximationAllowed(functionApproximation);
+                    return selectItem;
                 }
             }
         } else {
             function = null;
+            functionApproximation = false;
         }
 
         int lastIndexOfDot = expression.lastIndexOf(".");
@@ -146,9 +151,10 @@ public final class SelectItemParser implements QueryPartProcessor {
             if ("*".equals(columnName)) {
                 throw new MultipleSelectItemsParsedException(fromItem);
             } else if (fromItem.getTable() != null) {
-                Column column = fromItem.getTable().getColumnByName(columnName);
+                final Column column = fromItem.getTable().getColumnByName(columnName);
                 if (column != null) {
-                    SelectItem selectItem = new SelectItem(function, column, fromItem);
+                    final SelectItem selectItem = new SelectItem(function, column, fromItem);
+                    selectItem.setFunctionApproximationAllowed(functionApproximation);
                     return selectItem;
                 }
             } else if (fromItem.getSubQuery() != null) {
@@ -170,9 +176,10 @@ public final class SelectItemParser implements QueryPartProcessor {
         }
 
         if (_allowExpressionBasedSelectItems) {
-            return new SelectItem(function, expression, null);
+            final SelectItem selectItem = new SelectItem(function, expression, null);
+            selectItem.setFunctionApproximationAllowed(functionApproximation);
+            return selectItem;
         }
         return null;
     }
-
 }

--- a/core/src/test/java/org/apache/metamodel/query/SelectItemTest.java
+++ b/core/src/test/java/org/apache/metamodel/query/SelectItemTest.java
@@ -44,6 +44,12 @@ public class SelectItemTest extends MetaModelTestCase {
         SelectItem selectItem = new SelectItem(_schema.getTableByName(TABLE_PROJECT).getColumns()[0]);
         assertEquals("project.project_id", selectItem.toSql());
     }
+    
+    public void testToSqlFuntionApproximation() throws Exception {
+        SelectItem selectItem = new SelectItem(FunctionType.MAX, _schema.getTableByName(TABLE_PROJECT).getColumns()[0]);
+        selectItem.setFunctionApproximationAllowed(true);
+        assertEquals("~MAX(project.project_id)", selectItem.toSql());
+    }
 
     public void testSubQuerySelectItem() throws Exception {
         Table projectTable = _schema.getTableByName(TABLE_PROJECT);

--- a/core/src/test/java/org/apache/metamodel/query/SelectItemTest.java
+++ b/core/src/test/java/org/apache/metamodel/query/SelectItemTest.java
@@ -48,7 +48,7 @@ public class SelectItemTest extends MetaModelTestCase {
     public void testToSqlFuntionApproximation() throws Exception {
         SelectItem selectItem = new SelectItem(FunctionType.MAX, _schema.getTableByName(TABLE_PROJECT).getColumns()[0]);
         selectItem.setFunctionApproximationAllowed(true);
-        assertEquals("~MAX(project.project_id)", selectItem.toSql());
+        assertEquals("APPROXIMATE MAX(project.project_id)", selectItem.toSql());
     }
 
     public void testSubQuerySelectItem() throws Exception {

--- a/core/src/test/java/org/apache/metamodel/query/parser/QueryParserTest.java
+++ b/core/src/test/java/org/apache/metamodel/query/parser/QueryParserTest.java
@@ -87,6 +87,12 @@ public class QueryParserTest extends TestCase {
         Query q = MetaModelHelper.parseQuery(dc, "SELECT fo.o AS f FROM sch.tbl");
         assertEquals("SELECT tbl.fo.o AS f FROM sch.tbl", q.toSql());
     }
+    
+    public void testApproximateCountQuery() throws Exception {
+        Query q = MetaModelHelper.parseQuery(dc, "SELECT ~COUNT(*) FROM sch.tbl");
+        assertEquals("SELECT ~COUNT(*) FROM sch.tbl", q.toSql());
+        assertTrue(q.getSelectClause().getItem(0).isFunctionApproximationAllowed());
+    }
 
     public void testSelectAlias() throws Exception {
         Query q = MetaModelHelper.parseQuery(dc, "SELECT foo AS f FROM sch.tbl");

--- a/core/src/test/java/org/apache/metamodel/query/parser/QueryParserTest.java
+++ b/core/src/test/java/org/apache/metamodel/query/parser/QueryParserTest.java
@@ -89,8 +89,8 @@ public class QueryParserTest extends TestCase {
     }
     
     public void testApproximateCountQuery() throws Exception {
-        Query q = MetaModelHelper.parseQuery(dc, "SELECT ~COUNT(*) FROM sch.tbl");
-        assertEquals("SELECT ~COUNT(*) FROM sch.tbl", q.toSql());
+        Query q = MetaModelHelper.parseQuery(dc, "SELECT APPROXIMATE COUNT(*) FROM sch.tbl");
+        assertEquals("SELECT APPROXIMATE COUNT(*) FROM sch.tbl", q.toSql());
         assertTrue(q.getSelectClause().getItem(0).isFunctionApproximationAllowed());
     }
 


### PR DESCRIPTION
Fixes METAMODEL-200 by adding both toSql() and parser support for the tilde-character as a prefix "approximation indicator" for function names.

I also improved a few places in SelectItem.java where function.toString() was used instead of function.getFunctionName() (there's currently no difference because they all delegate toString() to getFunctionName(), but that should only be an implementation detail).