### PR TITLE
Javadoc fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ services:
   - mongodb
   
 after_success:
-  - mvn test
+  - mvn test javadoc:javadoc
  
 notifications:
   email: false

--- a/core/src/main/java/org/apache/metamodel/DataContext.java
+++ b/core/src/main/java/org/apache/metamodel/DataContext.java
@@ -163,7 +163,7 @@ public interface DataContext {
      * {@link #parseQuery(String)} and then {@link #executeQuery(Query)} with
      * the parsed query.
      * 
-     * @param query
+     * @param queryString
      *            the SQL query to parse
      * @return the {@link DataSet} produced from executing the query
      * @throws MetaModelException

--- a/core/src/main/java/org/apache/metamodel/convert/TypeConverter.java
+++ b/core/src/main/java/org/apache/metamodel/convert/TypeConverter.java
@@ -22,7 +22,7 @@ package org.apache.metamodel.convert;
  * Defines an interface for converting values from and to their physical
  * materializations and their virtual representations.
  * 
- * @see ConvertedDataContext
+ * @see Converters
  * 
  * @param <P>
  *            the physical type of value

--- a/core/src/main/java/org/apache/metamodel/data/DefaultRow.java
+++ b/core/src/main/java/org/apache/metamodel/data/DefaultRow.java
@@ -194,7 +194,7 @@ public final class DefaultRow extends AbstractRow implements Row {
     /**
      * Method invoked by the Java serialization framework while deserializing
      * Row instances. Since previous versions of MetaModel did not use a
-     * DataSetHeader, but had a reference to a List<SelectItem>, this
+     * DataSetHeader, but had a reference to a List&lt;SelectItem&gt;, this
      * deserialization is particularly tricky. We check if the items variable is
      * there, and if it is, we convert it to a header instead.
      * 

--- a/core/src/main/java/org/apache/metamodel/query/OperatorType.java
+++ b/core/src/main/java/org/apache/metamodel/query/OperatorType.java
@@ -48,7 +48,7 @@ public interface OperatorType extends Serializable {
 
 /**
      * Determines if this operator requires a space delimitor. Operators that are written using letters usually require
-     * space delimitation whereas sign-based operators such as "=" and "<" can be applied even without any delimitaton.
+     * space delimitation whereas sign-based operators such as "=" and "&lt;" can be applied even without any delimitaton.
      * 
      * @return
      */

--- a/core/src/main/java/org/apache/metamodel/query/OperatorTypeImpl.java
+++ b/core/src/main/java/org/apache/metamodel/query/OperatorTypeImpl.java
@@ -65,8 +65,8 @@ public class OperatorTypeImpl implements OperatorType {
     }
 
 /**
-     * Converts from SQL string literals to an OperatorType. Valid SQL values are "=", "<>", "LIKE", ">", ">=", "<" and
-     * "<=".
+     * Converts from SQL string literals to an OperatorType. Valid SQL values are "=", "&lt;&gt;", "LIKE", "&gt;", "&gt;=", "&lt;" and
+     * "&lt;=".
      *
      * @param sqlType
      * @return a OperatorType object representing the specified SQL type

--- a/core/src/main/java/org/apache/metamodel/query/builder/SatisfiedQueryBuilder.java
+++ b/core/src/main/java/org/apache/metamodel/query/builder/SatisfiedQueryBuilder.java
@@ -65,7 +65,7 @@ public interface SatisfiedQueryBuilder<B extends SatisfiedQueryBuilder<?>> {
     /**
      * Sets the limit (aka. max rows) of the query that is being built.
      * 
-     * @param maxRows
+     * @param limit
      * @return
      */
     public SatisfiedQueryBuilder<B> limit(int limit);

--- a/core/src/main/java/org/apache/metamodel/schema/Schema.java
+++ b/core/src/main/java/org/apache/metamodel/schema/Schema.java
@@ -89,7 +89,7 @@ public interface Schema extends Comparable<Schema>, Serializable, NamedStructure
 	 * @return the column with the specified index
 	 * 
 	 * @throws IndexOutOfBoundsException
-	 *             if the index is out of bounds (index >= table count)
+	 *             if the index is out of bounds (index &gt;= table count)
 	 */
 	public Table getTable(int index) throws IndexOutOfBoundsException;
 

--- a/core/src/main/java/org/apache/metamodel/schema/Table.java
+++ b/core/src/main/java/org/apache/metamodel/schema/Table.java
@@ -69,7 +69,7 @@ public interface Table extends Comparable<Table>, Serializable, NamedStructure {
      *            the index of the column
      * @return the column with the specified index
      * @throws IndexOutOfBoundsException
-     *             if the index is out of bounds (index >= column count)
+     *             if the index is out of bounds (index &gt;= column count)
      */
     public Column getColumn(int index) throws IndexOutOfBoundsException;
 

--- a/core/src/main/java/org/apache/metamodel/util/FormatHelper.java
+++ b/core/src/main/java/org/apache/metamodel/util/FormatHelper.java
@@ -150,7 +150,7 @@ public final class FormatHelper {
     /**
      * Parses a SQL string representation of a time based value
      * 
-     * @param type
+     * @param columnType
      * @param value
      * @return
      */

--- a/core/src/main/java/org/apache/metamodel/util/SimpleTableDefParser.java
+++ b/core/src/main/java/org/apache/metamodel/util/SimpleTableDefParser.java
@@ -29,8 +29,6 @@ public class SimpleTableDefParser {
     /**
      * Parses an array of table definitions.
      * 
-     * @see #setTableDefinitions(String)
-     * 
      * @param tableDefinitionsText
      * @return
      */
@@ -60,8 +58,6 @@ public class SimpleTableDefParser {
 
     /**
      * Parses a single table definition
-     * 
-     * @see #setTableDefinitions(String)
      * 
      * @param tableDefinitionText
      * @return

--- a/core/src/test/java/org/apache/metamodel/query/parser/QueryParserTest.java
+++ b/core/src/test/java/org/apache/metamodel/query/parser/QueryParserTest.java
@@ -50,6 +50,13 @@ public class QueryParserTest extends TestCase {
         MutableColumn col = (MutableColumn) dc.getColumnByQualifiedLabel("tbl.baz");
         col.setType(ColumnType.INTEGER);
     };
+	
+    public void testQueryWithParenthesis() throws Exception {
+        Query q = MetaModelHelper.parseQuery(dc,
+                "select foo from sch.tbl where (foo= 1) and (foo=2)");
+        assertEquals("SELECT tbl.foo FROM sch.tbl WHERE tbl.foo = '1' AND tbl.foo = '2'",
+                q.toSql());
+    }
 
     public void testQueryWithParenthesisAnd() throws Exception {
         Query q = MetaModelHelper.parseQuery(dc, "select foo from sch.tbl where (foo= 1) and (foo=2)");

--- a/elasticsearch/native/src/main/java/org/apache/metamodel/elasticsearch/nativeclient/ElasticSearchDataContext.java
+++ b/elasticsearch/native/src/main/java/org/apache/metamodel/elasticsearch/nativeclient/ElasticSearchDataContext.java
@@ -125,7 +125,7 @@ public class ElasticSearchDataContext extends QueryPostprocessDataContext implem
     /**
      * Constructs a {@link ElasticSearchDataContext} and automatically detects
      * the schema structure/view on all indexes (see
-     * {@link this.detectSchema(Client, String)}).
+     * {@link #detectTable(ClusterState, String, String)}).
      *
      * @param client
      *            the ElasticSearch client
@@ -141,7 +141,7 @@ public class ElasticSearchDataContext extends QueryPostprocessDataContext implem
      * {@link Client} instance and detects the elasticsearch types structure
      * based on the metadata provided by the ElasticSearch java client.
      *
-     * @see #detectTable(ClusterState, String, String)
+     * @see {@link #detectTable(ClusterState, String, String)}
      * @return a mutable schema instance, useful for further fine tuning by the
      *         user.
      */

--- a/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/ElasticSearchRestDataContext.java
+++ b/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/ElasticSearchRestDataContext.java
@@ -129,7 +129,7 @@ public class ElasticSearchRestDataContext extends QueryPostprocessDataContext im
     /**
      * Constructs a {@link ElasticSearchRestDataContext} and automatically detects
      * the schema structure/view on all indexes (see
-     * {@link this.detectSchema(JestClient, String)}).
+     * {@link #detectTable(JsonObject, String)}).
      *
      * @param client
      *            the ElasticSearch client
@@ -145,7 +145,7 @@ public class ElasticSearchRestDataContext extends QueryPostprocessDataContext im
      * {@link JestClient} instance and detects the elasticsearch types structure
      * based on the metadata provided by the ElasticSearch java client.
      *
-     * @see #detectTable(JsonObject, String)
+     * @see {@link #detectTable(JsonObject, String)}
      * @return a mutable schema instance, useful for further fine tuning by the
      *         user.
      */

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/AbstractQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/AbstractQueryRewriter.java
@@ -93,7 +93,6 @@ public abstract class AbstractQueryRewriter implements IQueryRewriter {
      * related. Cloning the query before modifying is recommended in order to
      * not violate referential integrity of clients (the query is mutable).
      * 
-     * @param strategy
      * @param query
      * @return the modified query
      */

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/DB2QueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/DB2QueryRewriter.java
@@ -69,11 +69,11 @@ public class DB2QueryRewriter extends DefaultQueryRewriter implements IQueryRewr
         final Integer firstRow = query.getFirstRow();
         final Integer maxRows = query.getMaxRows();
 
-        if (maxRows == null && firstRow == null) {
+        if (maxRows == null && (firstRow == null || firstRow.intValue() == 1)) {
             return super.rewriteQuery(query);
         }
 
-        if (firstRow == null || firstRow.intValue() == 1) {
+        if ((firstRow == null || firstRow.intValue() == 1) && maxRows != null && maxRows > 0) {
             // We prefer to use the "FETCH FIRST [n] ROWS ONLY" approach, if
             // firstRow is not specified.
             return super.rewriteQuery(query) + " FETCH FIRST " + maxRows + " ROWS ONLY";

--- a/jdbc/src/test/java/org/apache/metamodel/dialects/DB2QueryRewriterTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/dialects/DB2QueryRewriterTest.java
@@ -60,6 +60,12 @@ public class DB2QueryRewriterTest extends TestCase {
         assertEquals("SELECT sch.foo.bar FROM sch.foo FETCH FIRST 200 ROWS ONLY", str);
     }
 
+    public void testRewriteFirstRowIsOneAndMaxRowsIsNull() throws Exception {
+        Query q = new Query().from(table).select(col).setFirstRow(1);
+        String str = new DB2QueryRewriter(null).rewriteQuery(q);
+        assertEquals("SELECT sch.foo.bar FROM sch.foo", str);
+    }
+
     public void testRewriteFirstRow() throws Exception {
         Query q = new Query().from(table).select(col).setFirstRow(401);
         String str = new DB2QueryRewriter(null).rewriteQuery(q);

--- a/mongodb/common/src/main/java/org/apache/metamodel/mongodb/common/MongoDBUtils.java
+++ b/mongodb/common/src/main/java/org/apache/metamodel/mongodb/common/MongoDBUtils.java
@@ -57,7 +57,7 @@ public class MongoDBUtils {
     /**
      * Converts a map into MetaModel. This map stores data of a MongoDB document.
      * 
-     * @param dbObject
+     * @param map
      *            a map object storing data of a MongoDB document.
      * @param header
      *            a header describing the columns of the data stored.

--- a/mongodb/common/src/main/java/org/apache/metamodel/mongodb/common/MongoDbTableDef.java
+++ b/mongodb/common/src/main/java/org/apache/metamodel/mongodb/common/MongoDbTableDef.java
@@ -24,8 +24,8 @@ import org.apache.metamodel.schema.ColumnType;
 import org.apache.metamodel.util.SimpleTableDef;
 
 /**
- * Defines a table layout for {@link MongoDbDataContext} tables. This class can
- * be used as an instruction set for the {@link MongoDbDataContext} to specify
+ * Defines a table layout for MongoDB tables. This class can
+ * be used as an instruction set for the MongoDB DataContext implementations to specify
  * which collections, which columns (and their types) should be included in the
  * schema structure of a Mongo DB database.
  * 

--- a/mongodb/mongo3/src/main/java/org/apache/metamodel/mongodb/mongo3/MongoDbDataContext.java
+++ b/mongodb/mongo3/src/main/java/org/apache/metamodel/mongodb/mongo3/MongoDbDataContext.java
@@ -72,7 +72,7 @@ import com.mongodb.client.MongoIterable;
  * Since MongoDB has no schema, a virtual schema will be used in this
  * DataContext. This implementation supports either automatic discovery of a
  * schema or manual specification of a schema, through the
- * {@link MongoDbTableDef} class.
+ * {@link SimpleTableDef} class.
  */
 public class MongoDbDataContext extends QueryPostprocessDataContext implements UpdateableDataContext {
 
@@ -85,15 +85,15 @@ public class MongoDbDataContext extends QueryPostprocessDataContext implements U
 
     /**
      * Constructs a {@link MongoDbDataContext}. This constructor accepts a
-     * custom array of {@link MongoDbTableDef}s which allows the user to define
+     * custom array of {@link SimpleTableDef}s which allows the user to define
      * his own view on the collections in the database.
      *
      * @param mongoDb
      *            the mongo db connection
      * @param tableDefs
-     *            an array of {@link MongoDbTableDef}s, which define the table
+     *            an array of {@link SimpleTableDef}s, which define the table
      *            and column model of the mongo db collections. (consider using
-     *            {@link #detectSchema(DB)} or {@link #detectTable(DB, String)}
+     *            {@link #detectSchema(MongoDatabase)} or {@link #detectTable(MongoDatabase, String)}
      *            ).
      */
     public MongoDbDataContext(MongoDatabase mongoDb, SimpleTableDef... tableDefs) {
@@ -104,7 +104,7 @@ public class MongoDbDataContext extends QueryPostprocessDataContext implements U
 
     /**
      * Constructs a {@link MongoDbDataContext} and automatically detects the
-     * schema structure/view on all collections (see {@link #detectSchema(DB)}).
+     * schema structure/view on all collections (see {@link #detectSchema(MongoDatabase)}).
      *
      * @param mongoDb
      *            the mongo db connection
@@ -122,7 +122,7 @@ public class MongoDbDataContext extends QueryPostprocessDataContext implements U
      *            the mongo db to inspect
      * @return a mutable schema instance, useful for further fine tuning by the
      *         user.
-     * @see #detectTable(DB, String)
+     * @see #detectTable(MongoDatabase, String)
      */
     public static SimpleTableDef[] detectSchema(MongoDatabase mongoDb) {
         MongoIterable<String> collectionNames = mongoDb.listCollectionNames();

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ under the License.
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<sshwagon.version>2.6</sshwagon.version>
-		<javadoc.version>2.9.1</javadoc.version>
+		<javadoc.version>2.10.3</javadoc.version>
 		<slf4j.version>1.7.7</slf4j.version>
 		<junit.version>4.11</junit.version>
 		<guava.version>16.0.1</guava.version>
@@ -246,9 +246,6 @@ under the License.
 							<goal>aggregate</goal>
 						</goals>
 						<phase>site</phase>
-						<configuration>
-							<excludePackageNames>org.apache.metamodel.jdbc.dialects:org.apache.metamodel.detect</excludePackageNames>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/sugarcrm/pom.xml
+++ b/sugarcrm/pom.xml
@@ -95,6 +95,13 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+					<excludePackageNames>com.sugarcrm.ws.soap</excludePackageNames>
+				</configuration>
+			</plugin>
 		</plugins>
 
 		<pluginManagement>

--- a/xml/src/main/java/org/apache/metamodel/xml/XmlDomDataContext.java
+++ b/xml/src/main/java/org/apache/metamodel/xml/XmlDomDataContext.java
@@ -122,8 +122,8 @@ public class XmlDomDataContext extends QueryPostprocessDataContext {
     /**
      * Creates an XML DataContext strategy based on a file.
      * 
-     * @param file
-     *            the file to parse
+     * @param resource
+     *            the resource to parse
      * @param autoFlattenTables
      *            a parameter indicating whether or not tags with only text
      *            content or a single attribute should be flattened with it's


### PR DESCRIPTION
This PR fixes a bunch of errors in the javadoc comments of MetaModel. While running `mvn javadoc:javadoc` on a Java 8 runtime, then these bring build failures.