### PR TITLE
Do already-loaded check before retrieving connection.

### DIFF
--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcMetadataLoader.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcMetadataLoader.java
@@ -399,6 +399,10 @@ final class JdbcMetadataLoader implements MetadataLoader {
     
     @Override
     public void loadRelations(JdbcSchema jdbcSchema) {
+        final int identity = System.identityHashCode(jdbcSchema);
+        if (_loadedRelations.contains(identity)) {
+            return;
+        }
         final Connection connection = _dataContext.getConnection();
         try {
             loadRelations(jdbcSchema, connection);

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcMetadataLoader.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcMetadataLoader.java
@@ -149,6 +149,11 @@ final class JdbcMetadataLoader implements MetadataLoader {
     
     @Override
     public void loadIndexes(JdbcTable jdbcTable) {
+        final int identity = System.identityHashCode(jdbcTable);
+        if (_loadedIndexes.contains(identity)) {
+            return;
+        }
+
         final Connection connection = _dataContext.getConnection();
         try {
             loadIndexes(jdbcTable, connection);
@@ -180,6 +185,11 @@ final class JdbcMetadataLoader implements MetadataLoader {
     
     @Override
     public void loadPrimaryKeys(JdbcTable jdbcTable) {
+        final int identity = System.identityHashCode(jdbcTable);
+        if (_loadedPrimaryKeys.contains(identity)) {
+            return;
+        }
+
         final Connection connection = _dataContext.getConnection();
         try {
             loadPrimaryKeys(jdbcTable, connection);
@@ -268,6 +278,11 @@ final class JdbcMetadataLoader implements MetadataLoader {
     
     @Override
     public void loadColumns(JdbcTable jdbcTable) {
+        final int identity = System.identityHashCode(jdbcTable);
+        if (_loadedColumns.contains(identity)) {
+            return;
+        }
+
         final Connection connection = _dataContext.getConnection();
         try {
             loadColumns(jdbcTable, connection);


### PR DESCRIPTION
This avoids an issue with excessive retrieving/returning Connections introduced in METAMODEL-142

Fixes METAMODEL-252

Tested a table copy using DataCleaner on a SQL Server table of 8 varchar(max) columns with 500000 entries: Goes from 69 seconds to 33 seconds.