### PR TITLE
Added fix for escaping in CsvWriter in case where quote char is not set

### DIFF
--- a/csv/src/main/java/org/apache/metamodel/csv/CsvWriter.java
+++ b/csv/src/main/java/org/apache/metamodel/csv/CsvWriter.java
@@ -72,23 +72,38 @@ public final class CsvWriter {
     }
 
     private boolean stringContainsSpecialCharacters(String line) {
-        return line.indexOf(_configuration.getQuoteChar()) != -1 || line.indexOf(_configuration.getEscapeChar()) != -1;
+        boolean result = line.indexOf(_configuration.getQuoteChar()) != -1
+                || line.indexOf(_configuration.getEscapeChar()) != -1;
+        if (!result) {
+            result = _configuration.getQuoteChar() == CsvConfiguration.NOT_A_CHAR
+                    && _configuration.getEscapeChar() != CsvConfiguration.NOT_A_CHAR;
+        }
+        return result;
     }
 
-    private StringBuilder processLine(String nextElement) {
-        final StringBuilder sb = new StringBuilder(INITIAL_STRING_SIZE);
+    private String processLine(String nextElement) {
+        final char escapeChar = _configuration.getEscapeChar();
+        if (escapeChar == CsvConfiguration.NOT_A_CHAR) {
+            return nextElement;
+        }
+
+        final char quoteChar = _configuration.getQuoteChar();
+        final char separatorChar = _configuration.getSeparatorChar();
+
+        final StringBuilder sb = new StringBuilder(nextElement.length() + 10);
         for (int j = 0; j < nextElement.length(); j++) {
             final char nextChar = nextElement.charAt(j);
-            final char escapeChar = _configuration.getEscapeChar();
-            if (escapeChar != CsvConfiguration.NOT_A_CHAR && nextChar == _configuration.getQuoteChar()) {
+            if (nextChar == quoteChar) {
                 sb.append(escapeChar).append(nextChar);
-            } else if (escapeChar != CsvConfiguration.NOT_A_CHAR && nextChar == escapeChar) {
+            } else if (nextChar == escapeChar) {
+                sb.append(escapeChar).append(nextChar);
+            } else if (quoteChar == CsvConfiguration.NOT_A_CHAR && nextChar == separatorChar) {
                 sb.append(escapeChar).append(nextChar);
             } else {
                 sb.append(nextChar);
             }
         }
 
-        return sb;
+        return sb.toString();
     }
 }

--- a/csv/src/main/java/org/apache/metamodel/csv/CsvWriter.java
+++ b/csv/src/main/java/org/apache/metamodel/csv/CsvWriter.java
@@ -59,7 +59,7 @@ public final class CsvWriter {
                 sb.append(quoteChar);
             }
 
-            sb.append(stringContainsSpecialCharacters(nextElement) ? processLine(nextElement) : nextElement);
+            sb.append(valueNeedsEscaping(nextElement) ? processValue(nextElement) : nextElement);
 
             if (quoteChar != CsvConfiguration.NOT_A_CHAR) {
                 sb.append(quoteChar);
@@ -71,28 +71,28 @@ public final class CsvWriter {
 
     }
 
-    private boolean stringContainsSpecialCharacters(String line) {
+    private boolean valueNeedsEscaping(String line) {
         boolean result = line.indexOf(_configuration.getQuoteChar()) != -1
                 || line.indexOf(_configuration.getEscapeChar()) != -1;
         if (!result) {
             result = _configuration.getQuoteChar() == CsvConfiguration.NOT_A_CHAR
-                    && _configuration.getEscapeChar() != CsvConfiguration.NOT_A_CHAR;
+                    && line.indexOf(_configuration.getSeparatorChar()) != -1;
         }
         return result;
     }
 
-    private String processLine(String nextElement) {
+    private String processValue(String value) {
         final char escapeChar = _configuration.getEscapeChar();
         if (escapeChar == CsvConfiguration.NOT_A_CHAR) {
-            return nextElement;
+            return value;
         }
 
         final char quoteChar = _configuration.getQuoteChar();
         final char separatorChar = _configuration.getSeparatorChar();
 
-        final StringBuilder sb = new StringBuilder(nextElement.length() + 10);
-        for (int j = 0; j < nextElement.length(); j++) {
-            final char nextChar = nextElement.charAt(j);
+        final StringBuilder sb = new StringBuilder(value.length() + 10);
+        for (int j = 0; j < value.length(); j++) {
+            final char nextChar = value.charAt(j);
             if (nextChar == quoteChar) {
                 sb.append(escapeChar).append(nextChar);
             } else if (nextChar == escapeChar) {

--- a/csv/src/test/java/org/apache/metamodel/csv/CsvWriterTest.java
+++ b/csv/src/test/java/org/apache/metamodel/csv/CsvWriterTest.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.csv;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class CsvWriterTest {
+
+    @Test
+    public void testBuildLineWithSeparatorInValue() throws Exception {
+        CsvConfiguration configuration = new CsvConfiguration(1, "UTF-8", ',', '"', '\\');
+        CsvWriter writer = new CsvWriter(configuration);
+        String line = writer.buildLine(new String[] {"0", "1,2", "3'4", "5\\6"});
+        assertEquals("\"0\",\"1,2\",\"3'4\",\"5\\\\6\"\n", line);
+    }
+    
+
+    @Test
+    public void testBuildLineWithSeparatorInValueAndNoQuoteCharacterSet() throws Exception {
+        CsvConfiguration configuration = new CsvConfiguration(1, "UTF-8", ',', CsvConfiguration.NOT_A_CHAR, '\\');
+        CsvWriter writer = new CsvWriter(configuration);
+        String line = writer.buildLine(new String[] {"0", "1,2", "3'4", "5\\6"});
+        assertEquals("0,1\\,2,3'4,5\\\\6\n", line);
+    }
+}


### PR DESCRIPTION
Today I discovered a small bug in MetaModel's CsvWriter - that it would fail to escape a separator char if there is no quote char. Please find here my patch for the problem.