### PR TITLE
ElasticSearch bulk support and mapping creation using Map

### DIFF
--- a/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
+++ b/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
@@ -86,7 +86,7 @@ public class ElasticSearchUtils {
         return getFilteredQuery("exists", fieldName);
     }
 
-    public static Object getMappingSource(final MutableTable table) {
+    public static Map<String, ?> getMappingSource(final MutableTable table) {
         if (table.getColumnByName(FIELD_ID) == null) {
             final MutableColumn idColumn = new MutableColumn(FIELD_ID, ColumnType.STRING).setTable(table).setPrimaryKey(
                     true);
@@ -96,8 +96,6 @@ public class ElasticSearchUtils {
         final Map<String, Map<String, String>> propertiesMap = new LinkedHashMap<>();
         
         for (Column column : table.getColumns()) {
-            // each column is defined as a property pair of the form: ("field1",
-            // "type=string,store=true")
             final String columnName = column.getName();
             if (FIELD_ID.equals(columnName)) {
                 // do nothing - the ID is a client-side construct
@@ -108,7 +106,6 @@ public class ElasticSearchUtils {
             final Map<String, String> propertyMap = new HashMap<>();
             final String type = getType(column);
             propertyMap.put("type", type);
-//            propertyMap.put("store", "true");
             
             propertiesMap.put(fieldName, propertyMap);
         }

--- a/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
+++ b/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
@@ -21,7 +21,10 @@ package org.apache.metamodel.elasticsearch.common;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.metamodel.query.FilterItem;
 import org.apache.metamodel.query.LogicalOperator;
@@ -40,29 +43,34 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ElasticSearchUtils {
-    public static final String FIELD_ID = "_id";
+
     private static final Logger logger = LoggerFactory.getLogger(ElasticSearchUtils.class);
+
+    public static final String FIELD_ID = "_id";
+    public static final String SYSTEM_PROPERTY_STRIP_INVALID_FIELD_CHARS = "metamodel.elasticsearch.strip_invalid_field_chars";
 
     /**
      * Gets a "filter" query which is both 1.x and 2.x compatible.
      */
     private static QueryBuilder getFilteredQuery(String prefix, String fieldName) {
-        // 1.x: itemQueryBuilder = QueryBuilders.filteredQuery(null, FilterBuilders.missingFilter(fieldName));
-        // 2.x: itemQueryBuilder = QueryBuilders.boolQuery().must(QueryBuilders.missingQuery(fieldName));
+        // 1.x: itemQueryBuilder = QueryBuilders.filteredQuery(null,
+        // FilterBuilders.missingFilter(fieldName));
+        // 2.x: itemQueryBuilder =
+        // QueryBuilders.boolQuery().must(QueryBuilders.missingQuery(fieldName));
         try {
             try {
                 Method method = QueryBuilders.class.getDeclaredMethod(prefix + "Query", String.class);
                 method.setAccessible(true);
                 return QueryBuilders.boolQuery().must((QueryBuilder) method.invoke(null, fieldName));
             } catch (NoSuchMethodException e) {
-                Class<?> clazz = ElasticSearchUtils.class.getClassLoader()
-                        .loadClass("org.elasticsearch.index.query.FilterBuilders");
+                Class<?> clazz = ElasticSearchUtils.class.getClassLoader().loadClass(
+                        "org.elasticsearch.index.query.FilterBuilders");
                 Method filterBuilderMethod = clazz.getDeclaredMethod(prefix + "Filter", String.class);
                 filterBuilderMethod.setAccessible(true);
-                Method queryBuildersFilteredQueryMethod =
-                        QueryBuilders.class.getDeclaredMethod("filteredQuery", QueryBuilder.class, FilterBuilder.class);
-                return (QueryBuilder) queryBuildersFilteredQueryMethod.invoke(null, null,
-                        filterBuilderMethod.invoke(null, fieldName));
+                Method queryBuildersFilteredQueryMethod = QueryBuilders.class.getDeclaredMethod("filteredQuery",
+                        QueryBuilder.class, FilterBuilder.class);
+                return (QueryBuilder) queryBuildersFilteredQueryMethod.invoke(null, null, filterBuilderMethod.invoke(
+                        null, fieldName));
             }
         } catch (Exception e) {
             logger.error("Failed to resolve/invoke filtering method", e);
@@ -78,15 +86,15 @@ public class ElasticSearchUtils {
         return getFilteredQuery("exists", fieldName);
     }
 
-    public static List<Object> getSourceProperties(final MutableTable table) {
+    public static Object getMappingSource(final MutableTable table) {
         if (table.getColumnByName(FIELD_ID) == null) {
-            final MutableColumn idColumn = new MutableColumn(FIELD_ID, ColumnType.STRING)
-                    .setTable(table).setPrimaryKey(true);
+            final MutableColumn idColumn = new MutableColumn(FIELD_ID, ColumnType.STRING).setTable(table).setPrimaryKey(
+                    true);
             table.addColumn(0, idColumn);
         }
 
-        final List<Object> sourceProperties = new ArrayList<>();
-
+        final Map<String, Map<String, String>> propertiesMap = new LinkedHashMap<>();
+        
         for (Column column : table.getColumns()) {
             // each column is defined as a property pair of the form: ("field1",
             // "type=string,store=true")
@@ -95,17 +103,49 @@ public class ElasticSearchUtils {
                 // do nothing - the ID is a client-side construct
                 continue;
             }
-            sourceProperties.add(columnName);
-
-            String type = getType(column);
-            if (type == null) {
-                sourceProperties.add("store=true");
-            } else {
-                sourceProperties.add("type=" + type + ",store=true");
-            }
+            
+            final String fieldName = getValidatedFieldName(columnName);
+            final Map<String, String> propertyMap = new HashMap<>();
+            final String type = getType(column);
+            propertyMap.put("type", type);
+//            propertyMap.put("store", "true");
+            
+            propertiesMap.put(fieldName, propertyMap);
         }
 
-        return sourceProperties;
+        HashMap<String, Map<String, Map<String, String>>> docTypeMap = new HashMap<>();
+        docTypeMap.put("properties", propertiesMap);
+        
+        final Map<String, Map<String, Map<String, Map<String, String>>>> mapping = new HashMap<>();
+        mapping.put(table.getName(), docTypeMap);
+        return mapping;
+    }
+
+    /**
+     * Field name special characters are:
+     * 
+     * . (used for navigation between name components)
+     * 
+     * # (for delimiting name components in _uid, should work, but is
+     * discouraged)
+     * 
+     * * (for matching names)
+     * 
+     * @param fieldName
+     * @return
+     */
+    public static String getValidatedFieldName(String fieldName) {
+        if (fieldName == null || fieldName.isEmpty()) {
+            throw new IllegalArgumentException("Field name cannot be null or empty");
+        }
+        if (fieldName.contains(".") || fieldName.contains("#") || fieldName.contains("*")) {
+            if ("true".equalsIgnoreCase(System.getProperty(SYSTEM_PROPERTY_STRIP_INVALID_FIELD_CHARS, "true"))) {
+                fieldName = fieldName.replace('.', '_').replace('#', '_').replace('*', '_');
+            } else {
+                throw new IllegalArgumentException("Field name '" + fieldName + "' contains illegal character (.#*)");
+            }
+        }
+        return fieldName;
     }
 
     /**
@@ -154,8 +194,8 @@ public class ElasticSearchUtils {
             return "object";
         }
 
-        throw new UnsupportedOperationException("Unsupported column type '" + type.getName() + "' of column '"
-                + column.getName() + "' - cannot translate to an ElasticSearch type.");
+        throw new UnsupportedOperationException("Unsupported column type '" + type.getName() + "' of column '" + column
+                .getName() + "' - cannot translate to an ElasticSearch type.");
     }
 
     /**
@@ -204,8 +244,8 @@ public class ElasticSearchUtils {
                     if (operand == null) {
                         itemQueryBuilder = getExistsQuery(fieldName);
                     } else {
-                        itemQueryBuilder = QueryBuilders.boolQuery().mustNot(
-                                QueryBuilders.termQuery(fieldName, operand));
+                        itemQueryBuilder = QueryBuilders.boolQuery().mustNot(QueryBuilders.termQuery(fieldName,
+                                operand));
                     }
                 } else if (OperatorType.IN.equals(operator)) {
                     final List<?> operands = CollectionUtils.toList(operand);

--- a/elasticsearch/native/src/main/java/org/apache/metamodel/elasticsearch/nativeclient/ElasticSearchCreateTableBuilder.java
+++ b/elasticsearch/native/src/main/java/org/apache/metamodel/elasticsearch/nativeclient/ElasticSearchCreateTableBuilder.java
@@ -18,6 +18,8 @@
  */
 package org.apache.metamodel.elasticsearch.nativeclient;
 
+import java.util.Map;
+
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.create.AbstractTableCreationBuilder;
 import org.apache.metamodel.elasticsearch.common.ElasticSearchUtils;
@@ -50,7 +52,12 @@ final class ElasticSearchCreateTableBuilder extends AbstractTableCreationBuilder
 
         final PutMappingRequestBuilder requestBuilder = new PutMappingRequestBuilder(indicesAdmin)
                 .setIndices(indexName).setType(table.getName());
-        requestBuilder.setSource(source);
+        if (source instanceof Map) {
+            // ensure proper method linking
+            requestBuilder.setSource((Map<?, ?>) source);
+        } else {
+            requestBuilder.setSource(source);
+        }
         final PutMappingResponse result = requestBuilder.execute().actionGet();
 
         logger.debug("PutMapping response: acknowledged={}", result.isAcknowledged());

--- a/elasticsearch/native/src/main/java/org/apache/metamodel/elasticsearch/nativeclient/ElasticSearchCreateTableBuilder.java
+++ b/elasticsearch/native/src/main/java/org/apache/metamodel/elasticsearch/nativeclient/ElasticSearchCreateTableBuilder.java
@@ -44,20 +44,15 @@ final class ElasticSearchCreateTableBuilder extends AbstractTableCreationBuilder
     @Override
     public Table execute() throws MetaModelException {
         final MutableTable table = getTable();
-        final Object source = ElasticSearchUtils.getMappingSource(table);
+        final Map<String, ?> source = ElasticSearchUtils.getMappingSource(table);
 
         final ElasticSearchDataContext dataContext = getUpdateCallback().getDataContext();
         final IndicesAdminClient indicesAdmin = dataContext.getElasticSearchClient().admin().indices();
         final String indexName = dataContext.getIndexName();
 
-        final PutMappingRequestBuilder requestBuilder = new PutMappingRequestBuilder(indicesAdmin)
-                .setIndices(indexName).setType(table.getName());
-        if (source instanceof Map) {
-            // ensure proper method linking
-            requestBuilder.setSource((Map<?, ?>) source);
-        } else {
-            requestBuilder.setSource(source);
-        }
+        final PutMappingRequestBuilder requestBuilder = new PutMappingRequestBuilder(indicesAdmin).setIndices(indexName)
+                .setType(table.getName());
+        requestBuilder.setSource(source);
         final PutMappingResponse result = requestBuilder.execute().actionGet();
 
         logger.debug("PutMapping response: acknowledged={}", result.isAcknowledged());

--- a/elasticsearch/native/src/main/java/org/apache/metamodel/elasticsearch/nativeclient/ElasticSearchCreateTableBuilder.java
+++ b/elasticsearch/native/src/main/java/org/apache/metamodel/elasticsearch/nativeclient/ElasticSearchCreateTableBuilder.java
@@ -18,8 +18,6 @@
  */
 package org.apache.metamodel.elasticsearch.nativeclient;
 
-import java.util.List;
-
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.create.AbstractTableCreationBuilder;
 import org.apache.metamodel.elasticsearch.common.ElasticSearchUtils;
@@ -44,7 +42,7 @@ final class ElasticSearchCreateTableBuilder extends AbstractTableCreationBuilder
     @Override
     public Table execute() throws MetaModelException {
         final MutableTable table = getTable();
-        final List<Object> sourceProperties = ElasticSearchUtils.getSourceProperties(table);
+        final Object source = ElasticSearchUtils.getMappingSource(table);
 
         final ElasticSearchDataContext dataContext = getUpdateCallback().getDataContext();
         final IndicesAdminClient indicesAdmin = dataContext.getElasticSearchClient().admin().indices();
@@ -52,7 +50,7 @@ final class ElasticSearchCreateTableBuilder extends AbstractTableCreationBuilder
 
         final PutMappingRequestBuilder requestBuilder = new PutMappingRequestBuilder(indicesAdmin)
                 .setIndices(indexName).setType(table.getName());
-        requestBuilder.setSource(sourceProperties.toArray());
+        requestBuilder.setSource(source);
         final PutMappingResponse result = requestBuilder.execute().actionGet();
 
         logger.debug("PutMapping response: acknowledged={}", result.isAcknowledged());

--- a/elasticsearch/native/src/main/java/org/apache/metamodel/elasticsearch/nativeclient/NativeElasticSearchUtils.java
+++ b/elasticsearch/native/src/main/java/org/apache/metamodel/elasticsearch/nativeclient/NativeElasticSearchUtils.java
@@ -41,7 +41,8 @@ final class NativeElasticSearchUtils {
             final Column column = selectItem.getColumn();
 
             assert column != null;
-            assert selectItem.getFunction() == null;
+            assert selectItem.getAggregateFunction() == null;
+            assert selectItem.getScalarFunction() == null;
 
             if (column.isPrimaryKey()) {
                 values[i] = documentId;

--- a/elasticsearch/rest/pom.xml
+++ b/elasticsearch/rest/pom.xml
@@ -27,7 +27,7 @@ under the License.
 	<modelVersion>4.0.0</modelVersion>
 
 	<properties>
-		<jest.version>0.1.7</jest.version>
+		<jest.version>2.0.2</jest.version>
 		<elasticsearch.version>1.4.4</elasticsearch.version>
 	</properties>
 

--- a/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/ElasticSearchRestDataContext.java
+++ b/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/ElasticSearchRestDataContext.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.metamodel.BatchUpdateScript;
 import org.apache.metamodel.DataContext;
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.QueryPostprocessDataContext;
@@ -354,7 +355,8 @@ public class ElasticSearchRestDataContext extends QueryPostprocessDataContext im
 
     @Override
     public void executeUpdate(UpdateScript update) {
-        final JestElasticSearchUpdateCallback callback = new JestElasticSearchUpdateCallback(this);
+        final boolean isBatch = update instanceof BatchUpdateScript;
+        final JestElasticSearchUpdateCallback callback = new JestElasticSearchUpdateCallback(this, isBatch);
         update.run(callback);
         callback.onExecuteUpdateFinished();
     }

--- a/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/JestElasticSearchCreateTableBuilder.java
+++ b/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/JestElasticSearchCreateTableBuilder.java
@@ -18,29 +18,33 @@
  */
 package org.apache.metamodel.elasticsearch.rest;
 
-import io.searchbox.indices.mapping.PutMapping;
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.create.AbstractTableCreationBuilder;
 import org.apache.metamodel.elasticsearch.common.ElasticSearchUtils;
-import org.apache.metamodel.schema.*;
+import org.apache.metamodel.schema.MutableSchema;
+import org.apache.metamodel.schema.MutableTable;
+import org.apache.metamodel.schema.Schema;
+import org.apache.metamodel.schema.Table;
 
-import java.util.List;
+import io.searchbox.indices.mapping.PutMapping;
 
 final class JestElasticSearchCreateTableBuilder extends AbstractTableCreationBuilder<JestElasticSearchUpdateCallback> {
-    public JestElasticSearchCreateTableBuilder(JestElasticSearchUpdateCallback updateCallback, Schema schema, String name) {
+    
+    public JestElasticSearchCreateTableBuilder(JestElasticSearchUpdateCallback updateCallback, Schema schema,
+            String name) {
         super(updateCallback, schema, name);
     }
 
     @Override
     public Table execute() throws MetaModelException {
         final MutableTable table = getTable();
-        final List<Object> sourceProperties = ElasticSearchUtils.getSourceProperties(table);
+        final Object source = ElasticSearchUtils.getMappingSource(table);
 
         final ElasticSearchRestDataContext dataContext = getUpdateCallback().getDataContext();
         final String indexName = dataContext.getIndexName();
 
-        final PutMapping putMapping = new PutMapping.Builder(indexName, table.getName(), sourceProperties).build();
-        JestClientExecutor.execute(dataContext.getElasticSearchClient(), putMapping);
+        final PutMapping putMapping = new PutMapping.Builder(indexName, table.getName(), source).build();
+        getUpdateCallback().execute(putMapping);
 
         final MutableSchema schema = (MutableSchema) getSchema();
         schema.addTable(table);

--- a/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/JestElasticSearchCreateTableBuilder.java
+++ b/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/JestElasticSearchCreateTableBuilder.java
@@ -18,6 +18,8 @@
  */
 package org.apache.metamodel.elasticsearch.rest;
 
+import java.util.Map;
+
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.create.AbstractTableCreationBuilder;
 import org.apache.metamodel.elasticsearch.common.ElasticSearchUtils;
@@ -38,7 +40,7 @@ final class JestElasticSearchCreateTableBuilder extends AbstractTableCreationBui
     @Override
     public Table execute() throws MetaModelException {
         final MutableTable table = getTable();
-        final Object source = ElasticSearchUtils.getMappingSource(table);
+        final Map<String, ?> source = ElasticSearchUtils.getMappingSource(table);
 
         final ElasticSearchRestDataContext dataContext = getUpdateCallback().getDataContext();
         final String indexName = dataContext.getIndexName();

--- a/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/JestElasticSearchDataSet.java
+++ b/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/JestElasticSearchDataSet.java
@@ -106,7 +106,7 @@ final class JestElasticSearchDataSet extends AbstractDataSet {
         }
 
         // try to scroll to the next set of hits
-        SearchScroll scroll = new SearchScroll.Builder(scrollId.getAsString(), ElasticSearchRestDataContext.TIMEOUT_SCROLL).build();
+        final SearchScroll scroll = new SearchScroll.Builder(scrollId.getAsString(), ElasticSearchRestDataContext.TIMEOUT_SCROLL).build();
 
         _searchResponse = JestClientExecutor.execute(_client, scroll);
 

--- a/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/JestElasticSearchDeleteBuilder.java
+++ b/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/JestElasticSearchDeleteBuilder.java
@@ -71,6 +71,6 @@ final class JestElasticSearchDeleteBuilder extends AbstractRowDeletionBuilder {
                 new DeleteByQuery.Builder(searchSourceBuilder.toString()).addIndex(indexName).addType(
                         documentType).build();
 
-        JestClientExecutor.execute(dataContext.getElasticSearchClient(), deleteByQuery);
+        _updateCallback.execute(deleteByQuery);
     }
 }

--- a/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/JestElasticSearchDropTableBuilder.java
+++ b/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/JestElasticSearchDropTableBuilder.java
@@ -18,7 +18,6 @@
  */
 package org.apache.metamodel.elasticsearch.rest;
 
-import io.searchbox.indices.mapping.DeleteMapping;
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.drop.AbstractTableDropBuilder;
 import org.apache.metamodel.drop.TableDropBuilder;
@@ -26,6 +25,8 @@ import org.apache.metamodel.schema.MutableSchema;
 import org.apache.metamodel.schema.Table;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.searchbox.indices.mapping.DeleteMapping;
 
 /**
  * {@link TableDropBuilder} for dropping tables (document types) in an
@@ -52,7 +53,7 @@ final class JestElasticSearchDropTableBuilder extends AbstractTableDropBuilder {
 
         final DeleteMapping deleteIndex = new DeleteMapping.Builder(dataContext.getIndexName(), documentType).build();
 
-        JestClientExecutor.execute(dataContext.getElasticSearchClient(), deleteIndex);
+        _updateCallback.execute(deleteIndex);
 
         final MutableSchema schema = (MutableSchema) table.getSchema();
         schema.removeTable(table);

--- a/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/JestElasticSearchUpdateCallback.java
+++ b/elasticsearch/rest/src/main/java/org/apache/metamodel/elasticsearch/rest/JestElasticSearchUpdateCallback.java
@@ -18,8 +18,8 @@
  */
 package org.apache.metamodel.elasticsearch.rest;
 
-import io.searchbox.indices.Refresh;
 import org.apache.metamodel.AbstractUpdateCallback;
+import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.UpdateCallback;
 import org.apache.metamodel.create.TableCreationBuilder;
 import org.apache.metamodel.delete.RowDeletionBuilder;
@@ -27,13 +27,37 @@ import org.apache.metamodel.drop.TableDropBuilder;
 import org.apache.metamodel.insert.RowInsertionBuilder;
 import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.searchbox.action.Action;
+import io.searchbox.action.BulkableAction;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.Bulk;
+import io.searchbox.core.Bulk.Builder;
+import io.searchbox.indices.Refresh;
 
 /**
- * {@link UpdateCallback} implementation for {@link ElasticSearchRestDataContext}.
+ * {@link UpdateCallback} implementation for
+ * {@link ElasticSearchRestDataContext}.
  */
 final class JestElasticSearchUpdateCallback extends AbstractUpdateCallback {
-    public JestElasticSearchUpdateCallback(ElasticSearchRestDataContext dataContext) {
+
+    private static final Logger logger = LoggerFactory.getLogger(JestElasticSearchUpdateCallback.class);
+
+    private static final int BULK_BUFFER_SIZE = 1000;
+
+    private Bulk.Builder bulkBuilder;
+    private int bulkActionCount = 0;
+    private final boolean isBatch;
+
+    public JestElasticSearchUpdateCallback(ElasticSearchRestDataContext dataContext, boolean isBatch) {
         super(dataContext);
+        this.isBatch = isBatch;
+    }
+
+    private boolean isBatch() {
+        return isBatch;
     }
 
     @Override
@@ -76,9 +100,54 @@ final class JestElasticSearchUpdateCallback extends AbstractUpdateCallback {
     }
 
     public void onExecuteUpdateFinished() {
+        if (isBatch()) {
+            flushBulkActions();
+        }
+
         final String indexName = getDataContext().getIndexName();
-        Refresh refresh = new Refresh.Builder().addIndex(indexName).build();
+        final Refresh refresh = new Refresh.Builder().addIndex(indexName).build();
 
         JestClientExecutor.execute(getDataContext().getElasticSearchClient(), refresh, false);
+    }
+
+    private void flushBulkActions() {
+        if (bulkBuilder == null || bulkActionCount == 0) {
+            // nothing to flush
+            return;
+        }
+        final Bulk bulk = getBulkBuilder().build();
+        logger.info("Flushing {} actions to ElasticSearch index {}", bulkActionCount, getDataContext().getIndexName());
+        executeBlocking(bulk);
+
+        bulkActionCount = 0;
+        bulkBuilder = null;
+    }
+
+    public void execute(Action<?> action) {
+        if (isBatch() && action instanceof BulkableAction) {
+            final Bulk.Builder bulkBuilder = getBulkBuilder();
+            bulkBuilder.addAction((BulkableAction<?>) action);
+            bulkActionCount++;
+            if (bulkActionCount == BULK_BUFFER_SIZE) {
+                flushBulkActions();
+            }
+        } else {
+            executeBlocking(action);
+        }
+    }
+
+    private void executeBlocking(Action<?> action) {
+        final JestResult result = JestClientExecutor.execute(getDataContext().getElasticSearchClient(), action);
+        if (!result.isSucceeded()) {
+            throw new MetaModelException(result.getResponseCode() + " - " + result.getErrorMessage());
+        }
+    }
+
+    private Builder getBulkBuilder() {
+        if (bulkBuilder == null) {
+            bulkBuilder = new Bulk.Builder();
+            bulkBuilder.defaultIndex(getDataContext().getIndexName());
+        }
+        return bulkBuilder;
     }
 }


### PR DESCRIPTION
This branch adds support for two things... 

 * Creation of elastic search mappings (document types) using a JSON object instead of array. This was discussed on the mailing list in thread "Approach to submitting ElasticSearch mapping".
 * Support for bulk operations in the REST elasticsearch connector

Sorry, it should have been two PRs, but I did it all at once - please let me know if you need it to be split up.