### PR TITLE
METAMODEL-241: Fixed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
  * [METAMODEL-159] - DataContextFactory misses methods to create HBase and POJO data contexts.
  * [METAMODEL-252] - Fixed a bug that caused JDBC updates to unnecessarily refresh schema objects.
  * [METAMODEL-1082] - Improved performance of batch ElasticSearch operations by using bulk API.
+ * [METAMODEL-241] - Fixed deserialization of legacy enum types on OpenJDK after rev. 7c1d34773aa6.
 
 ### Apache MetaModel 4.5.2
 


### PR DESCRIPTION
This fix is implemented by further diving deep into the depths of OpenJDK. I'm not really fond of going down that route, but it seems to be the way to go if we really want to keep deserialization support.

Thanks to @LosD for the good hint on what had changed in OpenJDK by the way!