### PR TITLE
METAMODEL-1088 Fix aliases for MongoDB modules

### DIFF
--- a/mongodb/mongo2/src/main/java/org/apache/metamodel/mongodb/mongo2/MongoDbDataContext.java
+++ b/mongodb/mongo2/src/main/java/org/apache/metamodel/mongodb/mongo2/MongoDbDataContext.java
@@ -280,20 +280,23 @@ public class MongoDbDataContext extends QueryPostprocessDataContext implements U
                 final List<FilterItem> whereItems = query.getWhereClause().getItems();
 
                 // if all of the select items are "pure" column selection
-                boolean allSelectItemsAreColumns = true;
+                boolean allSelectItemsAreColumnsWithoutAliases = true;
                 List<SelectItem> selectItems = query.getSelectClause().getItems();
 
                 // if it is a
                 // "SELECT [columns] FROM [table] WHERE [conditions]"
                 // query.
                 for (SelectItem selectItem : selectItems) {
-                    if (selectItem.getFunction() != null || selectItem.getColumn() == null) {
-                        allSelectItemsAreColumns = false;
+                    if (selectItem.getAggregateFunction() != null
+                            || selectItem.getScalarFunction() != null
+                                || selectItem.getAlias() != null
+                                    || selectItem.getColumn() == null) {
+                        allSelectItemsAreColumnsWithoutAliases = false;
                         break;
                     }
                 }
 
-                if (allSelectItemsAreColumns) {
+                if (allSelectItemsAreColumnsWithoutAliases) {
                     logger.debug("Query can be expressed in full MongoDB, no post processing needed.");
 
                     // prepare for a non-post-processed query

--- a/mongodb/mongo2/src/main/java/org/apache/metamodel/mongodb/mongo2/MongoDbDataSet.java
+++ b/mongodb/mongo2/src/main/java/org/apache/metamodel/mongodb/mongo2/MongoDbDataSet.java
@@ -21,6 +21,7 @@ package org.apache.metamodel.mongodb.mongo2;
 import org.apache.metamodel.data.AbstractDataSet;
 import org.apache.metamodel.data.Row;
 import org.apache.metamodel.mongodb.common.MongoDBUtils;
+import org.apache.metamodel.query.SelectItem;
 import org.apache.metamodel.schema.Column;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +41,13 @@ final class MongoDbDataSet extends AbstractDataSet {
 
     public MongoDbDataSet(DBCursor cursor, Column[] columns, boolean queryPostProcessed) {
         super(columns);
+        _cursor = cursor;
+        _queryPostProcessed = queryPostProcessed;
+        _closed = false;
+    }
+
+    public MongoDbDataSet(DBCursor cursor, SelectItem[] selectItems, boolean queryPostProcessed) {
+        super(selectItems);
         _cursor = cursor;
         _queryPostProcessed = queryPostProcessed;
         _closed = false;

--- a/mongodb/mongo3/src/main/java/org/apache/metamodel/mongodb/mongo3/MongoDbDataContext.java
+++ b/mongodb/mongo3/src/main/java/org/apache/metamodel/mongodb/mongo3/MongoDbDataContext.java
@@ -268,20 +268,23 @@ public class MongoDbDataContext extends QueryPostprocessDataContext implements U
                 final List<FilterItem> whereItems = query.getWhereClause().getItems();
 
                 // if all of the select items are "pure" column selection
-                boolean allSelectItemsAreColumns = true;
+                boolean allSelectItemsAreColumnsWithoutAliases = true;
                 List<SelectItem> selectItems = query.getSelectClause().getItems();
 
                 // if it is a
                 // "SELECT [columns] FROM [table] WHERE [conditions]"
                 // query.
                 for (SelectItem selectItem : selectItems) {
-                    if (selectItem.getFunction() != null || selectItem.getColumn() == null) {
-                        allSelectItemsAreColumns = false;
+                    if (selectItem.getAggregateFunction() != null
+                            || selectItem.getScalarFunction() != null
+                                || selectItem.getAlias() != null
+                                    || selectItem.getColumn() == null) {
+                        allSelectItemsAreColumnsWithoutAliases = false;
                         break;
                     }
                 }
 
-                if (allSelectItemsAreColumns) {
+                if (allSelectItemsAreColumnsWithoutAliases) {
                     logger.debug("Query can be expressed in full MongoDB, no post processing needed.");
 
                     // prepare for a non-post-processed query

--- a/mongodb/mongo3/src/main/java/org/apache/metamodel/mongodb/mongo3/MongoDbDataSet.java
+++ b/mongodb/mongo3/src/main/java/org/apache/metamodel/mongodb/mongo3/MongoDbDataSet.java
@@ -21,6 +21,7 @@ package org.apache.metamodel.mongodb.mongo3;
 import org.apache.metamodel.data.AbstractDataSet;
 import org.apache.metamodel.data.Row;
 import org.apache.metamodel.mongodb.common.MongoDBUtils;
+import org.apache.metamodel.query.SelectItem;
 import org.apache.metamodel.schema.Column;
 import org.bson.Document;
 import org.slf4j.Logger;
@@ -40,6 +41,13 @@ final class MongoDbDataSet extends AbstractDataSet {
 
     public MongoDbDataSet(MongoCursor<Document> cursor, Column[] columns, boolean queryPostProcessed) {
         super(columns);
+        _cursor = cursor;
+        _queryPostProcessed = queryPostProcessed;
+        _closed = false;
+    }
+
+    public MongoDbDataSet(MongoCursor<Document> cursor, SelectItem[] selectItems, boolean queryPostProcessed) {
+        super(selectItems);
         _cursor = cursor;
         _queryPostProcessed = queryPostProcessed;
         _closed = false;


### PR DESCRIPTION
This PR includes the changes to fix METAMODEL-1088 by checking whether the columns contain aliases and if so just delegating the query to the QueryPostprocessDataContext.