### PR TITLE
First attempts at making the API change for METAMODEL-6

### DIFF
--- a/core/src/main/java/org/apache/metamodel/AbstractUpdateCallback.java
+++ b/core/src/main/java/org/apache/metamodel/AbstractUpdateCallback.java
@@ -43,21 +43,21 @@ public abstract class AbstractUpdateCallback implements UpdateCallback {
     @Override
     public TableCreationBuilder createTable(String schemaName, String tableName) throws IllegalArgumentException,
             IllegalStateException {
-        Schema schema = getSchema(schemaName);
+        final Schema schema = getSchema(schemaName);
         return createTable(schema, tableName);
     }
 
     @Override
     public TableDropBuilder dropTable(String schemaName, String tableName) throws IllegalArgumentException,
             IllegalStateException, UnsupportedOperationException {
-        Table table = getTable(schemaName, tableName);
+        final Table table = getTable(schemaName, tableName);
         return dropTable(table);
     }
 
     @Override
     public TableDropBuilder dropTable(Schema schema, String tableName) throws IllegalArgumentException,
             IllegalStateException, UnsupportedOperationException {
-        Table table = schema.getTableByName(tableName);
+        final Table table = schema.getTableByName(tableName);
         if (table == null) {
             throw new IllegalArgumentException("Nu such table '" + tableName + "' found in schema: " + schema
                     + ". Available tables are: " + Arrays.toString(schema.getTableNames()));
@@ -158,5 +158,9 @@ public abstract class AbstractUpdateCallback implements UpdateCallback {
     public RowUpdationBuilder update(Table table) throws IllegalArgumentException, IllegalStateException,
             UnsupportedOperationException {
         return new DeleteAndInsertBuilder(this, table);
+    }
+    
+    public UpdateSummary getUpdateSummary() {
+        return DefaultUpdateSummary.unknownUpdates();
     }
 }

--- a/core/src/main/java/org/apache/metamodel/DefaultUpdateSummary.java
+++ b/core/src/main/java/org/apache/metamodel/DefaultUpdateSummary.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel;
+
+/**
+ * Default implementation of {@link UpdateSummary}.
+ */
+public class DefaultUpdateSummary implements UpdateSummary {
+
+    private static final UpdateSummary UNKNOWN_UPDATES = new DefaultUpdateSummary(null, null, null, null);
+
+    /**
+     * Gets an {@link UpdateSummary} object to return when the extent of the
+     * updates are unknown.
+     * 
+     * @return a {@link UpdateSummary} object without any knowledge of updates
+     *         performed.
+     */
+    public static UpdateSummary unknownUpdates() {
+        return UNKNOWN_UPDATES;
+    }
+
+    private final Integer _insertedRows;
+    private final Integer _updatedRows;
+    private final Integer _deletedRows;
+    private final Iterable<Object> _generatedKeys;
+
+    public DefaultUpdateSummary(Integer insertedRows, Integer updatedRows, Integer deletedRows,
+            Iterable<Object> generatedKeys) {
+        _insertedRows = insertedRows;
+        _updatedRows = updatedRows;
+        _deletedRows = deletedRows;
+        _generatedKeys = generatedKeys;
+    }
+
+    @Override
+    public Integer getInsertedRows() {
+        return _insertedRows;
+    }
+
+    @Override
+    public Integer getUpdatedRows() {
+        return _updatedRows;
+    }
+
+    @Override
+    public Integer getDeletedRows() {
+        return _deletedRows;
+    }
+
+    @Override
+    public Iterable<Object> getGeneratedKeys() {
+        return _generatedKeys;
+    }
+
+}

--- a/core/src/main/java/org/apache/metamodel/UpdateSummary.java
+++ b/core/src/main/java/org/apache/metamodel/UpdateSummary.java
@@ -31,10 +31,25 @@ package org.apache.metamodel;
  */
 public interface UpdateSummary {
 
+    /**
+     * Gets the number of inserted rows, or null if this number is unknown.
+     * 
+     * @return a row count or null if the number is unknown.
+     */
     public Integer getInsertedRows();
 
+    /**
+     * Gets the number of updated rows, or null if this number is unknown.
+     * 
+     * @return a row count or null if the number is unknown.
+     */
     public Integer getUpdatedRows();
 
+    /**
+     * Gets the number of deleted rows, or null if this number is unknown.
+     * 
+     * @return a row count or null if the number is unknown.
+     */
     public Integer getDeletedRows();
 
     /**

--- a/core/src/main/java/org/apache/metamodel/UpdateSummary.java
+++ b/core/src/main/java/org/apache/metamodel/UpdateSummary.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel;
+
+/**
+ * Represents a summary of changes made in a given
+ * {@link UpdateableDataContext#executeUpdate(UpdateScript)} call.
+ * 
+ * The amount of information available from an update varies a lot between
+ * different implementations of {@link UpdateableDataContext}. This interface
+ * represents the most common elements of interest, but not all elements may be
+ * available for a given update. For this reason any method call on this
+ * interface should be considered not guaranteed to return a value (so expect
+ * nulls to represent "not known/available").
+ */
+public interface UpdateSummary {
+
+    public Integer getInsertedRows();
+
+    public Integer getUpdatedRows();
+
+    public Integer getDeletedRows();
+
+    /**
+     * Gets a collection of keys that was generated as part of the update -
+     * typically because INSERTs where executed on an underlying database which
+     * generated record IDs for each insert.
+     * 
+     * @return a collection of generated keys, or null if not available.
+     */
+    public Iterable<Object> getGeneratedKeys();
+}

--- a/core/src/main/java/org/apache/metamodel/UpdateableDataContext.java
+++ b/core/src/main/java/org/apache/metamodel/UpdateableDataContext.java
@@ -23,17 +23,18 @@ package org.apache.metamodel;
  */
 public interface UpdateableDataContext extends DataContext {
 
-	/**
-	 * Submits an {@link UpdateScript} for execution on the {@link DataContext}.
-	 * 
-	 * Since implementations of the {@link DataContext} vary quite a lot, there
-	 * is no golden rule as to how an update script will be executed. But the
-	 * implementors should strive towards handling an {@link UpdateScript} as a
-	 * single transactional change to the data store.
-	 * 
-	 * @param update
-	 *            the update script to execute
-	 */
-	public void executeUpdate(UpdateScript update);
+    /**
+     * Submits an {@link UpdateScript} for execution on the {@link DataContext}.
+     * 
+     * Since implementations of the {@link DataContext} vary quite a lot, there
+     * is no golden rule as to how an update script will be executed. But the
+     * implementors should strive towards handling an {@link UpdateScript} as a
+     * single transactional change to the data store.
+     * 
+     * @param update
+     *            the update script to execute
+     * @return a summary of the updates performed
+     */
+    public UpdateSummary executeUpdate(UpdateScript update);
 
 }

--- a/core/src/main/java/org/apache/metamodel/intercept/InterceptableDataContext.java
+++ b/core/src/main/java/org/apache/metamodel/intercept/InterceptableDataContext.java
@@ -21,6 +21,7 @@ package org.apache.metamodel.intercept;
 import org.apache.metamodel.DataContext;
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.UpdateScript;
+import org.apache.metamodel.UpdateSummary;
 import org.apache.metamodel.UpdateableDataContext;
 import org.apache.metamodel.create.TableCreationBuilder;
 import org.apache.metamodel.data.DataSet;
@@ -241,7 +242,7 @@ public class InterceptableDataContext implements UpdateableDataContext {
     }
 
     @Override
-    public void executeUpdate(UpdateScript update) {
+    public UpdateSummary executeUpdate(UpdateScript update) {
         if (!(_delegate instanceof UpdateableDataContext)) {
             throw new UnsupportedOperationException("Delegate is not an UpdateableDataContext");
         }
@@ -250,14 +251,13 @@ public class InterceptableDataContext implements UpdateableDataContext {
         if (_tableCreationInterceptors.isEmpty() && _tableDropInterceptors.isEmpty()
                 && _rowInsertionInterceptors.isEmpty() && _rowUpdationInterceptors.isEmpty()
                 && _rowDeletionInterceptors.isEmpty()) {
-            delegate.executeUpdate(update);
-            return;
+            return delegate.executeUpdate(update);
         }
 
-        UpdateScript interceptableUpdateScript = new InterceptableUpdateScript(this, update,
+        final UpdateScript interceptableUpdateScript = new InterceptableUpdateScript(this, update,
                 _tableCreationInterceptors, _tableDropInterceptors, _rowInsertionInterceptors,
                 _rowUpdationInterceptors, _rowDeletionInterceptors);
-        delegate.executeUpdate(interceptableUpdateScript);
+        return delegate.executeUpdate(interceptableUpdateScript);
     }
 
     @Override

--- a/core/src/test/java/org/apache/metamodel/MockUpdateableDataContext.java
+++ b/core/src/test/java/org/apache/metamodel/MockUpdateableDataContext.java
@@ -100,8 +100,8 @@ public class MockUpdateableDataContext extends QueryPostprocessDataContext imple
     }
 
     @Override
-    public void executeUpdate(UpdateScript update) {
-        update.run(new AbstractUpdateCallback(this) {
+    public UpdateSummary executeUpdate(UpdateScript update) {
+        final AbstractUpdateCallback callback = new AbstractUpdateCallback(this) {
 
             @Override
             public boolean isDeleteSupported() {
@@ -153,7 +153,11 @@ public class MockUpdateableDataContext extends QueryPostprocessDataContext imple
                     IllegalStateException {
                 throw new UnsupportedOperationException();
             }
-        });
+        };
+        
+        update.run(callback);
+        
+        return callback.getUpdateSummary();
     }
 
     private void delete(List<FilterItem> whereItems) {

--- a/couchdb/src/main/java/org/apache/metamodel/couchdb/CouchDbDataContext.java
+++ b/couchdb/src/main/java/org/apache/metamodel/couchdb/CouchDbDataContext.java
@@ -24,6 +24,7 @@ import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.MetaModelHelper;
 import org.apache.metamodel.QueryPostprocessDataContext;
 import org.apache.metamodel.UpdateScript;
+import org.apache.metamodel.UpdateSummary;
 import org.apache.metamodel.UpdateableDataContext;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.data.DocumentSource;
@@ -167,13 +168,14 @@ public class CouchDbDataContext extends QueryPostprocessDataContext implements U
     }
 
     @Override
-    public void executeUpdate(UpdateScript script) {
-        CouchDbUpdateCallback callback = new CouchDbUpdateCallback(this);
+    public UpdateSummary executeUpdate(UpdateScript script) {
+        final CouchDbUpdateCallback callback = new CouchDbUpdateCallback(this);
         try {
             script.run(callback);
         } finally {
             callback.close();
         }
+        return callback.getUpdateSummary();
     }
 
     @Override

--- a/csv/src/main/java/org/apache/metamodel/csv/CsvDataContext.java
+++ b/csv/src/main/java/org/apache/metamodel/csv/CsvDataContext.java
@@ -33,6 +33,7 @@ import java.util.List;
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.QueryPostprocessDataContext;
 import org.apache.metamodel.UpdateScript;
+import org.apache.metamodel.UpdateSummary;
 import org.apache.metamodel.UpdateableDataContext;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.data.EmptyDataSet;
@@ -423,9 +424,10 @@ public final class CsvDataContext extends QueryPostprocessDataContext implements
     }
 
     @Override
-    public void executeUpdate(UpdateScript update) {
+    public UpdateSummary executeUpdate(UpdateScript update) {
         checkWritable();
-        CsvUpdateCallback callback = new CsvUpdateCallback(this);
+        
+        final CsvUpdateCallback callback = new CsvUpdateCallback(this);
         synchronized (WRITE_LOCK) {
             try {
                 update.run(callback);
@@ -433,5 +435,6 @@ public final class CsvDataContext extends QueryPostprocessDataContext implements
                 callback.close();
             }
         }
+        return callback.getUpdateSummary();
     }
 }

--- a/elasticsearch/native/src/main/java/org/apache/metamodel/elasticsearch/nativeclient/ElasticSearchDataContext.java
+++ b/elasticsearch/native/src/main/java/org/apache/metamodel/elasticsearch/nativeclient/ElasticSearchDataContext.java
@@ -29,6 +29,7 @@ import org.apache.metamodel.DataContext;
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.QueryPostprocessDataContext;
 import org.apache.metamodel.UpdateScript;
+import org.apache.metamodel.UpdateSummary;
 import org.apache.metamodel.UpdateableDataContext;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.data.DataSetHeader;
@@ -90,7 +91,8 @@ public class ElasticSearchDataContext extends QueryPostprocessDataContext implem
 
     private final Client elasticSearchClient;
     private final String indexName;
-    // Table definitions that are set from the beginning, not supposed to be changed.
+    // Table definitions that are set from the beginning, not supposed to be
+    // changed.
     private final List<SimpleTableDef> staticTableDefinitions;
 
     // Table definitions that are discovered, these can change
@@ -124,8 +126,8 @@ public class ElasticSearchDataContext extends QueryPostprocessDataContext implem
 
     /**
      * Constructs a {@link ElasticSearchDataContext} and automatically detects
-     * the schema structure/view on all indexes (see
-     * {@link this.detectSchema(Client, String)}).
+     * the schema structure/view on all indexes (see {@link
+     * this.detectSchema(Client, String)}).
      *
      * @param client
      *            the ElasticSearch client
@@ -149,8 +151,8 @@ public class ElasticSearchDataContext extends QueryPostprocessDataContext implem
         logger.info("Detecting schema for index '{}'", indexName);
 
         final ClusterState cs;
-        final ClusterStateRequestBuilder clusterStateRequestBuilder =
-                getElasticSearchClient().admin().cluster().prepareState();
+        final ClusterStateRequestBuilder clusterStateRequestBuilder = getElasticSearchClient().admin().cluster()
+                .prepareState();
 
         // different methods here to set the index name, so we have to use
         // reflection :-/
@@ -280,7 +282,8 @@ public class ElasticSearchDataContext extends QueryPostprocessDataContext implem
     @Override
     protected DataSet materializeMainSchemaTable(Table table, List<SelectItem> selectItems,
             List<FilterItem> whereItems, int firstRow, int maxRows) {
-        final QueryBuilder queryBuilder = ElasticSearchUtils.createQueryBuilderForSimpleWhere(whereItems, LogicalOperator.AND);
+        final QueryBuilder queryBuilder = ElasticSearchUtils.createQueryBuilderForSimpleWhere(whereItems,
+                LogicalOperator.AND);
         if (queryBuilder != null) {
             // where clause can be pushed down to an ElasticSearch query
             final SearchRequestBuilder searchRequest = createSearchRequest(table, firstRow, maxRows, queryBuilder);
@@ -358,10 +361,11 @@ public class ElasticSearchDataContext extends QueryPostprocessDataContext implem
     }
 
     @Override
-    public void executeUpdate(UpdateScript update) {
+    public UpdateSummary executeUpdate(UpdateScript update) {
         final ElasticSearchUpdateCallback callback = new ElasticSearchUpdateCallback(this);
         update.run(callback);
         callback.onExecuteUpdateFinished();
+        return callback.getUpdateSummary();
     }
 
     /**

--- a/excel/src/main/java/org/apache/metamodel/excel/ExcelDataContext.java
+++ b/excel/src/main/java/org/apache/metamodel/excel/ExcelDataContext.java
@@ -26,6 +26,7 @@ import org.apache.metamodel.DataContext;
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.QueryPostprocessDataContext;
 import org.apache.metamodel.UpdateScript;
+import org.apache.metamodel.UpdateSummary;
 import org.apache.metamodel.UpdateableDataContext;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.schema.Column;
@@ -225,8 +226,8 @@ public final class ExcelDataContext extends QueryPostprocessDataContext implemen
     }
 
     @Override
-    public void executeUpdate(UpdateScript update) {
-        ExcelUpdateCallback updateCallback = new ExcelUpdateCallback(this);
+    public UpdateSummary executeUpdate(UpdateScript update) {
+        final ExcelUpdateCallback updateCallback = new ExcelUpdateCallback(this);
         synchronized (WRITE_LOCK) {
             try {
                 update.run(updateCallback);
@@ -234,5 +235,6 @@ public final class ExcelDataContext extends QueryPostprocessDataContext implemen
                 updateCallback.close();
             }
         }
+        return updateCallback.getUpdateSummary();
     }
 }

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataContext.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataContext.java
@@ -39,6 +39,7 @@ import org.apache.metamodel.BatchUpdateScript;
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.MetaModelHelper;
 import org.apache.metamodel.UpdateScript;
+import org.apache.metamodel.UpdateSummary;
 import org.apache.metamodel.UpdateableDataContext;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.data.EmptyDataSet;
@@ -819,7 +820,7 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
     }
 
     @Override
-    public void executeUpdate(final UpdateScript update) {
+    public UpdateSummary executeUpdate(final UpdateScript update) {
         final JdbcUpdateCallback updateCallback;
 
         if (_supportsBatchUpdates && update instanceof BatchUpdateScript) {
@@ -844,6 +845,8 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
             updateCallback.close(false);
             throw e;
         }
+        
+        return updateCallback.getUpdateSummary();
     }
 
     protected boolean isSingleConnection() {

--- a/mongodb/src/main/java/org/apache/metamodel/mongodb/MongoDbDataContext.java
+++ b/mongodb/src/main/java/org/apache/metamodel/mongodb/MongoDbDataContext.java
@@ -31,6 +31,7 @@ import org.apache.metamodel.DataContext;
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.QueryPostprocessDataContext;
 import org.apache.metamodel.UpdateScript;
+import org.apache.metamodel.UpdateSummary;
 import org.apache.metamodel.UpdateableDataContext;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.data.DataSetHeader;
@@ -467,14 +468,16 @@ public class MongoDbDataContext extends QueryPostprocessDataContext implements U
 
     /**
      * Executes an update with a specific {@link WriteConcernAdvisor}.
+     * @return 
      */
-    public void executeUpdate(UpdateScript update, WriteConcernAdvisor writeConcernAdvisor) {
-        MongoDbUpdateCallback callback = new MongoDbUpdateCallback(this, writeConcernAdvisor);
+    public UpdateSummary executeUpdate(UpdateScript update, WriteConcernAdvisor writeConcernAdvisor) {
+        final MongoDbUpdateCallback callback = new MongoDbUpdateCallback(this, writeConcernAdvisor);
         try {
             update.run(callback);
         } finally {
             callback.close();
         }
+        return callback.getUpdateSummary();
     }
 
     /**
@@ -485,8 +488,8 @@ public class MongoDbDataContext extends QueryPostprocessDataContext implements U
     }
 
     @Override
-    public void executeUpdate(UpdateScript update) {
-        executeUpdate(update, getWriteConcernAdvisor());
+    public UpdateSummary executeUpdate(UpdateScript update) {
+        return executeUpdate(update, getWriteConcernAdvisor());
     }
 
     /**

--- a/pojo/src/main/java/org/apache/metamodel/pojo/PojoDataContext.java
+++ b/pojo/src/main/java/org/apache/metamodel/pojo/PojoDataContext.java
@@ -30,6 +30,7 @@ import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.MetaModelHelper;
 import org.apache.metamodel.QueryPostprocessDataContext;
 import org.apache.metamodel.UpdateScript;
+import org.apache.metamodel.UpdateSummary;
 import org.apache.metamodel.UpdateableDataContext;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.data.MaxRowsDataSet;
@@ -140,11 +141,12 @@ public class PojoDataContext extends QueryPostprocessDataContext implements Upda
     }
 
     @Override
-    public void executeUpdate(UpdateScript update) {
-        PojoUpdateCallback updateCallback = new PojoUpdateCallback(this);
+    public UpdateSummary executeUpdate(UpdateScript update) {
+        final PojoUpdateCallback updateCallback = new PojoUpdateCallback(this);
         synchronized (this) {
             update.run(updateCallback);
         }
+        return updateCallback.getUpdateSummary();
     }
 
     protected void addTableDataProvider(TableDataProvider<?> tableDataProvider) {

--- a/salesforce/src/main/java/org/apache/metamodel/salesforce/SalesforceDataContext.java
+++ b/salesforce/src/main/java/org/apache/metamodel/salesforce/SalesforceDataContext.java
@@ -25,9 +25,11 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 import com.sforce.ws.ConnectorConfig;
+
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.QueryPostprocessDataContext;
 import org.apache.metamodel.UpdateScript;
+import org.apache.metamodel.UpdateSummary;
 import org.apache.metamodel.UpdateableDataContext;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.data.FirstRowDataSet;
@@ -362,9 +364,10 @@ public class SalesforceDataContext extends QueryPostprocessDataContext implement
     }
 
     @Override
-    public void executeUpdate(UpdateScript update) {
+    public UpdateSummary executeUpdate(UpdateScript update) {
         final SalesforceUpdateCallback callback = new SalesforceUpdateCallback(this, _connection);
         update.run(callback);
         callback.close();
+        return callback.getUpdateSummary();
     }
 }


### PR DESCRIPTION
This PR proposes an important API change (admittedly without any proper implementation at this stage) to allow the publishing of information about a given data change/update.

I decided to post this PR without any proper implementation because (1) the API change alone will be beneficial to do sooner rather than later - we seem to be approaching a 4.5.0 release at the moment, so I find it smarter to break the API now instead of having to wait for the next major release and (2) adding the better implementation of the update summary can always be done on a case-by-case basis. I would suggest to start with a generic method for the number of inserts since that can be generalized very easily.