### PR TITLE
METAMODEL-6: Added UpdateSummary building for JDBC module

### DIFF
--- a/core/src/main/java/org/apache/metamodel/AbstractUpdateCallback.java
+++ b/core/src/main/java/org/apache/metamodel/AbstractUpdateCallback.java
@@ -48,14 +48,14 @@ public abstract class AbstractUpdateCallback implements UpdateCallback {
     }
 
     @Override
-    public TableDropBuilder dropTable(String schemaName, String tableName) throws IllegalArgumentException,
+    public final TableDropBuilder dropTable(String schemaName, String tableName) throws IllegalArgumentException,
             IllegalStateException, UnsupportedOperationException {
         final Table table = getTable(schemaName, tableName);
         return dropTable(table);
     }
 
     @Override
-    public TableDropBuilder dropTable(Schema schema, String tableName) throws IllegalArgumentException,
+    public final TableDropBuilder dropTable(Schema schema, String tableName) throws IllegalArgumentException,
             IllegalStateException, UnsupportedOperationException {
         final Table table = schema.getTableByName(tableName);
         if (table == null) {
@@ -72,7 +72,7 @@ public abstract class AbstractUpdateCallback implements UpdateCallback {
     }
 
     @Override
-    public RowInsertionBuilder insertInto(String schemaName, String tableName) throws IllegalArgumentException,
+    public final RowInsertionBuilder insertInto(String schemaName, String tableName) throws IllegalArgumentException,
             IllegalStateException, UnsupportedOperationException {
         return insertInto(getTable(schemaName, tableName));
     }
@@ -101,7 +101,7 @@ public abstract class AbstractUpdateCallback implements UpdateCallback {
     }
 
     @Override
-    public RowDeletionBuilder deleteFrom(String schemaName, String tableName) throws IllegalArgumentException,
+    public final RowDeletionBuilder deleteFrom(String schemaName, String tableName) throws IllegalArgumentException,
             IllegalStateException, UnsupportedOperationException {
         final Table table = getTable(schemaName, tableName);
         return deleteFrom(table);
@@ -138,7 +138,7 @@ public abstract class AbstractUpdateCallback implements UpdateCallback {
 
     @Override
     public boolean isInsertSupported() {
-        // since 2.0 all updateable datacontext have create table support
+        // since 2.0 all updateable datacontext have insert into table support
         return true;
     }
 
@@ -148,7 +148,7 @@ public abstract class AbstractUpdateCallback implements UpdateCallback {
     }
 
     @Override
-    public RowUpdationBuilder update(String schemaName, String tableName) throws IllegalArgumentException,
+    public final RowUpdationBuilder update(String schemaName, String tableName) throws IllegalArgumentException,
             IllegalStateException, UnsupportedOperationException {
         final Table table = getTable(schemaName, tableName);
         return update(table);

--- a/core/src/main/java/org/apache/metamodel/UpdateSummaryBuilder.java
+++ b/core/src/main/java/org/apache/metamodel/UpdateSummaryBuilder.java
@@ -1,0 +1,130 @@
+/**
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * A builder object for {@link UpdateSummary}.
+ */
+public class UpdateSummaryBuilder {
+
+    private int _inserts;
+    private int _updates;
+    private int _deletes;
+    private Set<Object> _generatedKeys;
+
+    public UpdateSummaryBuilder() {
+    }
+
+    public UpdateSummary build() {
+        final Integer insertedRows = (_inserts == -1 ? null : _inserts);
+        final Integer updatedRows = (_updates == -1 ? null : _updates);
+        final Integer deletedRows = (_deletes == -1 ? null : _deletes);
+        final Iterable<Object> generatedKeys;
+        if (_generatedKeys != null) {
+            generatedKeys = new LinkedHashSet<>(_generatedKeys);
+        } else {
+            generatedKeys = null;
+        }
+        return new DefaultUpdateSummary(insertedRows, updatedRows, deletedRows, generatedKeys);
+    }
+
+    public UpdateSummaryBuilder addInsert() {
+        return addInserts(1);
+    }
+
+    public UpdateSummaryBuilder addInserts(int inserts) {
+        if (_inserts != -1) {
+            _inserts += inserts;
+        }
+        return this;
+    }
+
+    public UpdateSummaryBuilder makeInsertsUnknown() {
+        _inserts = -1;
+        return this;
+    }
+
+    public UpdateSummaryBuilder addUpdate() {
+        return addUpdates(1);
+    }
+
+    public UpdateSummaryBuilder addUpdates(int updates) {
+        if (_updates != -1) {
+            _updates += updates;
+        }
+        return this;
+    }
+
+    public UpdateSummaryBuilder makeUpdatesUnknown() {
+        _updates = -1;
+        return this;
+    }
+
+    public UpdateSummaryBuilder addDelete() {
+        return addDeletes(1);
+    }
+
+    public UpdateSummaryBuilder addDeletes(int deletes) {
+        if (_deletes != -1) {
+            _deletes += deletes;
+        }
+        return this;
+    }
+
+    public UpdateSummaryBuilder makeDeletesUnknown() {
+        _deletes = -1;
+        return this;
+    }
+
+    public UpdateSummaryBuilder addGeneratedKey(Object key) {
+        if (_generatedKeys == null) {
+            _generatedKeys = new HashSet<>();
+        }
+        _generatedKeys.add(key);
+        return this;
+    }
+
+    public UpdateSummaryBuilder addGeneratedKeys(Object... keys) {
+        if (_generatedKeys == null) {
+            _generatedKeys = new HashSet<>();
+        }
+        for (Object key : keys) {
+            _generatedKeys.add(key);
+        }
+        return this;
+    }
+
+    public UpdateSummaryBuilder addGeneratedKeys(Iterable<?> keys) {
+        if (_generatedKeys == null) {
+            _generatedKeys = new HashSet<>();
+        }
+        for (Object key : keys) {
+            _generatedKeys.add(key);
+        }
+        return this;
+    }
+
+    public UpdateSummaryBuilder makeGeneratedKeysUnknown() {
+        _generatedKeys = null;
+        return this;
+    }
+}

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcBatchUpdateCallback.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcBatchUpdateCallback.java
@@ -68,7 +68,13 @@ final class JdbcBatchUpdateCallback extends JdbcUpdateCallback {
     }
 
     @Override
-    protected void executePreparedStatement(PreparedStatement st) throws SQLException {
+    protected int executePreparedStatement(PreparedStatement st) throws SQLException {
         st.addBatch();
+        return -1;
+    }
+    
+    @Override
+    protected boolean isGeneratedKeysCollectionEnabled() {
+        return false;
     }
 }

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDeleteBuilder.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDeleteBuilder.java
@@ -62,7 +62,7 @@ final class JdbcDeleteBuilder extends AbstractRowDeletionBuilder {
 
         logger.debug("Delete statement created: {}", sql);
         final boolean reuseStatement = !_inlineValues;
-        final PreparedStatement st = _updateCallback.getPreparedStatement(sql, reuseStatement);
+        final PreparedStatement st = _updateCallback.getPreparedStatement(sql, reuseStatement, false);
         try {
             if (reuseStatement) {
                 int valueCounter = 1;
@@ -75,7 +75,7 @@ final class JdbcDeleteBuilder extends AbstractRowDeletionBuilder {
                     }
                 }
             }
-            _updateCallback.executePreparedStatement(st, reuseStatement);
+            _updateCallback.executeDelete(st, reuseStatement);
         } catch (SQLException e) {
             throw JdbcUtils.wrapException(e, "execute delete statement: " + sql);
         } finally {

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDropTableBuilder.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDropTableBuilder.java
@@ -46,9 +46,9 @@ final class JdbcDropTableBuilder extends AbstractTableDropBuilder implements Tab
     @Override
     public void execute() {
         final String sql = createSqlStatement();
-        final PreparedStatement statement = _updateCallback.getPreparedStatement(sql, false);
+        final PreparedStatement statement = _updateCallback.getPreparedStatement(sql, false, false);
         try {
-            _updateCallback.executePreparedStatement(statement, false);
+            _updateCallback.executePreparedStatement(statement, false, false);
 
             // remove the table reference from the schema
             final Schema schema = getTable().getSchema();

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcInsertBuilder.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcInsertBuilder.java
@@ -66,7 +66,7 @@ final class JdbcInsertBuilder extends AbstractRowInsertionBuilder<JdbcUpdateCall
 		}
 		final JdbcUpdateCallback updateCallback = getUpdateCallback();
 		final boolean reuseStatement = !_inlineValues;
-		final PreparedStatement st = updateCallback.getPreparedStatement(sql, reuseStatement);
+		final PreparedStatement st = updateCallback.getPreparedStatement(sql, reuseStatement, true);
 		try {
 			if (reuseStatement) {
 				Column[] columns = getColumns();
@@ -81,7 +81,7 @@ final class JdbcInsertBuilder extends AbstractRowInsertionBuilder<JdbcUpdateCall
 					}
 				}
 			}
-			updateCallback.executePreparedStatement(st, reuseStatement);
+			updateCallback.executeInsert(st, reuseStatement);
 		} catch (SQLException e) {
 			throw JdbcUtils.wrapException(e, "execute insert statement: " + sql);
 		} finally {

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcSimpleUpdateCallback.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcSimpleUpdateCallback.java
@@ -34,14 +34,19 @@ final class JdbcSimpleUpdateCallback extends JdbcUpdateCallback {
     public JdbcSimpleUpdateCallback(JdbcDataContext dataContext) {
         super(dataContext);
     }
-    
+
     @Override
     protected void closePreparedStatement(PreparedStatement preparedStatement) {
         FileHelper.safeClose(preparedStatement);
     }
 
     @Override
-    protected void executePreparedStatement(PreparedStatement st) throws SQLException {
-        st.executeUpdate();
+    protected int executePreparedStatement(PreparedStatement st) throws SQLException {
+        return st.executeUpdate();
+    }
+    
+    @Override
+    protected boolean isGeneratedKeysCollectionEnabled() {
+        return true;
     }
 }

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcUpdateBuilder.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcUpdateBuilder.java
@@ -62,7 +62,7 @@ final class JdbcUpdateBuilder extends AbstractRowUpdationBuilder {
         String sql = createSqlStatement();
         logger.debug("Update statement created: {}", sql);
         final boolean reuseStatement = !_inlineValues;
-        final PreparedStatement st = _updateCallback.getPreparedStatement(sql, reuseStatement);
+        final PreparedStatement st = _updateCallback.getPreparedStatement(sql, reuseStatement, false);
         try {
             if (reuseStatement) {
                 Column[] columns = getColumns();
@@ -90,7 +90,7 @@ final class JdbcUpdateBuilder extends AbstractRowUpdationBuilder {
                     }
                 }
             }
-            _updateCallback.executePreparedStatement(st, reuseStatement);
+            _updateCallback.executeUpdate(st, reuseStatement);
         } catch (SQLException e) {
             throw JdbcUtils.wrapException(e, "execute update statement: " + sql);
         } finally {

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/JdbcTestTemplates.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/JdbcTestTemplates.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.metamodel.BatchUpdateScript;
 import org.apache.metamodel.UpdateCallback;
 import org.apache.metamodel.UpdateScript;
+import org.apache.metamodel.UpdateSummary;
 import org.apache.metamodel.create.ColumnCreationBuilder;
 import org.apache.metamodel.create.CreateTable;
 import org.apache.metamodel.create.TableCreationBuilder;
@@ -73,7 +74,7 @@ public class JdbcTestTemplates {
 
         final Map<Object, Object> map = new HashMap<Object, Object>();
         try {
-            dc.executeUpdate(new UpdateScript() {
+            final UpdateSummary summary = dc.executeUpdate(new UpdateScript() {
                 @Override
                 public void run(UpdateCallback cb) {
                     ColumnCreationBuilder createTableBuilder = cb.createTable(schema, "test_table").withColumn("id")
@@ -86,6 +87,7 @@ public class JdbcTestTemplates {
                     cb.insertInto(table).value("id", 4.0).value("code", "C02").execute();
                 }
             });
+            assertEquals(4, summary.getInsertedRows().get().intValue());
 
             assertEquals(1, getCount(dc.query().from("test_table").selectCount().where("code").isNull().execute()));
             assertEquals(3, getCount(dc.query().from("test_table").selectCount().where("code").isNotNull().execute()));

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/JdbcTestTemplates.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/JdbcTestTemplates.java
@@ -335,12 +335,15 @@ public class JdbcTestTemplates {
         assertFalse(ds.next());
         ds.close();
 
-        dc.executeUpdate(new UpdateScript() {
+        final UpdateSummary updateSummary = dc.executeUpdate(new UpdateScript() {
             @Override
             public void run(UpdateCallback callback) {
                 callback.deleteFrom("test_table").where("id").in(Arrays.<String> asList("1", "2")).execute();
             }
         });
+        assertEquals(2, updateSummary.getDeletedRows().get().intValue());
+        assertEquals(0, updateSummary.getUpdatedRows().get().intValue());
+        assertEquals(0, updateSummary.getInsertedRows().get().intValue());
 
         ds = dc.query().from("test_table").selectCount().where("id").eq(2).or("id").eq(1).execute();
         assertTrue(ds.next());
@@ -433,7 +436,7 @@ public class JdbcTestTemplates {
             assertFalse(ds.next());
             ds.close();
 
-            dc.executeUpdate(new UpdateScript() {
+            final UpdateSummary updateSummary = dc.executeUpdate(new UpdateScript() {
                 @Override
                 public void run(UpdateCallback callback) {
                     // update record 1
@@ -450,6 +453,9 @@ public class JdbcTestTemplates {
                             .where("birthdate").isEquals(DateUtils.get(1982, Month.APRIL, 20)).execute();
                 }
             });
+            assertEquals(0, updateSummary.getInsertedRows().get().intValue());
+            assertEquals(0, updateSummary.getDeletedRows().get().intValue());
+            assertEquals(1, updateSummary.getUpdatedRows().get().intValue());
 
             ds = dc.query().from(schema.getTableByName(tableName)).select("id", "birthdate", "wakemeup").orderBy("id")
                     .execute();

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
@@ -23,6 +23,7 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import javax.swing.table.TableModel;
@@ -31,8 +32,10 @@ import org.apache.metamodel.BatchUpdateScript;
 import org.apache.metamodel.DataContext;
 import org.apache.metamodel.UpdateCallback;
 import org.apache.metamodel.UpdateScript;
+import org.apache.metamodel.UpdateSummary;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.data.DataSetTableModel;
+import org.apache.metamodel.drop.DropTable;
 import org.apache.metamodel.insert.RowInsertionBuilder;
 import org.apache.metamodel.jdbc.JdbcDataContext;
 import org.apache.metamodel.jdbc.JdbcTestTemplates;
@@ -429,6 +432,42 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
                 }
             });
         }
+    }
+
+    public void testGetGeneratedKeys() throws Exception {
+        if (!isConfigured()) {
+            return;
+        }
+
+        final JdbcDataContext dc = new JdbcDataContext(getConnection());
+        final Schema schema = dc.getDefaultSchema();
+        final String tableName = "my_table_with_generated_keys";
+        
+        if (schema.getTableByName(tableName) != null) {
+            dc.executeUpdate(new DropTable(schema, tableName));
+        }
+
+        final UpdateSummary updateSummary = dc.executeUpdate(new UpdateScript() {
+            @Override
+            public void run(UpdateCallback cb) {
+                Table table = cb.createTable(schema, tableName).withColumn("id").ofType(ColumnType.INTEGER)
+                        .ofNativeType("SERIAL").nullable(false).asPrimaryKey().withColumn("foo").ofType(
+                                ColumnType.STRING).execute();
+                assertEquals(tableName, table.getName());
+
+                cb.insertInto(table).value("foo", "hello").execute();
+                cb.insertInto(table).value("foo", "world").execute();
+            }
+        });
+
+        final Optional<Integer> insertedRows = updateSummary.getInsertedRows();
+        assertTrue(insertedRows.isPresent());
+        assertEquals(2, insertedRows.get().intValue());
+        
+        final Optional<Iterable<Object>> generatedKeys = updateSummary.getGeneratedKeys();
+        assertTrue(generatedKeys.isPresent());
+        assertEquals("[1, 2]", generatedKeys.get().toString());
+        
     }
     
     public void testBlob() throws Exception {


### PR DESCRIPTION
Some more progress on METAMODEL-6. This adds support for the JDBC module to return number of inserts, updates, deletes and any generated keys. I chose the JDBC module because it is arguably the most complex. I imagine the reusing bits and pieces from here would be beneficial when implementing support in some of the other modules.