### PR TITLE
Moved javadoc exclude to parent pom to fix 'mvn javadoc:aggregate'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,9 @@ under the License.
 						<phase>site</phase>
 					</execution>
 				</executions>
+				<configuration>
+					<excludePackageNames>com.sugarcrm.ws.soap</excludePackageNames>
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>net.ju-n.maven.plugins</groupId>

--- a/sugarcrm/pom.xml
+++ b/sugarcrm/pom.xml
@@ -95,13 +95,6 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<configuration>
-					<excludePackageNames>com.sugarcrm.ws.soap</excludePackageNames>
-				</configuration>
-			</plugin>
 		</plugins>
 
 		<pluginManagement>


### PR DESCRIPTION
With the 4.5.2 release I wanted to update the published javadocs but found that running ´mvn javadoc:aggregate` runs into problems because of the sugarcrm WSDL stubs that are generated and not 100% javadoc "correct". Normally we have an exclude rule for that in the sugarcrm module but since the ´aggregate´ goal runs on the parent module, it does not apply. So with this PR I want to change it back so that the exclusion is done in the parent POM.

I removed it from the sugarcrm module to avoid redundancy. Hope that is correct, but feedback welcome.