### PR TITLE
METAMODEL-222: Removed Java 7 compatibility and build options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: java
 jdk:
-  - openjdk7
   - oraclejdk8
   
 before_install:

--- a/pom.xml
+++ b/pom.xml
@@ -166,12 +166,12 @@ under the License.
 	<build>
 		<plugins>
 			<plugin>
-				<!-- Ensures java 7 compatibility -->
+				<!-- Ensures java 8 compatibility -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<encoding>utf-8</encoding>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
Note that the target of this PR is the new "5.x" branch.

This PR removes support for Java 7.
Fixes METAMODEL-222.