### PR TITLE
METAMODEL-235: Fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .project
-.settings/
-.classpath/
+.settings
+.classpath
 .metadata/
 target/
 /.idea/

--- a/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/JestElasticSearchUtils.java
+++ b/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/JestElasticSearchUtils.java
@@ -55,12 +55,15 @@ final class JestElasticSearchUtils {
     }
 
     private static Object getDataFromColumnType(JsonElement field, ColumnType type) {
+        if (field == null || field.isJsonNull()) {
+            return null;
+        }
         if (type.isNumber()) {
             // Pretty terrible workaround to avoid LazilyParsedNumber
             // (which is happily output, but not recognized by Jest/GSON).
             return NumberComparator.toNumber(field.getAsString());
         } else if (type.isTimeBased()) {
-            Date valueToDate = ElasticSearchDateConverter.tryToConvert(field.getAsString());
+            final Date valueToDate = ElasticSearchDateConverter.tryToConvert(field.getAsString());
             if (valueToDate == null) {
                 return field.getAsString();
             } else {


### PR DESCRIPTION
This fixes METAMODEL-235 which was essentially about supporting null values and missing values in the REST API of ElasticSearch.

I also expanded the unittests a bit in general around the relevant utility class. It seemed that it didn't have a lot of corner cases covered so now I added a couple at least.