### PR TITLE
METAMODEL-224 CONCAT function support first approach (non-functional)

### DIFF
--- a/core/src/main/java/org/apache/metamodel/MetaModelHelper.java
+++ b/core/src/main/java/org/apache/metamodel/MetaModelHelper.java
@@ -277,7 +277,7 @@ public final class MetaModelHelper {
         final List<SelectItem> scalarFunctionSelectItemsToEvaluate = new ArrayList<>();
 
         for (SelectItem selectItem : selectItems) {
-            if (selectItem.getScalarFunction() != null) {
+            if (selectItem !=null && selectItem.getScalarFunction() != null) {
                 if (!dataSetSelectItems.contains(selectItem)
                         && dataSetSelectItems.contains(selectItem.replaceFunction(null))) {
                     scalarFunctionSelectItemsToEvaluate.add(selectItem);
@@ -768,7 +768,9 @@ public final class MetaModelHelper {
     public static SelectItem[] createSelectItems(Column... columns) {
         SelectItem[] items = new SelectItem[columns.length];
         for (int i = 0; i < items.length; i++) {
-            items[i] = new SelectItem(columns[i]);
+            if (columns[i] != null) {
+                items[i] = new SelectItem(columns[i]);
+            }
         }
         return items;
     }

--- a/core/src/main/java/org/apache/metamodel/data/AbstractRow.java
+++ b/core/src/main/java/org/apache/metamodel/data/AbstractRow.java
@@ -159,7 +159,7 @@ public abstract class AbstractRow implements Cloneable, Row {
         for (int i = 0; i < size; i++) {
             final SelectItem selectItem = header.getSelectItem(i);
 
-            if (selectItem.getSubQuerySelectItem() != null) {
+            if (selectItem != null && selectItem.getSubQuerySelectItem() != null) {
                 values[i] = getValue(selectItem.getSubQuerySelectItem());
                 styles[i] = getStyle(selectItem.getSubQuerySelectItem());
                 if (values[i] == null) {

--- a/core/src/main/java/org/apache/metamodel/query/ConcatFunction.java
+++ b/core/src/main/java/org/apache/metamodel/query/ConcatFunction.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.query;
+
+import org.apache.metamodel.data.Row;
+import org.apache.metamodel.schema.ColumnType;
+import org.apache.metamodel.util.CollectionUtils;
+
+import java.util.Map;
+
+/**
+ * Represents a function that concatenates values.
+ */
+public final class ConcatFunction extends DefaultScalarFunction {
+
+    @Override
+    public Object evaluate(Row row, Object[] parameters, SelectItem operandItem) {
+        if (parameters.length == 0) {
+            throw new IllegalArgumentException("Expecting some parameters to CONCAT function");
+        }
+        StringBuilder strBuilder = new StringBuilder();
+        for (Object parameter: parameters) {
+            String parameterAsString = parameter.toString();
+            final int startLiteral = parameterAsString.indexOf('\'');
+            if (startLiteral == 0) {
+                String literalWithoutTicks = parameterAsString.substring(1, parameterAsString.length() - 1);
+                strBuilder.append(literalWithoutTicks);
+            } else {
+                strBuilder.append(row.getValue(operandItem));
+            }
+        }
+        return strBuilder;
+    }
+
+    @Override
+    public ColumnType getExpectedColumnType(ColumnType type) {
+        // the column type cannot be inferred so null is returned
+        return null;
+    }
+
+    @Override
+    public String getFunctionName() {
+        return "CONCAT";
+    }
+
+}

--- a/core/src/main/java/org/apache/metamodel/query/FunctionType.java
+++ b/core/src/main/java/org/apache/metamodel/query/FunctionType.java
@@ -40,6 +40,7 @@ public interface FunctionType {
     public static final ScalarFunction TO_DATE = new ToDateFunction();
     public static final ScalarFunction TO_BOOLEAN = new ToBooleanFunction();
     public static final ScalarFunction MAP_VALUE = new MapValueFunction();
+    public static final ScalarFunction CONCAT = new ConcatFunction();
 
     public ColumnType getExpectedColumnType(ColumnType type);
 

--- a/core/src/main/java/org/apache/metamodel/query/FunctionTypeFactory.java
+++ b/core/src/main/java/org/apache/metamodel/query/FunctionTypeFactory.java
@@ -69,6 +69,8 @@ public class FunctionTypeFactory {
             return FunctionType.TO_DATE;
         case "MAP_VALUE":
             return FunctionType.MAP_VALUE;
+        case "CONCAT":
+            return FunctionType.CONCAT;
         default:
             return null;
         }

--- a/core/src/main/java/org/apache/metamodel/query/SelectItem.java
+++ b/core/src/main/java/org/apache/metamodel/query/SelectItem.java
@@ -190,6 +190,18 @@ public class SelectItem extends BaseObject implements QueryItem, Cloneable {
     }
 
     /**
+     * Creates a SelectItem that uses a function with multiple parameters
+     * from a particular {@link FromItem}, for example
+     * CONCAT('string1', col1, 'string2')
+     *
+     * @param function
+     * @param functionParameters
+     */
+    public SelectItem(FunctionType function, Object[] functionParameters) {
+        this(null, null, function, functionParameters, null, null, null, false);
+    }
+
+    /**
      * Creates a SelectItem based on an expression. All expression-based
      * SelectItems must have aliases.
      * 
@@ -484,10 +496,16 @@ public class SelectItem extends BaseObject implements QueryItem, Cloneable {
             final Object[] functionParameters = getFunctionParameters();
             if (functionParameters != null && functionParameters.length != 0) {
                 for (int i = 0; i < functionParameters.length; i++) {
-                    functionBeginning.append('\'');
+                    if (!_function.getFunctionName().equals(FunctionType.CONCAT.getFunctionName())) {
+                        functionBeginning.append('\'');
+                    }
                     functionBeginning.append(functionParameters[i]);
-                    functionBeginning.append('\'');
-                    functionBeginning.append(',');
+                    if (!_function.getFunctionName().equals(FunctionType.CONCAT.getFunctionName())) {
+                        functionBeginning.append('\'');
+                    }
+                    if (i != functionParameters.length - 1) {
+                        functionBeginning.append(',');
+                    }
                 }
             }
             sb.insert(0, functionBeginning.toString());

--- a/core/src/main/java/org/apache/metamodel/query/builder/ConcatSelectBuilderImpl.java
+++ b/core/src/main/java/org/apache/metamodel/query/builder/ConcatSelectBuilderImpl.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.query.builder;
+
+import org.apache.metamodel.query.FunctionType;
+import org.apache.metamodel.query.Query;
+import org.apache.metamodel.query.SelectItem;
+import org.apache.metamodel.schema.Column;
+
+import java.util.List;
+
+final class ConcatSelectBuilderImpl extends SatisfiedSelectBuilderImpl implements
+        FunctionSelectBuilder<GroupedQueryBuilder> {
+
+    private SelectItem selectItem;
+
+    public ConcatSelectBuilderImpl(FunctionType functionType,Object[] functionParameters,
+                                   Query query, GroupedQueryBuilder queryBuilder) {
+        super(queryBuilder);
+
+        this.selectItem = new SelectItem(functionType, functionParameters);
+
+        query.select(selectItem);
+    }
+
+    @Override
+    public GroupedQueryBuilder as(String alias) {
+        if (alias == null) {
+            throw new IllegalArgumentException("alias cannot be null");
+        }
+        selectItem.setAlias(alias);
+        return getQueryBuilder();
+    }
+
+    @Override
+    protected void decorateIdentity(List<Object> identifiers) {
+        super.decorateIdentity(identifiers);
+        identifiers.add(selectItem);
+    }
+}

--- a/core/src/main/java/org/apache/metamodel/query/builder/ConcatSelectBuilderImpl.java
+++ b/core/src/main/java/org/apache/metamodel/query/builder/ConcatSelectBuilderImpl.java
@@ -23,6 +23,7 @@ import org.apache.metamodel.query.Query;
 import org.apache.metamodel.query.SelectItem;
 import org.apache.metamodel.schema.Column;
 
+import java.util.Arrays;
 import java.util.List;
 
 final class ConcatSelectBuilderImpl extends SatisfiedSelectBuilderImpl implements
@@ -33,7 +34,18 @@ final class ConcatSelectBuilderImpl extends SatisfiedSelectBuilderImpl implement
     public ConcatSelectBuilderImpl(FunctionType functionType,Object[] functionParameters,
                                    Query query, GroupedQueryBuilder queryBuilder) {
         super(queryBuilder);
-
+        String[] paramsAsString = Arrays.asList(functionParameters).toArray(new String[functionParameters.length]);
+        Object[] functionParams = new Object[functionParameters.length];
+        int i = 0;
+        for (String parameter : paramsAsString) {
+            try {
+                Column column = queryBuilder.findColumn(parameter);
+                functionParams[i] = column;
+            } catch(IllegalArgumentException iAEx) {
+                functionParams[i] = parameter;
+            }
+            i++;
+        }
         this.selectItem = new SelectItem(functionType, functionParameters);
 
         query.select(selectItem);

--- a/core/src/main/java/org/apache/metamodel/query/builder/SatisfiedFromBuilder.java
+++ b/core/src/main/java/org/apache/metamodel/query/builder/SatisfiedFromBuilder.java
@@ -39,7 +39,9 @@ public interface SatisfiedFromBuilder {
     public FunctionSelectBuilder<?> select(FunctionType function, String columnName);
 
     public FunctionSelectBuilder<?> select(FunctionType function, Column column);
-    
+
+    public FunctionSelectBuilder<?> select(FunctionType function, Object[] functionParameters);
+
     public FunctionSelectBuilder<?> select(FunctionType function, String columnName, Object[] functionParameters);
 
     public FunctionSelectBuilder<?> select(FunctionType function, Column column, Object[] functionParameters);

--- a/core/src/main/java/org/apache/metamodel/query/builder/SatisfiedFromBuilderCallback.java
+++ b/core/src/main/java/org/apache/metamodel/query/builder/SatisfiedFromBuilderCallback.java
@@ -92,6 +92,19 @@ abstract class SatisfiedFromBuilderCallback extends BaseObject implements Satisf
     }
 
     @Override
+    public FunctionSelectBuilder<?> select(FunctionType function, Object[] functionParameters) {
+        if (function == null) {
+            throw new IllegalArgumentException("functionType cannot be null");
+        }
+        if (functionParameters == null) {
+            throw new IllegalArgumentException("functionParameters cannot be null");
+        }
+
+        final GroupedQueryBuilder queryBuilder = new GroupedQueryBuilderImpl(dataContext, query);
+        return new ConcatSelectBuilderImpl(function, functionParameters, query, queryBuilder);
+    }
+
+    @Override
     public FunctionSelectBuilder<?> select(FunctionType function, Column column, Object[] functionParameters) {
         if (function == null) {
             throw new IllegalArgumentException("functionType cannot be null");

--- a/core/src/main/java/org/apache/metamodel/query/parser/SelectItemParser.java
+++ b/core/src/main/java/org/apache/metamodel/query/parser/SelectItemParser.java
@@ -23,6 +23,8 @@ import org.apache.metamodel.MetaModelHelper;
 import org.apache.metamodel.query.*;
 import org.apache.metamodel.schema.Column;
 
+import java.util.Arrays;
+
 public final class SelectItemParser implements QueryPartProcessor {
 
     public static class MultipleSelectItemsParsedException extends IllegalArgumentException {
@@ -120,6 +122,9 @@ public final class SelectItemParser implements QueryPartProcessor {
                     final SelectItem selectItem = SelectItem.getCountAllItem();
                     selectItem.setFunctionApproximationAllowed(functionApproximation);
                     return selectItem;
+                }
+                if (functionName.equals(FunctionType.CONCAT.getFunctionName())) {
+                    return new SelectItem(new ConcatFunction(), expression.split(","));
                 }
             }
         } else {

--- a/core/src/test/java/org/apache/metamodel/QueryPostprocessDataContextTest.java
+++ b/core/src/test/java/org/apache/metamodel/QueryPostprocessDataContextTest.java
@@ -301,14 +301,15 @@ public class QueryPostprocessDataContextTest extends MetaModelTestCase {
         Query query = dc.query()
                 .from(table)
                 .select(FunctionType.CONCAT,
-                        new Object[] { "foo", "\' $\'" })
+                        new Object[] { "tab.foo", "\'$\'" })
                 .where("bar")
                 .eq("hello")
                 .toQuery();
-        assertEquals("SELECT CONCAT(foo,' $') FROM sch.tab WHERE tab.bar = 'hello'", query.toSql());
+        assertEquals("SELECT CONCAT(tab.foo,'$') FROM sch.tab WHERE tab.bar = 'hello'", query.toSql());
 
         DataSet ds = dc.executeQuery(query);
         assertTrue(ds.next());
+        assertEquals("Row[values=[1$]]", ds.getRow().toString());
         assertFalse(ds.next());
     }
 

--- a/core/src/test/java/org/apache/metamodel/QueryPostprocessDataContextTest.java
+++ b/core/src/test/java/org/apache/metamodel/QueryPostprocessDataContextTest.java
@@ -294,6 +294,24 @@ public class QueryPostprocessDataContextTest extends MetaModelTestCase {
         ds.close();
     }
 
+    public void testScalarFunctionConcat() throws Exception {
+        MockDataContext dc = new MockDataContext("sch", "tab", "1");
+        Table table = dc.getDefaultSchema().getTables()[0];
+
+        Query query = dc.query()
+                .from(table)
+                .select(FunctionType.CONCAT,
+                        new Object[] { "foo", "\' $\'" })
+                .where("bar")
+                .eq("hello")
+                .toQuery();
+        assertEquals("SELECT CONCAT(foo,' $') FROM sch.tab WHERE tab.bar = 'hello'", query.toSql());
+
+        DataSet ds = dc.executeQuery(query);
+        assertTrue(ds.next());
+        assertFalse(ds.next());
+    }
+
     public void testSelectItemReferencesToFromItems() throws Exception {
         MockDataContext dc = new MockDataContext("sch", "tab", "1");
 

--- a/core/src/test/java/org/apache/metamodel/query/ConcatFunctionTest.java
+++ b/core/src/test/java/org/apache/metamodel/query/ConcatFunctionTest.java
@@ -21,6 +21,9 @@ package org.apache.metamodel.query;
 import org.apache.metamodel.data.DefaultRow;
 import org.apache.metamodel.data.Row;
 import org.apache.metamodel.data.SimpleDataSetHeader;
+import org.apache.metamodel.schema.Column;
+import org.apache.metamodel.schema.ColumnType;
+import org.apache.metamodel.schema.MutableColumn;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -34,21 +37,30 @@ public class ConcatFunctionTest {
 
     @Test
     public void testConcatValues() throws Exception {
-        final SelectItem operandItem1 = new SelectItem("foo", "f");
-        final SelectItem operandItem2 = new SelectItem("bar", "b");
-        final Row row = new DefaultRow(new SimpleDataSetHeader(new SelectItem[] { operandItem1 }),
-                new Object[] { 1 });
-        final Object v1 = function.evaluate(row, new Object[] { "foo", "\'stringtobeappended\'" }, operandItem1);
-        assertEquals("1stringtobeappended", v1.toString());
+        MutableColumn column1 = new MutableColumn("column1", ColumnType.VARCHAR);
+        MutableColumn column2 = new MutableColumn("column2", ColumnType.INTEGER);
+        final SelectItem operandItem1 = new SelectItem(column1);
+        final SelectItem operandItem2 = new SelectItem(column2);
+        final Row row = new DefaultRow(new SimpleDataSetHeader(new SelectItem[] { operandItem1 , operandItem2}),
+                new Object[] { 1 , "hello"});
+        final Object v1 = function.evaluate(
+                row,
+                new Object[] { "column1", "\' stringtobeappended \'", "column2" },
+                operandItem1);
+        assertEquals("1 stringtobeappended hello", v1.toString());
     }
 
-    /*@Test
-    public void testNotAMap() throws Exception {
-        final SelectItem operandItem = new SelectItem("foo", "f");
-        final Row row = new DefaultRow(new SimpleDataSetHeader(new SelectItem[] { operandItem }),
-                new Object[] { "not a map" });
-        final Object v1 = function.evaluate(row, new Object[] { "foo.bar" }, operandItem);
-        assertEquals(null, v1);
-    }*/
+    @Test
+    public void testNotAValidColumn() throws Exception {
+        MutableColumn column1 = new MutableColumn("column1", ColumnType.VARCHAR);
+        final SelectItem operandItem1 = new SelectItem(column1);
+        final Row row = new DefaultRow(new SimpleDataSetHeader(new SelectItem[] { operandItem1 }),
+                new Object[] { "hello" });
+        final Object v1 = function.evaluate(
+                row,
+                new Object[] { "column1", "\' stringtobeappended \'", "column2" },
+                operandItem1);
+        assertEquals("hello stringtobeappended null", v1.toString());
+    }
 
 }

--- a/core/src/test/java/org/apache/metamodel/query/ConcatFunctionTest.java
+++ b/core/src/test/java/org/apache/metamodel/query/ConcatFunctionTest.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.query;
+
+import org.apache.metamodel.data.DefaultRow;
+import org.apache.metamodel.data.Row;
+import org.apache.metamodel.data.SimpleDataSetHeader;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConcatFunctionTest {
+
+    private final ScalarFunction function = FunctionType.CONCAT;
+
+    @Test
+    public void testConcatValues() throws Exception {
+        final SelectItem operandItem1 = new SelectItem("foo", "f");
+        final SelectItem operandItem2 = new SelectItem("bar", "b");
+        final Row row = new DefaultRow(new SimpleDataSetHeader(new SelectItem[] { operandItem1 }),
+                new Object[] { 1 });
+        final Object v1 = function.evaluate(row, new Object[] { "foo", "\'stringtobeappended\'" }, operandItem1);
+        assertEquals("1stringtobeappended", v1.toString());
+    }
+
+    /*@Test
+    public void testNotAMap() throws Exception {
+        final SelectItem operandItem = new SelectItem("foo", "f");
+        final Row row = new DefaultRow(new SimpleDataSetHeader(new SelectItem[] { operandItem }),
+                new Object[] { "not a map" });
+        final Object v1 = function.evaluate(row, new Object[] { "foo.bar" }, operandItem);
+        assertEquals(null, v1);
+    }*/
+
+}

--- a/core/src/test/java/org/apache/metamodel/query/parser/QueryParserTest.java
+++ b/core/src/test/java/org/apache/metamodel/query/parser/QueryParserTest.java
@@ -80,6 +80,11 @@ public class QueryParserTest extends TestCase {
                 q.toSql());
     }
 
+    public void testSelectUsingConcatFunction() throws Exception {
+        Query q = MetaModelHelper.parseQuery(dc, "select CONCAT(a.foo, 'bar') from sch.tbl a WHERE BOOLEAN(a.bar) = false");
+        assertEquals("SELECT CONCAT(a.foo, 'bar') FROM sch.tbl a WHERE TO_BOOLEAN(a.bar) = FALSE", q.toSql());
+    }
+
     public void testSelectEverythingFromTable() throws Exception {
         Query q = MetaModelHelper.parseQuery(dc, "SELECT * FROM sch.tbl");
         assertEquals("SELECT tbl.foo, tbl.bar, tbl.baz FROM sch.tbl", q.toSql());


### PR DESCRIPTION
These are the first steps to add support for the CONCAT scalar function.

I've got a bit bogged down with this, not sure whether I'm going down the right path. It's been quite complicated because is the first time we're having a function that might have one or more parameters and even the parameters might apply to one, two... columns or they might be just literals. We might have the following CONCAT functions:

CONCAT(column1, 'hello', column2)
CONCAT('hello', 'world')
CONCAT(column1, column2, column3)

I've created a new select method with the following parameters: function and functionParameters where the functionParameters are going to be the column names (or literals). But I've found out that when I evaluate the function within my new ConcatFunction class the selectItems from the row do not contain all the columns so I can't get the values to create the result.

I'm afraid that I'd need some tips to keep working on this :(