### PR TITLE
Feature/read fixedwidth metadata files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
  * [METAMODEL-225] - Fixed support for nested objects and arrays in ElasticSearch using REST client.
  * [METAMODEL-244] - Added ColumnNamingStrategies concept which allows custom column naming and column name overriding.
  * [METAMODEL-242] - Fixed issue when de-serializing old enum-instances of FunctionType.
+ * [METAMODEL-247] - Added FixedWidthConfigurationReader for reading fixed width file metadata from external files.
 
 ### Apache MetaModel 4.5.2
 

--- a/core/src/main/java/org/apache/metamodel/schema/naming/ColumnNamingStrategies.java
+++ b/core/src/main/java/org/apache/metamodel/schema/naming/ColumnNamingStrategies.java
@@ -18,6 +18,8 @@
  */
 package org.apache.metamodel.schema.naming;
 
+import java.util.List;
+
 /**
  * Constructors and common utilities for {@link ColumnNamingStrategy} objects.
  */
@@ -31,5 +33,13 @@ public class ColumnNamingStrategies {
 
     public static ColumnNamingStrategy defaultStrategy() {
         return DEFAULT_STRATEGY;
+    }
+
+    public static ColumnNamingStrategy customNames(List<String> columnNames) {
+        return new CustomColumnNamingStrategy(columnNames);
+    }
+
+    public static ColumnNamingStrategy customNames(String ... columnNames) {
+        return new CustomColumnNamingStrategy(columnNames);
     }
 }

--- a/core/src/main/java/org/apache/metamodel/schema/naming/CustomColumnNamingStrategy.java
+++ b/core/src/main/java/org/apache/metamodel/schema/naming/CustomColumnNamingStrategy.java
@@ -37,7 +37,7 @@ public class CustomColumnNamingStrategy implements ColumnNamingStrategy {
     }
 
     public CustomColumnNamingStrategy(String... columnNames) {
-        this.columnNames = Arrays.asList(columnNames);
+        this(Arrays.asList(columnNames));
     }
 
     @Override

