### PR TITLE
METAMODEL-218: Fixed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
  * [METAMODEL-216] - Added new aggregate functions: FIRST, LAST and RANDOM.
  * [METAMODEL-15] - Query parser support for table names with space. Delimitters can be double quote or square brackets. 
  * [METAMODEL-215] - Improved the capability of NumberComparator to support Integer, Long, Double, BigInteger and other built-in Number classes.
+ * [METAMODEL-218] - Fixed conversion of STRING and NUMBER types to database-specific types in JDBC module.
 
 ### Apache MetaModel 4.4.1
 

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/DefaultQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/DefaultQueryRewriter.java
@@ -88,11 +88,11 @@ public class DefaultQueryRewriter extends AbstractQueryRewriter {
     public String rewriteColumnType(ColumnType columnType, Integer columnSize) {
         if (columnType == ColumnType.STRING) {
             // convert STRING to VARCHAR as the default SQL type for strings
-            rewriteColumnType(ColumnType.VARCHAR, columnSize);
+            return rewriteColumnType(ColumnType.VARCHAR, columnSize);
         }
         if (columnType == ColumnType.NUMBER) {
             // convert NUMBER to FLOAT as the default SQL type for numbers
-            rewriteColumnType(ColumnType.FLOAT, columnSize);
+            return rewriteColumnType(ColumnType.FLOAT, columnSize);
         }
         return super.rewriteColumnType(columnType, columnSize);
     }

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/JdbcTestTemplates.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/JdbcTestTemplates.java
@@ -549,7 +549,7 @@ public class JdbcTestTemplates {
 
         dataContext.executeUpdate(new CreateTable(defaultSchema, testTableName).withColumn("mykey")
                 .ofType(ColumnType.INTEGER).nullable(false).asPrimaryKey().withColumn("name")
-                .ofType(ColumnType.VARCHAR).ofSize(20));
+                .ofType(ColumnType.STRING).ofSize(20));
         try {
             final Table table = defaultSchema.getTableByName(testTableName);
             assertNotNull(table);


### PR DESCRIPTION
This fixes METAMODEL-218 by adding a few return statement in DefaultQueryRewriter.

Also updated the test template to ensure that it's working on all the databases covered by these tests.