### PR TITLE
Improving writing to an excel file

### DIFF
--- a/excel/src/main/java/org/apache/metamodel/excel/ExcelUpdateCallback.java
+++ b/excel/src/main/java/org/apache/metamodel/excel/ExcelUpdateCallback.java
@@ -79,8 +79,7 @@ final class ExcelUpdateCallback extends AbstractUpdateCallback implements Update
     protected void close() {
         if (_workbook != null) {
             ExcelUtils.writeAndCloseWorkbook(_dataContext, _workbook);
-
-            _workbook = null;
+            _workbook = null; 
             _dateCellFormat = null;
             _dateCellStyle = null;
         }

--- a/excel/src/test/java/org/apache/metamodel/excel/ExcelDataContextTest.java
+++ b/excel/src/test/java/org/apache/metamodel/excel/ExcelDataContextTest.java
@@ -22,8 +22,6 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
-import junit.framework.TestCase;
-
 import org.apache.metamodel.DataContext;
 import org.apache.metamodel.MetaModelHelper;
 import org.apache.metamodel.UpdateCallback;
@@ -39,6 +37,8 @@ import org.apache.metamodel.schema.Table;
 import org.apache.metamodel.util.DateUtils;
 import org.apache.metamodel.util.FileHelper;
 import org.apache.metamodel.util.Month;
+
+import junit.framework.TestCase;
 
 public class ExcelDataContextTest extends TestCase {
 

--- a/full/src/main/java/org/apache/metamodel/DataContextFactory.java
+++ b/full/src/main/java/org/apache/metamodel/DataContextFactory.java
@@ -545,6 +545,7 @@ public class DataContextFactory {
      */
     public static UpdateableDataContext createMongoDbDataContext(String hostname, Integer port, String databaseName,
             String username, char[] password, SimpleTableDef[] tableDefs) {
+        MongoClient mongoClient = null;
         try {
             final ServerAddress serverAddress;
             if (port == null) {
@@ -552,7 +553,6 @@ public class DataContextFactory {
             } else {
                 serverAddress = new ServerAddress(hostname, port);
             }
-            MongoClient mongoClient = null;
             final MongoDatabase mongoDb;
             if (Strings.isNullOrEmpty(username)) {
                 mongoClient = new MongoClient(serverAddress);
@@ -571,6 +571,8 @@ public class DataContextFactory {
                 throw (RuntimeException) e;
             }
             throw new IllegalStateException(e);
+        } finally {
+            mongoClient.close();
         }
     }
 


### PR DESCRIPTION
In DataCleaner we have a performance issue when trying to write an Excel file:  https://github.com/datacleaner/DataCleaner/issues/1370 

I removed the workaround to "first write to a temp file to avoid that workbook source is the same as the target (will cause read+write cyclic overflow)"
The "InMemoryResource" is not needed anymore after the change I have made.