--- a/core/src/main/java/org/apache/metamodel/schema/naming/CustomColumnNamingStrategy.java
+++ b/core/src/main/java/org/apache/metamodel/schema/naming/CustomColumnNamingStrategy.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.schema.naming;
+
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A {@link ColumnNamingStrategy} that allows the user to supply his own list of
+ * custom column names.
+ */
+public class CustomColumnNamingStrategy implements ColumnNamingStrategy {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<String> columnNames;
+
+    public CustomColumnNamingStrategy(List<String> columnNames) {
+        this.columnNames = columnNames;
+    }
+
+    @Override
+    public ColumnNamingSession startColumnNamingSession() {
+        final Iterator<String> iterator = columnNames.iterator();
+        return new ColumnNamingSession() {
+
+            @Override
+            public String getNextColumnName(ColumnNamingContext ctx) {
+                if (iterator.hasNext()) {
+                    return iterator.next();
+                }
+                return null;
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+    }
+
+}

--- a/fixedwidth/pom.xml
+++ b/fixedwidth/pom.xml
@@ -33,6 +33,12 @@ under the License.
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.metamodel</groupId>
+			<artifactId>MetaModel-csv</artifactId>
+			<version>${project.version}</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-nop</artifactId>
 			<scope>test</scope>

--- a/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthColumnSpec.java
+++ b/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthColumnSpec.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.fixedwidth;
+
+import org.apache.metamodel.util.HasName;
+
+/**
+ * Represents the specification of a single column for a
+ * {@link FixedWidthDataContext}.
+ */
+public final class FixedWidthColumnSpec implements HasName {
+
+    private final String name;
+    private final int width;
+
+    public FixedWidthColumnSpec(String name, int width) {
+        this.name = name;
+        this.width = width;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+}

--- a/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthConfiguration.java
+++ b/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthConfiguration.java
@@ -24,9 +24,12 @@ import java.util.List;
 
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.schema.naming.ColumnNamingStrategy;
+import org.apache.metamodel.schema.naming.CustomColumnNamingStrategy;
 import org.apache.metamodel.schema.naming.DefaultColumnNamingStrategy;
 import org.apache.metamodel.util.BaseObject;
+import org.apache.metamodel.util.CollectionUtils;
 import org.apache.metamodel.util.FileHelper;
+import org.apache.metamodel.util.HasNameMapper;
 
 /**
  * Configuration of metadata about a fixed width values datacontext.
@@ -84,8 +87,26 @@ public final class FixedWidthConfiguration extends BaseObject implements
         this.columnNamingStrategy = columnNamingStrategy;
         this.valueWidths = valueWidths;
     }
+    
+    public FixedWidthConfiguration(String encoding, List<FixedWidthColumnSpec> columnSpecs) {
+        this(encoding, columnSpecs, false);
+    }
 
-	/**
+    public FixedWidthConfiguration(String encoding, List<FixedWidthColumnSpec> columnSpecs,
+            boolean failOnInconsistentLineWidth) {
+        this.encoding = encoding;
+        this.fixedValueWidth = -1;
+        this.columnNameLineNumber = NO_COLUMN_NAME_LINE;
+        this.columnNamingStrategy = new CustomColumnNamingStrategy(CollectionUtils.map(columnSpecs,
+                new HasNameMapper()));
+        this.valueWidths = new int[columnSpecs.size()];
+        for (int i = 0; i < valueWidths.length; i++) {
+            valueWidths[i] = columnSpecs.get(i).getWidth();
+        }
+        this.failOnInconsistentLineWidth = failOnInconsistentLineWidth;
+    }
+
+    /**
 	 * The line number (1 based) from which to get the names of the columns.
 	 * 
 	 * @return an int representing the line number of the column headers/names.

--- a/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthConfiguration.java
+++ b/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthConfiguration.java
@@ -25,7 +25,6 @@ import java.util.List;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.schema.naming.ColumnNamingStrategies;
 import org.apache.metamodel.schema.naming.ColumnNamingStrategy;
-import org.apache.metamodel.schema.naming.CustomColumnNamingStrategy;
 import org.apache.metamodel.util.BaseObject;
 import org.apache.metamodel.util.CollectionUtils;
 import org.apache.metamodel.util.FileHelper;

--- a/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthConfiguration.java
+++ b/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthConfiguration.java
@@ -97,7 +97,7 @@ public final class FixedWidthConfiguration extends BaseObject implements
         this.encoding = encoding;
         this.fixedValueWidth = -1;
         this.columnNameLineNumber = NO_COLUMN_NAME_LINE;
-        this.columnNamingStrategy = new CustomColumnNamingStrategy(CollectionUtils.map(columnSpecs,
+        this.columnNamingStrategy = ColumnNamingStrategies.customNames(CollectionUtils.map(columnSpecs,
                 new HasNameMapper()));
         this.valueWidths = new int[columnSpecs.size()];
         for (int i = 0; i < valueWidths.length; i++) {

--- a/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthConfigurationReader.java
+++ b/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthConfigurationReader.java
@@ -1,0 +1,180 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.fixedwidth;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.metamodel.csv.CsvConfiguration;
+import org.apache.metamodel.csv.CsvDataContext;
+import org.apache.metamodel.data.DataSet;
+import org.apache.metamodel.schema.Table;
+import org.apache.metamodel.util.Action;
+import org.apache.metamodel.util.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Object capable of reading fixed width metadata from external sources and
+ * thereby producing an appropriate {@link FixedWidthConfiguration} to use with
+ * a {@link FixedWidthDataContext}.
+ */
+public class FixedWidthConfigurationReader {
+
+    private static final Logger logger = LoggerFactory.getLogger(FixedWidthConfigurationReader.class);
+
+    // example: @1 COL1 $char1.
+    private final Pattern PATTERN_SAS_INPUT_LINE = Pattern.compile("\\@(\\d+) (.+) .*?(\\d+)\\.");
+
+    // example: COL1 "Record type"
+    private final Pattern PATTERN_SAS_LABEL_LINE = Pattern.compile("(.+) \\\"(.+)\\\"");
+
+    /**
+     * Reads a {@link FixedWidthConfiguration} based on a SAS 'format file',
+     * <a href=
+     * "http://support.sas.com/documentation/cdl/en/etlug/67323/HTML/default/viewer.htm#p0h03yig7fp1qan1arghp3lwjqi6.htm">
+     * described here</a>.
+     * 
+     * @param encoding
+     * @param resource
+     *            the format file resource
+     * @param failOnInconsistentLineWidth
+     * @return a {@link FixedWidthConfiguration} object to use
+     */
+    public FixedWidthConfiguration readFromSasFormatFile(String encoding, Resource resource,
+            boolean failOnInconsistentLineWidth) {
+        final List<FixedWidthColumnSpec> columnSpecs = new ArrayList<>();
+
+        final CsvDataContext dataContext = new CsvDataContext(resource, new CsvConfiguration());
+        final Table table = dataContext.getDefaultSchema().getTable(0);
+        try (final DataSet dataSet = dataContext.query().from(table).select("Name", "BeginPosition", "EndPosition")
+                .execute()) {
+            while (dataSet.next()) {
+                final String name = (String) dataSet.getRow().getValue(0);
+                final int beginPosition = Integer.parseInt((String) dataSet.getRow().getValue(1));
+                final int endPosition = Integer.parseInt((String) dataSet.getRow().getValue(2));
+                final int width = 1 + endPosition - beginPosition;
+                columnSpecs.add(new FixedWidthColumnSpec(name, width));
+            }
+        }
+
+        return new FixedWidthConfiguration(encoding, columnSpecs, failOnInconsistentLineWidth);
+    }
+
+    /**
+     * Reads a {@link FixedWidthConfiguration} based on a SAS INPUT declaration.
+     * The reader method also optionally will look for a LABEL defintion for
+     * column naming.
+     * 
+     * @param encoding
+     * @param resource
+     *            the format file resource
+     * @param failOnInconsistentLineWidth
+     * @return a {@link FixedWidthConfiguration} object to use
+     */
+    public FixedWidthConfiguration readFromSasInputDefinition(String encoding, Resource resource,
+            boolean failOnInconsistentLineWidth) {
+
+        final Map<String, Integer> inputWidthDeclarations = new LinkedHashMap<>();
+        final Map<String, String> labelDeclarations = new HashMap<>();
+
+        resource.read(new Action<InputStream>() {
+
+            private boolean inInputSection = false;
+            private boolean inLabelSection = false;
+
+            @Override
+            public void run(InputStream in) throws Exception {
+                try (final BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
+                    for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+                        processLine(line);
+                    }
+                }
+            }
+
+            private void processLine(String line) {
+                line = line.trim();
+                if (line.isEmpty()) {
+                    return;
+                }
+                if (";".equals(line)) {
+                    inInputSection = false;
+                    inLabelSection = false;
+                    return;
+                } else if ("INPUT".equals(line)) {
+                    inInputSection = true;
+                    return;
+                } else if ("LABEL".equals(line)) {
+                    inLabelSection = true;
+                    return;
+                }
+
+                if (inInputSection) {
+                    final Matcher matcher = PATTERN_SAS_INPUT_LINE.matcher(line);
+                    if (matcher.matches()) {
+                        final String positionSpec = matcher.group(1);
+                        final String nameSpec = matcher.group(2);
+                        final int width = Integer.parseInt(matcher.group(3));
+                        logger.debug("Parsed INPUT line \"{}\": position={}, name={}, width={}", line, positionSpec,
+                                nameSpec, width);
+                        inputWidthDeclarations.put(nameSpec, width);
+                    } else {
+                        logger.debug("Failed to parse/recognize INPUT line \"{}\"", line);
+                    }
+                } else if (inLabelSection) {
+                    final Matcher matcher = PATTERN_SAS_LABEL_LINE.matcher(line);
+                    if (matcher.matches()) {
+                        final String nameSpec = matcher.group(1);
+                        final String labelSpec = matcher.group(2);
+                        logger.debug("Parsed LABEL line \"{}\": name={}, label={}", line, nameSpec, labelSpec);
+                        labelDeclarations.put(nameSpec, labelSpec);
+                    } else {
+                        logger.debug("Failed to parse/recognize LABEL line \"{}\"", line);
+                    }
+                }
+
+                if (line.endsWith(";")) {
+                    inInputSection = false;
+                    inLabelSection = false;
+                }
+            }
+        });
+
+        final List<FixedWidthColumnSpec> columnSpecs = new ArrayList<>();
+        for (Entry<String, Integer> entry : inputWidthDeclarations.entrySet()) {
+            final String columnKey = entry.getKey();
+            final Integer columnWidth = entry.getValue();
+            final String columnLabel = labelDeclarations.get(columnKey);
+            final String columnName = columnLabel == null ? columnKey : columnLabel;
+            columnSpecs.add(new FixedWidthColumnSpec(columnName, columnWidth));
+        }
+
+        return new FixedWidthConfiguration(encoding, columnSpecs, failOnInconsistentLineWidth);
+    }
+
+}

--- a/fixedwidth/src/test/java/org/apache/metamodel/fixedwidth/FixedWidthConfigurationReaderTest.java
+++ b/fixedwidth/src/test/java/org/apache/metamodel/fixedwidth/FixedWidthConfigurationReaderTest.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.fixedwidth;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+
+import org.apache.metamodel.DataContext;
+import org.apache.metamodel.data.DataSet;
+import org.apache.metamodel.schema.Table;
+import org.apache.metamodel.util.FileResource;
+import org.apache.metamodel.util.Resource;
+import org.junit.Test;
+
+public class FixedWidthConfigurationReaderTest {
+
+    private final FileResource dataResource = new FileResource("src/test/resources/metadata_spec1/data.txt");
+
+    @Test
+    public void testReadConfigurationFromSasFormatFile() throws Exception {
+        final FixedWidthConfigurationReader reader = new FixedWidthConfigurationReader();
+        final Resource resource = new FileResource("src/test/resources/metadata_spec1/sas-formatfile-metadata.txt");
+        assertTrue(resource.isExists());
+
+        final FixedWidthConfiguration configuration = reader.readFromSasFormatFile("UTF8", resource, false);
+        assertEquals("[1, 20, 2]", Arrays.toString(configuration.getValueWidths()));
+
+        final FixedWidthDataContext dataContext = new FixedWidthDataContext(dataResource, configuration);
+
+        performAssertionsOnSpec1(dataContext);
+    }
+    
+    @Test
+    public void testReadConfigurationFromSasInputMetadata() throws Exception {
+        final FixedWidthConfigurationReader reader = new FixedWidthConfigurationReader();
+        final Resource resource = new FileResource("src/test/resources/metadata_spec1/sas-input-metadata.txt");
+        assertTrue(resource.isExists());
+
+        final FixedWidthConfiguration configuration = reader.readFromSasInputDefinition("UTF8", resource, false);
+        assertEquals("[1, 20, 2]", Arrays.toString(configuration.getValueWidths()));
+
+        final FixedWidthDataContext dataContext = new FixedWidthDataContext(dataResource, configuration);
+
+        performAssertionsOnSpec1(dataContext);
+    }
+
+    /**
+     * Shared assertions section once the 'metadata_spec1' {@link DataContext}
+     * has been loaded.
+     * 
+     * @param dataContext
+     */
+    private void performAssertionsOnSpec1(FixedWidthDataContext dataContext) {
+        final Table table = dataContext.getDefaultSchema().getTable(0);
+        final String[] columnNames = table.getColumnNames();
+        assertEquals("[Record type, Description, Initials]", Arrays.toString(columnNames));
+
+        try (final DataSet dataSet = dataContext.query().from(table).selectAll().execute()) {
+            assertTrue(dataSet.next());
+            assertEquals("Row[values=[P, Kasper Sorensen, KS]]", dataSet.getRow().toString());
+            assertTrue(dataSet.next());
+            assertEquals("Row[values=[C, Human Inference, HI]]", dataSet.getRow().toString());
+            assertTrue(dataSet.next());
+            assertEquals("Row[values=[P, Ankit Kumar, AK]]", dataSet.getRow().toString());
+            assertTrue(dataSet.next());
+            assertEquals("Row[values=[C, Stratio, S]]", dataSet.getRow().toString());
+            assertTrue(dataSet.next());
+            assertEquals("Row[values=[U, Unknown, ]]", dataSet.getRow().toString());
+            assertFalse(dataSet.next());
+        }
+    }
+}

--- a/fixedwidth/src/test/resources/metadata_spec1/data.txt
+++ b/fixedwidth/src/test/resources/metadata_spec1/data.txt
@@ -1,0 +1,5 @@
+PKasper Sorensen     KS
+CHuman Inference     HI
+PAnkit Kumar         AK
+CStratio             S 
+UUnknown               

--- a/fixedwidth/src/test/resources/metadata_spec1/sas-formatfile-metadata.txt
+++ b/fixedwidth/src/test/resources/metadata_spec1/sas-formatfile-metadata.txt
@@ -1,0 +1,4 @@
+Name,SASColumnType,BeginPosition,EndPosition,ReadFlag,Desc,SASFormat,SASInformat
+Record type,C,1,1,y,Record Type,$char.,$char.
+Description,C,2,21,y,Description of record,$char.,$char.
+Initials,C,22,23,y,Initials of record,,

--- a/fixedwidth/src/test/resources/metadata_spec1/sas-input-metadata.txt
+++ b/fixedwidth/src/test/resources/metadata_spec1/sas-input-metadata.txt
@@ -1,0 +1,19 @@
+INPUT
+
+   @1 COL1 $char1.
+
+   @2 COL2 $char20.
+
+   @22 COL3 $char2.
+   
+;
+
+LABEL
+
+   COL1 "Record type"
+
+   COL2 "Description"
+
+   COL3 "Initials"
+
+;


### PR DESCRIPTION
Assuming that #96 (METAMODEL-244) is going forward, here's a patch that would add another logical piece on top: A utility reader class that allows reading Fixed Width file configuration from external metadata files. I encountered two of these formats myself so felt the need for a utility and that might just as well reside in MetaModel if anyone can reuse it.