### PR TITLE
Dynamic DataContext factory (MM 1099)

### DIFF
--- a/core/src/main/java/org/apache/metamodel/ConnectionException.java
+++ b/core/src/main/java/org/apache/metamodel/ConnectionException.java
@@ -16,26 +16,29 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.metamodel.factory;
-
-import java.util.Collection;
-
-import org.apache.metamodel.ConnectionException;
-import org.apache.metamodel.DataContext;
+package org.apache.metamodel;
 
 /**
- * Represents a registry of {@link DataContextFactory} objects. This registry
- * can be used to create {@link DataContext}s of varying types using the
- * underlying factories.
+ * Specialized {@link MetaModelException} thrown to indicate that establishing
+ * the connection to the underlying data store of an {@link DataContext} failed.
  */
-public interface DataContextFactoryRegistry {
+public class ConnectionException extends MetaModelException {
 
-    public void addFactory(DataContextFactory factory);
+    private static final long serialVersionUID = 1L;
 
-    public void clearFactories();
+    public ConnectionException() {
+        super();
+    }
 
-    public Collection<DataContextFactory> getFactories();
+    public ConnectionException(Exception cause) {
+        super(cause);
+    }
 
-    public DataContext createDataContext(DataContextProperties properties)
-            throws UnsupportedDataContextPropertiesException, ConnectionException;
+    public ConnectionException(String message, Exception cause) {
+        super(message, cause);
+    }
+
+    public ConnectionException(String message) {
+        super(message);
+    }
 }

--- a/core/src/main/java/org/apache/metamodel/factory/ClasspathResourceFactory.java
+++ b/core/src/main/java/org/apache/metamodel/factory/ClasspathResourceFactory.java
@@ -18,30 +18,19 @@
  */
 package org.apache.metamodel.factory;
 
-import org.apache.metamodel.MetaModelException;
+import org.apache.metamodel.util.ClasspathResource;
+import org.apache.metamodel.util.Resource;
 
-/**
- * Exception thrown if a {@link DataContextFactory} or
- * {@link DataContextFactoryRegistry} is being invoked with
- * {@link DataContextProperties} that are not supported by the implementation.
- */
-public class UnsupportedDataContextPropertiesException extends MetaModelException {
+public class ClasspathResourceFactory implements ResourceFactory {
 
-    private static final long serialVersionUID = 1L;
-
-    public UnsupportedDataContextPropertiesException() {
-        super();
+    @Override
+    public boolean accepts(ResourceProperties properties) {
+        return "classpath".equals(properties.getUri().getScheme());
     }
 
-    public UnsupportedDataContextPropertiesException(Exception cause) {
-        super(cause);
-    }
-
-    public UnsupportedDataContextPropertiesException(String message, Exception cause) {
-        super(message, cause);
-    }
-
-    public UnsupportedDataContextPropertiesException(String message) {
-        super(message);
+    @Override
+    public Resource create(ResourceProperties properties) throws UnsupportedResourcePropertiesException {
+        assert accepts(properties);
+        return new ClasspathResource(properties.getUri().getPath());
     }
 }

--- a/core/src/main/java/org/apache/metamodel/factory/DataContextFactory.java
+++ b/core/src/main/java/org/apache/metamodel/factory/DataContextFactory.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.factory;
+
+import org.apache.metamodel.DataContext;
+
+public interface DataContextFactory {
+
+    public boolean accepts(DataContextProperties properties);
+
+    public DataContext create(DataContextProperties properties) throws UnsupportedDataContextPropertiesException;
+}

--- a/core/src/main/java/org/apache/metamodel/factory/DataContextFactory.java
+++ b/core/src/main/java/org/apache/metamodel/factory/DataContextFactory.java
@@ -18,11 +18,13 @@
  */
 package org.apache.metamodel.factory;
 
+import org.apache.metamodel.ConnectionException;
 import org.apache.metamodel.DataContext;
 
 public interface DataContextFactory {
 
-    public boolean accepts(DataContextProperties properties);
+    public boolean accepts(DataContextProperties properties, ResourceFactoryRegistry resourceFactoryRegistry);
 
-    public DataContext create(DataContextProperties properties) throws UnsupportedDataContextPropertiesException;
+    public DataContext create(DataContextProperties properties, ResourceFactoryRegistry resourceFactoryRegistry)
+            throws UnsupportedDataContextPropertiesException, ConnectionException;
 }

--- a/core/src/main/java/org/apache/metamodel/factory/DataContextFactoryRegistry.java
+++ b/core/src/main/java/org/apache/metamodel/factory/DataContextFactoryRegistry.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.factory;
+
+import java.util.Collection;
+
+import org.apache.metamodel.DataContext;
+
+public interface DataContextFactoryRegistry {
+
+    public void addFactory(DataContextFactory factory);
+    
+    public void clearFactories();
+    
+    public Collection<DataContextFactory> getFactories();
+    
+    public DataContext createDataContext(DataContextProperties properties);
+}

--- a/core/src/main/java/org/apache/metamodel/factory/DataContextFactoryRegistryImpl.java
+++ b/core/src/main/java/org/apache/metamodel/factory/DataContextFactoryRegistryImpl.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.factory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.ServiceLoader;
+
+import org.apache.metamodel.DataContext;
+
+public class DataContextFactoryRegistryImpl implements DataContextFactoryRegistry {
+
+    private static final DataContextFactoryRegistry DEFAULT_INSTANCE;
+
+    static {
+        final DataContextFactoryRegistryImpl registry = new DataContextFactoryRegistryImpl();
+        registry.discoverFromClasspath();
+        DEFAULT_INSTANCE = registry;
+    }
+
+    public static DataContextFactoryRegistry getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+    }
+
+    private final List<DataContextFactory> factories;
+
+    public DataContextFactoryRegistryImpl() {
+        factories = new ArrayList<>();
+    }
+
+    @Override
+    public void addFactory(DataContextFactory factory) {
+        factories.add(factory);
+    }
+
+    @Override
+    public void clearFactories() {
+        factories.clear();
+    }
+
+    public void discoverFromClasspath() {
+        final ServiceLoader<DataContextFactory> serviceLoader = ServiceLoader.load(DataContextFactory.class);
+        for (DataContextFactory factory : serviceLoader) {
+            addFactory(factory);
+        }
+    }
+
+    @Override
+    public Collection<DataContextFactory> getFactories() {
+        return Collections.unmodifiableList(factories);
+    }
+
+    @Override
+    public DataContext createDataContext(DataContextProperties properties) throws UnsupportedDataContextPropertiesException {
+        for (DataContextFactory factory : factories) {
+            if (factory.accepts(properties)) {
+                return factory.create(properties);
+            }
+        }
+        throw new UnsupportedDataContextPropertiesException();
+    }
+}

--- a/core/src/main/java/org/apache/metamodel/factory/DataContextProperties.java
+++ b/core/src/main/java/org/apache/metamodel/factory/DataContextProperties.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.factory;
+
+import java.net.URI;
+
+import javax.sql.DataSource;
+
+import org.apache.metamodel.schema.TableType;
+import org.apache.metamodel.util.SimpleTableDef;
+
+public interface DataContextProperties {
+
+    String getDataContextType();
+
+    URI getUri();
+
+    int getColumnNameLineNumber();
+
+    boolean isSkipEmptyLines();
+
+    boolean isSkipEmptyColumns();
+
+    String getEncoding();
+
+    char getSeparatorChar();
+
+    char getQuoteChar();
+
+    char getEscapeChar();
+
+    boolean isFailOnInconsistentRowLength();
+
+    boolean isMultilineValuesEnabled();
+
+    TableType[] getTableTypes();
+
+    String getCatalogName();
+
+    DataSource getDataSource();
+
+    String getUsername();
+
+    String getPassword();
+
+    String getDriverClassName();
+
+    String getHostname();
+
+    Integer getPort();
+
+    String getDatabaseName();
+
+    SimpleTableDef[] getTableDefs();
+}

--- a/core/src/main/java/org/apache/metamodel/factory/DataContextProperties.java
+++ b/core/src/main/java/org/apache/metamodel/factory/DataContextProperties.java
@@ -18,40 +18,61 @@
  */
 package org.apache.metamodel.factory;
 
-import java.net.URI;
+import java.io.Serializable;
+import java.util.Map;
 
 import javax.sql.DataSource;
 
+import org.apache.metamodel.DataContext;
 import org.apache.metamodel.schema.TableType;
 import org.apache.metamodel.util.SimpleTableDef;
 
-public interface DataContextProperties {
+/**
+ * Represents the {@link Serializable} properties used to fully describe and
+ * construct a {@link DataContext}.
+ */
+public interface DataContextProperties extends Serializable {
 
+    /**
+     * Gets the type of {@link DataContext}, such as "csv" or "jdbc".
+     * 
+     * @return
+     */
     String getDataContextType();
 
-    URI getUri();
+    /**
+     * Gets all the properties represented as a {@link Map}. Note that any
+     * unstandardized properties may also be exposed via this map.
+     * 
+     * @return
+     */
+    Map<String, Object> toMap();
 
-    int getColumnNameLineNumber();
+    ResourceProperties getResourceProperties();
 
-    boolean isSkipEmptyLines();
+    Integer getColumnNameLineNumber();
 
-    boolean isSkipEmptyColumns();
+    Boolean isSkipEmptyLines();
+
+    Boolean isSkipEmptyColumns();
 
     String getEncoding();
 
-    char getSeparatorChar();
+    Character getSeparatorChar();
 
-    char getQuoteChar();
+    Character getQuoteChar();
 
-    char getEscapeChar();
+    Character getEscapeChar();
 
-    boolean isFailOnInconsistentRowLength();
+    Boolean isFailOnInconsistentRowLength();
 
-    boolean isMultilineValuesEnabled();
+    Boolean isMultilineValuesEnabled();
 
     TableType[] getTableTypes();
 
     String getCatalogName();
+
+    String getUrl();
 
     DataSource getDataSource();
 

--- a/core/src/main/java/org/apache/metamodel/factory/DataContextPropertiesImpl.java
+++ b/core/src/main/java/org/apache/metamodel/factory/DataContextPropertiesImpl.java
@@ -1,0 +1,224 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.factory;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.sql.DataSource;
+
+import org.apache.metamodel.schema.TableType;
+import org.apache.metamodel.util.SimpleTableDef;
+
+public class DataContextPropertiesImpl implements DataContextProperties {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Map<String, Object> map;
+
+    public DataContextPropertiesImpl() {
+        this(new HashMap<String, Object>());
+    }
+
+    public DataContextPropertiesImpl(Properties properties) {
+        this();
+        final Set<String> propertyNames = properties.stringPropertyNames();
+        for (String key : propertyNames) {
+            put(key, properties.get(key));
+        }
+    }
+
+    public DataContextPropertiesImpl(Map<String, Object> map) {
+        this.map = map;
+    }
+
+    public Object get(String key) {
+        return map.get(key);
+    }
+
+    public Object put(String key, Object value) {
+        return map.put(key, value);
+    }
+
+    public String getString(String key) {
+        final Object value = map.get(key);
+        if (value == null) {
+            return null;
+        }
+        return value.toString();
+    }
+
+    public Character getChar(String key) {
+        final String str = getString(key);
+        if (str == null || str.isEmpty()) {
+            return null;
+        }
+        return str.charAt(0);
+    }
+
+    public Integer getInt(String key) {
+        return (Integer) get(key);
+    }
+
+    private Boolean getBoolean(String key) {
+        return (Boolean) get(key);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getMap(String key) {
+        return (Map<String, Object>) get(key);
+    }
+
+    @Override
+    public String getDataContextType() {
+        return getString("type");
+    }
+
+    @Override
+    public Map<String, Object> toMap() {
+        return map;
+    }
+
+    @Override
+    public ResourceProperties getResourceProperties() {
+        final Object resourceValue = get("resource");
+        if (resourceValue == null) {
+            return null;
+        }
+        if (resourceValue instanceof String) {
+            return new SimpleResourceProperties((String) resourceValue);
+        }
+        if (resourceValue instanceof URI) {
+            return new SimpleResourceProperties((URI) resourceValue);
+        }
+        if (resourceValue instanceof Map) {
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> resourceMap = (Map<String, Object>) resourceValue;
+            return new ResourcePropertiesImpl(resourceMap);
+        }
+        throw new IllegalStateException("Unsupported 'resource' definition: " + resourceValue);
+    }
+
+    @Override
+    public Integer getColumnNameLineNumber() {
+        return getInt("column-name-line-number");
+    }
+
+    @Override
+    public Boolean isSkipEmptyLines() {
+        return getBoolean("skip-empty-lines");
+    }
+
+    @Override
+    public Boolean isSkipEmptyColumns() {
+        return getBoolean("skip-empty-columns");
+    }
+
+    @Override
+    public String getEncoding() {
+        return getString("encoding");
+    }
+
+    @Override
+    public Character getSeparatorChar() {
+        return getChar("separator-char");
+    }
+
+    @Override
+    public Character getQuoteChar() {
+        return getChar("quote-char");
+    }
+
+    @Override
+    public Character getEscapeChar() {
+        return getChar("escape-char");
+    }
+
+    @Override
+    public Boolean isFailOnInconsistentRowLength() {
+        return getBoolean("fail-on-inconsistent-row-length");
+    }
+
+    @Override
+    public Boolean isMultilineValuesEnabled() {
+        return getBoolean("multiline-values");
+    }
+
+    @Override
+    public TableType[] getTableTypes() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public String getCatalogName() {
+        return getString("catalog");
+    }
+
+    @Override
+    public String getUrl() {
+        return getString("url");
+    }
+
+    @Override
+    public DataSource getDataSource() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return getString("username");
+    }
+
+    @Override
+    public String getPassword() {
+        return getString("password");
+    }
+
+    @Override
+    public String getDriverClassName() {
+        return getString("driver-class");
+    }
+
+    @Override
+    public String getHostname() {
+        return getString("hostname");
+    }
+
+    @Override
+    public Integer getPort() {
+        return getInt("port");
+    }
+
+    @Override
+    public String getDatabaseName() {
+        return getString("database");
+    }
+
+    @Override
+    public SimpleTableDef[] getTableDefs() {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+}

--- a/core/src/main/java/org/apache/metamodel/factory/FileResourceFactory.java
+++ b/core/src/main/java/org/apache/metamodel/factory/FileResourceFactory.java
@@ -18,30 +18,21 @@
  */
 package org.apache.metamodel.factory;
 
-import org.apache.metamodel.MetaModelException;
+import org.apache.metamodel.util.FileResource;
+import org.apache.metamodel.util.Resource;
 
-/**
- * Exception thrown if a {@link DataContextFactory} or
- * {@link DataContextFactoryRegistry} is being invoked with
- * {@link DataContextProperties} that are not supported by the implementation.
- */
-public class UnsupportedDataContextPropertiesException extends MetaModelException {
+public class FileResourceFactory implements ResourceFactory {
 
-    private static final long serialVersionUID = 1L;
-
-    public UnsupportedDataContextPropertiesException() {
-        super();
+    @Override
+    public boolean accepts(ResourceProperties properties) {
+        final String scheme = properties.getUri().getScheme();
+        return scheme == null || "file".equals(scheme);
     }
 
-    public UnsupportedDataContextPropertiesException(Exception cause) {
-        super(cause);
-    }
-
-    public UnsupportedDataContextPropertiesException(String message, Exception cause) {
-        super(message, cause);
-    }
-
-    public UnsupportedDataContextPropertiesException(String message) {
-        super(message);
+    @Override
+    public Resource create(ResourceProperties properties) throws UnsupportedResourcePropertiesException {
+        assert accepts(properties);
+        final String path = properties.getUri().getPath();
+        return new FileResource(path);
     }
 }

--- a/core/src/main/java/org/apache/metamodel/factory/InMemoryResourceFactory.java
+++ b/core/src/main/java/org/apache/metamodel/factory/InMemoryResourceFactory.java
@@ -18,30 +18,19 @@
  */
 package org.apache.metamodel.factory;
 
-import org.apache.metamodel.MetaModelException;
+import org.apache.metamodel.util.InMemoryResource;
+import org.apache.metamodel.util.Resource;
 
-/**
- * Exception thrown if a {@link DataContextFactory} or
- * {@link DataContextFactoryRegistry} is being invoked with
- * {@link DataContextProperties} that are not supported by the implementation.
- */
-public class UnsupportedDataContextPropertiesException extends MetaModelException {
+public class InMemoryResourceFactory implements ResourceFactory {
 
-    private static final long serialVersionUID = 1L;
-
-    public UnsupportedDataContextPropertiesException() {
-        super();
+    @Override
+    public boolean accepts(ResourceProperties properties) {
+        return "mem".equals(properties.getUri().getScheme());
     }
 
-    public UnsupportedDataContextPropertiesException(Exception cause) {
-        super(cause);
-    }
-
-    public UnsupportedDataContextPropertiesException(String message, Exception cause) {
-        super(message, cause);
-    }
-
-    public UnsupportedDataContextPropertiesException(String message) {
-        super(message);
+    @Override
+    public Resource create(ResourceProperties properties) throws UnsupportedResourcePropertiesException {
+        assert accepts(properties);
+        return new InMemoryResource(properties.getUri().getPath());
     }
 }

--- a/core/src/main/java/org/apache/metamodel/factory/ResourceFactory.java
+++ b/core/src/main/java/org/apache/metamodel/factory/ResourceFactory.java
@@ -18,30 +18,11 @@
  */
 package org.apache.metamodel.factory;
 
-import org.apache.metamodel.MetaModelException;
+import org.apache.metamodel.util.Resource;
 
-/**
- * Exception thrown if a {@link DataContextFactory} or
- * {@link DataContextFactoryRegistry} is being invoked with
- * {@link DataContextProperties} that are not supported by the implementation.
- */
-public class UnsupportedDataContextPropertiesException extends MetaModelException {
+public interface ResourceFactory {
 
-    private static final long serialVersionUID = 1L;
+    public boolean accepts(ResourceProperties properties);
 
-    public UnsupportedDataContextPropertiesException() {
-        super();
-    }
-
-    public UnsupportedDataContextPropertiesException(Exception cause) {
-        super(cause);
-    }
-
-    public UnsupportedDataContextPropertiesException(String message, Exception cause) {
-        super(message, cause);
-    }
-
-    public UnsupportedDataContextPropertiesException(String message) {
-        super(message);
-    }
+    public Resource create(ResourceProperties properties) throws UnsupportedResourcePropertiesException;
 }

--- a/core/src/main/java/org/apache/metamodel/factory/ResourceFactoryRegistry.java
+++ b/core/src/main/java/org/apache/metamodel/factory/ResourceFactoryRegistry.java
@@ -18,30 +18,17 @@
  */
 package org.apache.metamodel.factory;
 
-import org.apache.metamodel.MetaModelException;
+import java.util.Collection;
 
-/**
- * Exception thrown if a {@link DataContextFactory} or
- * {@link DataContextFactoryRegistry} is being invoked with
- * {@link DataContextProperties} that are not supported by the implementation.
- */
-public class UnsupportedDataContextPropertiesException extends MetaModelException {
+import org.apache.metamodel.util.Resource;
 
-    private static final long serialVersionUID = 1L;
+public interface ResourceFactoryRegistry {
 
-    public UnsupportedDataContextPropertiesException() {
-        super();
-    }
+    public void addFactory(ResourceFactory factory);
 
-    public UnsupportedDataContextPropertiesException(Exception cause) {
-        super(cause);
-    }
+    public void clearFactories();
 
-    public UnsupportedDataContextPropertiesException(String message, Exception cause) {
-        super(message, cause);
-    }
+    public Collection<ResourceFactory> getFactories();
 
-    public UnsupportedDataContextPropertiesException(String message) {
-        super(message);
-    }
+    public Resource createResource(ResourceProperties properties) throws UnsupportedResourcePropertiesException;
 }

--- a/core/src/main/java/org/apache/metamodel/factory/ResourceFactoryRegistryImpl.java
+++ b/core/src/main/java/org/apache/metamodel/factory/ResourceFactoryRegistryImpl.java
@@ -24,30 +24,30 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ServiceLoader;
 
-import org.apache.metamodel.DataContext;
+import org.apache.metamodel.util.Resource;
 
-public class DataContextFactoryRegistryImpl implements DataContextFactoryRegistry {
+public class ResourceFactoryRegistryImpl implements ResourceFactoryRegistry {
 
-    private static final DataContextFactoryRegistry DEFAULT_INSTANCE;
+    private static final ResourceFactoryRegistry DEFAULT_INSTANCE;
 
     static {
-        final DataContextFactoryRegistryImpl registry = new DataContextFactoryRegistryImpl();
+        final ResourceFactoryRegistryImpl registry = new ResourceFactoryRegistryImpl();
         registry.discoverFromClasspath();
         DEFAULT_INSTANCE = registry;
     }
 
-    public static DataContextFactoryRegistry getDefaultInstance() {
+    public static ResourceFactoryRegistry getDefaultInstance() {
         return DEFAULT_INSTANCE;
     }
 
-    private final List<DataContextFactory> factories;
+    private final List<ResourceFactory> factories;
 
-    public DataContextFactoryRegistryImpl() {
+    public ResourceFactoryRegistryImpl() {
         factories = new ArrayList<>();
     }
 
     @Override
-    public void addFactory(DataContextFactory factory) {
+    public void addFactory(ResourceFactory factory) {
         factories.add(factory);
     }
 
@@ -57,23 +57,23 @@ public class DataContextFactoryRegistryImpl implements DataContextFactoryRegistr
     }
 
     @Override
-    public Collection<DataContextFactory> getFactories() {
+    public Collection<ResourceFactory> getFactories() {
         return Collections.unmodifiableList(factories);
     }
 
     @Override
-    public DataContext createDataContext(DataContextProperties properties) throws UnsupportedDataContextPropertiesException {
-        for (DataContextFactory factory : factories) {
+    public Resource createResource(ResourceProperties properties) {
+        for (ResourceFactory factory : factories) {
             if (factory.accepts(properties)) {
                 return factory.create(properties);
             }
         }
-        throw new UnsupportedDataContextPropertiesException();
+        throw new UnsupportedResourcePropertiesException();
     }
-    
+
     public void discoverFromClasspath() {
-        final ServiceLoader<DataContextFactory> serviceLoader = ServiceLoader.load(DataContextFactory.class);
-        for (DataContextFactory factory : serviceLoader) {
+        final ServiceLoader<ResourceFactory> serviceLoader = ServiceLoader.load(ResourceFactory.class);
+        for (ResourceFactory factory : serviceLoader) {
             addFactory(factory);
         }
     }

--- a/core/src/main/java/org/apache/metamodel/factory/ResourceProperties.java
+++ b/core/src/main/java/org/apache/metamodel/factory/ResourceProperties.java
@@ -18,30 +18,29 @@
  */
 package org.apache.metamodel.factory;
 
-import org.apache.metamodel.MetaModelException;
+import java.io.Serializable;
+import java.net.URI;
+import java.util.Map;
+
+import org.apache.metamodel.util.Resource;
 
 /**
- * Exception thrown if a {@link DataContextFactory} or
- * {@link DataContextFactoryRegistry} is being invoked with
- * {@link DataContextProperties} that are not supported by the implementation.
+ * Represents the {@link Serializable} properties used to fully describe and
+ * construct a {@link Resource}.
  */
-public class UnsupportedDataContextPropertiesException extends MetaModelException {
+public interface ResourceProperties extends Serializable {
 
-    private static final long serialVersionUID = 1L;
+    URI getUri();
 
-    public UnsupportedDataContextPropertiesException() {
-        super();
-    }
+    /**
+     * Gets all the properties represented as a {@link Map}. Note that any
+     * unstandardized properties may also be exposed via this map.
+     * 
+     * @return
+     */
+    Map<String, Object> toMap();
 
-    public UnsupportedDataContextPropertiesException(Exception cause) {
-        super(cause);
-    }
+    String getUsername();
 
-    public UnsupportedDataContextPropertiesException(String message, Exception cause) {
-        super(message, cause);
-    }
-
-    public UnsupportedDataContextPropertiesException(String message) {
-        super(message);
-    }
+    String getPassword();
 }

--- a/core/src/main/java/org/apache/metamodel/factory/ResourcePropertiesImpl.java
+++ b/core/src/main/java/org/apache/metamodel/factory/ResourcePropertiesImpl.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.factory;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ResourcePropertiesImpl implements ResourceProperties {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Map<String, Object> map;
+
+    public ResourcePropertiesImpl() {
+        this(new HashMap<String, Object>());
+    }
+
+    public ResourcePropertiesImpl(Map<String, Object> map) {
+        this.map = map;
+    }
+
+    private String getString(String key) {
+        final Object value = map.get(key);
+        if (value == null) {
+            return null;
+        }
+        return value.toString();
+    }
+
+    @Override
+    public URI getUri() {
+        final Object uri = map.get("uri");
+        if (uri == null) {
+            return null;
+        }
+        if (uri instanceof URI) {
+            return (URI) uri;
+        }
+        return URI.create(uri.toString());
+    }
+
+    @Override
+    public Map<String, Object> toMap() {
+        return map;
+    }
+
+    @Override
+    public String getUsername() {
+        return getString("username");
+    }
+
+    @Override
+    public String getPassword() {
+        return getString("password");
+    }
+
+}

--- a/core/src/main/java/org/apache/metamodel/factory/SimpleResourceProperties.java
+++ b/core/src/main/java/org/apache/metamodel/factory/SimpleResourceProperties.java
@@ -18,30 +18,43 @@
  */
 package org.apache.metamodel.factory;
 
-import org.apache.metamodel.MetaModelException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
-/**
- * Exception thrown if a {@link DataContextFactory} or
- * {@link DataContextFactoryRegistry} is being invoked with
- * {@link DataContextProperties} that are not supported by the implementation.
- */
-public class UnsupportedDataContextPropertiesException extends MetaModelException {
+public class SimpleResourceProperties implements ResourceProperties {
 
     private static final long serialVersionUID = 1L;
+    private final URI uri;
 
-    public UnsupportedDataContextPropertiesException() {
-        super();
+    public SimpleResourceProperties(URI uri) {
+        this.uri = uri;
     }
 
-    public UnsupportedDataContextPropertiesException(Exception cause) {
-        super(cause);
+    public SimpleResourceProperties(String uri) {
+        this.uri = URI.create(uri);
     }
 
-    public UnsupportedDataContextPropertiesException(String message, Exception cause) {
-        super(message, cause);
+    @Override
+    public URI getUri() {
+        return uri;
     }
 
-    public UnsupportedDataContextPropertiesException(String message) {
-        super(message);
+    @Override
+    public Map<String, Object> toMap() {
+        final Map<String, Object> map = new HashMap<>();
+        map.put("uri", uri);
+        return map;
     }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
 }

--- a/core/src/main/java/org/apache/metamodel/factory/UnsupportedDataContextPropertiesException.java
+++ b/core/src/main/java/org/apache/metamodel/factory/UnsupportedDataContextPropertiesException.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.factory;
+
+import org.apache.metamodel.MetaModelException;
+
+/**
+ * Exception thrown if a {@link DataContextFactory} or
+ * {@link DataContextFactoryRegistry} is being invoked with
+ * {@link DataContextProperties} that are not supported by the implementation.
+ */
+public class UnsupportedDataContextPropertiesException extends MetaModelException {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/core/src/main/java/org/apache/metamodel/factory/UnsupportedResourcePropertiesException.java
+++ b/core/src/main/java/org/apache/metamodel/factory/UnsupportedResourcePropertiesException.java
@@ -20,28 +20,24 @@ package org.apache.metamodel.factory;
 
 import org.apache.metamodel.MetaModelException;
 
-/**
- * Exception thrown if a {@link DataContextFactory} or
- * {@link DataContextFactoryRegistry} is being invoked with
- * {@link DataContextProperties} that are not supported by the implementation.
- */
-public class UnsupportedDataContextPropertiesException extends MetaModelException {
+public class UnsupportedResourcePropertiesException extends MetaModelException {
 
     private static final long serialVersionUID = 1L;
 
-    public UnsupportedDataContextPropertiesException() {
+    public UnsupportedResourcePropertiesException() {
         super();
     }
 
-    public UnsupportedDataContextPropertiesException(Exception cause) {
+    public UnsupportedResourcePropertiesException(Exception cause) {
         super(cause);
     }
 
-    public UnsupportedDataContextPropertiesException(String message, Exception cause) {
+    public UnsupportedResourcePropertiesException(String message, Exception cause) {
         super(message, cause);
     }
 
-    public UnsupportedDataContextPropertiesException(String message) {
+    public UnsupportedResourcePropertiesException(String message) {
         super(message);
     }
+
 }

--- a/core/src/main/java/org/apache/metamodel/factory/UrlResourceFactory.java
+++ b/core/src/main/java/org/apache/metamodel/factory/UrlResourceFactory.java
@@ -18,30 +18,29 @@
  */
 package org.apache.metamodel.factory;
 
-import org.apache.metamodel.MetaModelException;
+import java.net.MalformedURLException;
 
-/**
- * Exception thrown if a {@link DataContextFactory} or
- * {@link DataContextFactoryRegistry} is being invoked with
- * {@link DataContextProperties} that are not supported by the implementation.
- */
-public class UnsupportedDataContextPropertiesException extends MetaModelException {
+import org.apache.metamodel.util.Resource;
+import org.apache.metamodel.util.UrlResource;
 
-    private static final long serialVersionUID = 1L;
+public class UrlResourceFactory implements ResourceFactory {
 
-    public UnsupportedDataContextPropertiesException() {
-        super();
+    @Override
+    public boolean accepts(ResourceProperties properties) {
+        try {
+            properties.getUri().toURL();
+            return true;
+        } catch (MalformedURLException | IllegalArgumentException e) {
+            return false;
+        }
     }
 
-    public UnsupportedDataContextPropertiesException(Exception cause) {
-        super(cause);
-    }
-
-    public UnsupportedDataContextPropertiesException(String message, Exception cause) {
-        super(message, cause);
-    }
-
-    public UnsupportedDataContextPropertiesException(String message) {
-        super(message);
+    @Override
+    public Resource create(ResourceProperties properties) throws UnsupportedResourcePropertiesException {
+        try {
+            return new UrlResource(properties.getUri().toURL());
+        } catch (MalformedURLException e) {
+            throw new UnsupportedResourcePropertiesException(e);
+        }
     }
 }

--- a/core/src/main/java/org/apache/metamodel/util/ResourceUtils.java
+++ b/core/src/main/java/org/apache/metamodel/util/ResourceUtils.java
@@ -18,10 +18,30 @@
  */
 package org.apache.metamodel.util;
 
+import java.net.URI;
+
+import org.apache.metamodel.factory.ResourceFactoryRegistryImpl;
+import org.apache.metamodel.factory.ResourceProperties;
+import org.apache.metamodel.factory.SimpleResourceProperties;
+import org.apache.metamodel.factory.UnsupportedResourcePropertiesException;
+
 /**
  * Static utility methods for handling {@link Resource}s.
  */
 public class ResourceUtils {
+
+    public static Resource toResource(URI uri) {
+        return toResource(new SimpleResourceProperties(uri));
+    }
+
+    public static Resource toResource(String uri) {
+        return toResource(new SimpleResourceProperties(uri));
+    }
+
+    public static Resource toResource(ResourceProperties resourceProperties)
+            throws UnsupportedResourcePropertiesException {
+        return ResourceFactoryRegistryImpl.getDefaultInstance().createResource(resourceProperties);
+    }
 
     /**
      * Gets the parent name of a resource. For example, if the resource's

--- a/core/src/main/java/org/apache/metamodel/util/ResourceUtils.java
+++ b/core/src/main/java/org/apache/metamodel/util/ResourceUtils.java
@@ -30,14 +30,39 @@ import org.apache.metamodel.factory.UnsupportedResourcePropertiesException;
  */
 public class ResourceUtils {
 
-    public static Resource toResource(URI uri) {
+    /**
+     * Creates a Resource based on a URI
+     * 
+     * @param uri
+     * @return
+     * @throws UnsupportedResourcePropertiesException
+     *             if the scheme or other part of the URI is unsupported.
+     */
+    public static Resource toResource(URI uri) throws UnsupportedResourcePropertiesException {
         return toResource(new SimpleResourceProperties(uri));
     }
 
-    public static Resource toResource(String uri) {
+    /**
+     * Creates a Resource based on a path or URI (represented by a String)
+     * 
+     * @param uri
+     * @return
+     * @throws UnsupportedResourcePropertiesException
+     *             if the scheme or other part of the string is unsupported.
+     */
+    public static Resource toResource(String uri) throws UnsupportedResourcePropertiesException {
         return toResource(new SimpleResourceProperties(uri));
     }
 
+    /**
+     * Creates a Resource based on the {@link ResourceProperties} definition.
+     * 
+     * @param resourceProperties
+     * @return
+     * @throws UnsupportedResourcePropertiesException
+     *             if the provided properties cannot be handled in creation of a
+     *             resource.
+     */
     public static Resource toResource(ResourceProperties resourceProperties)
             throws UnsupportedResourcePropertiesException {
         return ResourceFactoryRegistryImpl.getDefaultInstance().createResource(resourceProperties);

--- a/core/src/main/resources/META-INF/services/org.apache.metamodel.factory.ResourceFactory
+++ b/core/src/main/resources/META-INF/services/org.apache.metamodel.factory.ResourceFactory
@@ -1,0 +1,4 @@
+org.apache.metamodel.factory.FileResourceFactory
+org.apache.metamodel.factory.ClasspathResourceFactory
+org.apache.metamodel.factory.UrlResourceFactory
+org.apache.metamodel.factory.InMemoryResourceFactory

--- a/core/src/test/java/org/apache/metamodel/factory/ResourceFactoryRegistryImplTest.java
+++ b/core/src/test/java/org/apache/metamodel/factory/ResourceFactoryRegistryImplTest.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.factory;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.apache.metamodel.util.ClasspathResource;
+import org.apache.metamodel.util.InMemoryResource;
+import org.apache.metamodel.util.Resource;
+import org.apache.metamodel.util.UrlResource;
+import org.junit.Test;
+
+public class ResourceFactoryRegistryImplTest {
+
+    private final ResourceFactoryRegistry registry = ResourceFactoryRegistryImpl.getDefaultInstance();
+
+    @Test
+    public void testGetQualifiedFileResource() throws Exception {
+        final File file = new File("src/test/resources/unicode-text-utf8.txt");
+        final Resource res = registry.createResource(new SimpleResourceProperties("file:///" + file.getAbsolutePath()));
+        assertTrue(res.isExists());
+        assertEquals("unicode-text-utf8.txt", res.getName());
+    }
+
+    @Test
+    public void testGetUnqualifiedRelativeFileResource() throws Exception {
+        final Resource res = registry.createResource(new SimpleResourceProperties(
+                "src/test/resources/unicode-text-utf8.txt"));
+        assertTrue(res.isExists());
+        assertEquals("unicode-text-utf8.txt", res.getName());
+    }
+
+    @Test
+    public void testGetInMemoryResource() throws Exception {
+        final Resource res = registry.createResource(new SimpleResourceProperties("mem:///foo.bar.txt"));
+        assertTrue(res instanceof InMemoryResource);
+    }
+
+    @Test
+    public void testGetClasspathResource() throws Exception {
+        final Resource res = registry.createResource(new SimpleResourceProperties("classpath:///folder/foo"));
+        assertTrue(res.isExists());
+        assertTrue(res instanceof ClasspathResource);
+    }
+
+    @Test
+    public void testGetUrlResource() throws Exception {
+        final Resource res = registry.createResource(new SimpleResourceProperties(
+                "http://metamodel.apache.org/robots.txt"));
+        assertTrue(res.isExists());
+        assertTrue(res instanceof UrlResource);
+    }
+}

--- a/core/src/test/java/org/apache/metamodel/util/UrlResourceTest.java
+++ b/core/src/test/java/org/apache/metamodel/util/UrlResourceTest.java
@@ -23,10 +23,10 @@ import junit.framework.TestCase;
 public class UrlResourceTest extends TestCase {
 
     public void testGetName() throws Exception {
-        UrlResource resource = new UrlResource("http://eobjects.org/foo.txt");
-        assertEquals("foo.txt", resource.getName());
+        UrlResource resource = new UrlResource("http://metamodel.apache.org/robots.txt");
+        assertEquals("robots.txt", resource.getName());
         
-        resource = new UrlResource("http://eobjects.org/");
-        assertEquals("http://eobjects.org/", resource.getName());
+        resource = new UrlResource("http://metamodel.apache.org/");
+        assertEquals("http://metamodel.apache.org/", resource.getName());
     }
 }

--- a/csv/src/main/java/org/apache/metamodel/csv/CsvDataContextFactory.java
+++ b/csv/src/main/java/org/apache/metamodel/csv/CsvDataContextFactory.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.csv;
+
+import org.apache.metamodel.DataContext;
+import org.apache.metamodel.factory.DataContextFactory;
+import org.apache.metamodel.factory.DataContextProperties;
+import org.apache.metamodel.factory.UnsupportedDataContextPropertiesException;
+import org.apache.metamodel.util.FileHelper;
+import org.apache.metamodel.util.Resource;
+import org.apache.metamodel.util.ResourceUtils;
+
+public class CsvDataContextFactory implements DataContextFactory {
+
+    @Override
+    public boolean accepts(DataContextProperties properties) {
+        return "csv".equals(properties.getDataContextType());
+    }
+
+    @Override
+    public DataContext create(DataContextProperties properties) throws UnsupportedDataContextPropertiesException {
+        assert accepts(properties);
+
+        final Resource resource = ResourceUtils.toResource(properties.getResourceProperties());
+
+        final int columnNameLineNumber = getInt(properties.getColumnNameLineNumber(),
+                CsvConfiguration.DEFAULT_COLUMN_NAME_LINE);
+        final String encoding = getString(properties.getEncoding(), FileHelper.DEFAULT_ENCODING);
+        final char separatorChar = getChar(properties.getSeparatorChar(), CsvConfiguration.DEFAULT_SEPARATOR_CHAR);
+        final char quoteChar = getChar(properties.getQuoteChar(), CsvConfiguration.DEFAULT_QUOTE_CHAR);
+        final char escapeChar = getChar(properties.getEscapeChar(), CsvConfiguration.DEFAULT_ESCAPE_CHAR);
+        final boolean failOnInconsistentRowLength = getBoolean(properties.isFailOnInconsistentRowLength(), false);
+        final boolean multilineValuesEnabled = getBoolean(properties.isMultilineValuesEnabled(), true);
+
+        final CsvConfiguration configuration = new CsvConfiguration(columnNameLineNumber, encoding, separatorChar,
+                quoteChar, escapeChar, failOnInconsistentRowLength, multilineValuesEnabled);
+        return new CsvDataContext(resource, configuration);
+    }
+
+    private String getString(String value, String ifNull) {
+        return value == null ? ifNull : value;
+    }
+
+    private int getInt(Integer value, int ifNull) {
+        return value == null ? ifNull : value;
+    }
+
+    private boolean getBoolean(Boolean value, boolean ifNull) {
+        return value == null ? ifNull : value;
+    }
+
+    private char getChar(Character value, char ifNull) {
+        return value == null ? ifNull : value;
+    }
+
+}

--- a/csv/src/main/java/org/apache/metamodel/csv/CsvDataContextFactory.java
+++ b/csv/src/main/java/org/apache/metamodel/csv/CsvDataContextFactory.java
@@ -21,23 +21,24 @@ package org.apache.metamodel.csv;
 import org.apache.metamodel.DataContext;
 import org.apache.metamodel.factory.DataContextFactory;
 import org.apache.metamodel.factory.DataContextProperties;
-import org.apache.metamodel.factory.UnsupportedDataContextPropertiesException;
+import org.apache.metamodel.factory.ResourceFactoryRegistry;
 import org.apache.metamodel.util.FileHelper;
 import org.apache.metamodel.util.Resource;
-import org.apache.metamodel.util.ResourceUtils;
 
 public class CsvDataContextFactory implements DataContextFactory {
 
+    public static final String PROPERTY_TYPE = "csv";
+
     @Override
-    public boolean accepts(DataContextProperties properties) {
-        return "csv".equals(properties.getDataContextType());
+    public boolean accepts(DataContextProperties properties, ResourceFactoryRegistry resourceFactoryRegistry) {
+        return PROPERTY_TYPE.equals(properties.getDataContextType());
     }
 
     @Override
-    public DataContext create(DataContextProperties properties) throws UnsupportedDataContextPropertiesException {
-        assert accepts(properties);
+    public DataContext create(DataContextProperties properties, ResourceFactoryRegistry resourceFactoryRegistry) {
+        assert accepts(properties, resourceFactoryRegistry);
 
-        final Resource resource = ResourceUtils.toResource(properties.getResourceProperties());
+        final Resource resource = resourceFactoryRegistry.createResource(properties.getResourceProperties());
 
         final int columnNameLineNumber = getInt(properties.getColumnNameLineNumber(),
                 CsvConfiguration.DEFAULT_COLUMN_NAME_LINE);

--- a/csv/src/main/resources/META-INF/services/org.apache.metamodel.factory.DataContextFactory
+++ b/csv/src/main/resources/META-INF/services/org.apache.metamodel.factory.DataContextFactory
@@ -1,0 +1,1 @@
+org.apache.metamodel.csv.CsvDataContextFactory

--- a/csv/src/test/java/org/apache/metamodel/csv/CsvDataContextFactoryTest.java
+++ b/csv/src/test/java/org/apache/metamodel/csv/CsvDataContextFactoryTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.csv;
+
+import java.util.Collection;
+
+import org.apache.metamodel.factory.DataContextFactory;
+import org.apache.metamodel.factory.DataContextFactoryRegistryImpl;
+import org.apache.metamodel.factory.DataContextPropertiesImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CsvDataContextFactoryTest {
+
+    @Test
+    public void testDiscovery() throws Exception {
+        final Collection<DataContextFactory> factories = DataContextFactoryRegistryImpl.getDefaultInstance()
+                .getFactories();
+
+        boolean found = false;
+        for (DataContextFactory factory : factories) {
+            if (factory instanceof CsvDataContextFactory) {
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) {
+            Assert.fail("Expected to find CsvDataContextFactory. Found: " + factories);
+        }
+    }
+
+    @Test
+    public void testCreateDataContext() throws Exception {
+        final DataContextPropertiesImpl properties = new DataContextPropertiesImpl();
+        properties.put("type", "csv");
+        properties.put("resource", "src/test/resources/csv_people.csv");
+
+        DataContextFactoryRegistryImpl.getDefaultInstance().createDataContext(properties);
+    }
+}

--- a/hadoop/src/main/java/org/apache/metamodel/hadoop/HdfsResourceFactory.java
+++ b/hadoop/src/main/java/org/apache/metamodel/hadoop/HdfsResourceFactory.java
@@ -16,33 +16,31 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.metamodel.factory;
+package org.apache.metamodel.hadoop;
 
-import java.net.MalformedURLException;
-import java.net.URI;
-
+import org.apache.metamodel.factory.ResourceFactory;
+import org.apache.metamodel.factory.ResourceProperties;
+import org.apache.metamodel.factory.UnsupportedResourcePropertiesException;
+import org.apache.metamodel.util.HdfsResource;
 import org.apache.metamodel.util.Resource;
-import org.apache.metamodel.util.UrlResource;
 
-public class UrlResourceFactory implements ResourceFactory {
+public class HdfsResourceFactory implements ResourceFactory {
+
+    /**
+     * Property that can be used
+     */
+    public static final String PROPERTY_HADOOP_CONF_DIR = "hadoop-conf-dir";
 
     @Override
     public boolean accepts(ResourceProperties properties) {
-        final URI uri = properties.getUri();
-        switch (uri.getScheme()) {
-        case "http":
-        case "https":
-            return true;
-        }
-        return false;
+        return "hdfs".equals(properties.getUri().getScheme());
     }
 
     @Override
     public Resource create(ResourceProperties properties) throws UnsupportedResourcePropertiesException {
-        try {
-            return new UrlResource(properties.getUri().toURL());
-        } catch (MalformedURLException e) {
-            throw new UnsupportedResourcePropertiesException(e);
-        }
+        final Object hadoopConfDirProperty = properties.toMap().get(PROPERTY_HADOOP_CONF_DIR);
+        final String hadoopConfDir = hadoopConfDirProperty == null ? null : hadoopConfDirProperty.toString();
+        return new HdfsResource(properties.getUri().toString(), hadoopConfDir);
     }
+
 }

--- a/hadoop/src/main/resources/META-INF/services/org.apache.metamodel.factory.ResourceFactory
+++ b/hadoop/src/main/resources/META-INF/services/org.apache.metamodel.factory.ResourceFactory
@@ -1,0 +1,1 @@
+org.apache.metamodel.hadoop.HdfsResourceFactory

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataContextFactory.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataContextFactory.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import org.apache.metamodel.ConnectionException;
+import org.apache.metamodel.DataContext;
+import org.apache.metamodel.factory.DataContextFactory;
+import org.apache.metamodel.factory.DataContextProperties;
+import org.apache.metamodel.factory.ResourceFactoryRegistry;
+import org.apache.metamodel.schema.TableType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JdbcDataContextFactory implements DataContextFactory {
+
+    private static final Logger logger = LoggerFactory.getLogger(JdbcDataContextFactory.class);
+
+    public static final String PROPERTY_TYPE = "jdbc";
+
+    @Override
+    public boolean accepts(DataContextProperties properties, ResourceFactoryRegistry resourceFactoryRegistry) {
+        return PROPERTY_TYPE.equals(properties.getDataContextType());
+    }
+
+    @Override
+    public DataContext create(DataContextProperties properties, ResourceFactoryRegistry resourceFactoryRegistry)
+            throws ConnectionException {
+        final String driverClassName = properties.getDriverClassName();
+        if (driverClassName != null) {
+            try {
+                Class.forName(driverClassName);
+            } catch (ClassNotFoundException e) {
+                logger.warn("Failed to initialize driver class: {}", driverClassName, e);
+            }
+        }
+
+        final TableType[] tableTypes = properties.getTableTypes() == null ? TableType.DEFAULT_TABLE_TYPES
+                : properties.getTableTypes();
+        final String catalogName = properties.getCatalogName();
+
+        final DataSource dataSource = properties.getDataSource();
+        if (dataSource != null) {
+            return new JdbcDataContext(dataSource, tableTypes, catalogName);
+        }
+
+        final String url = properties.getUrl();
+        final String username = properties.getUsername();
+        final String password = properties.getPassword();
+
+        final Connection connection;
+        try {
+            if (username != null) {
+                connection = DriverManager.getConnection(url, username, password);
+            } else {
+                connection = DriverManager.getConnection(url);
+            }
+        } catch (SQLException e) {
+            throw new ConnectionException("Failed to open JDBC connection from URL: " + url, e);
+        }
+
+        return new JdbcDataContext(connection, tableTypes, catalogName);
+    }
+
+}

--- a/jdbc/src/main/resources/META-INF/services/org.apache.metamodel.factory.DataContextFactory
+++ b/jdbc/src/main/resources/META-INF/services/org.apache.metamodel.factory.DataContextFactory
@@ -1,0 +1,1 @@
+org.apache.metamodel.jdbc.JdbcDataContextFactory

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/H2databaseTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/H2databaseTest.java
@@ -26,8 +26,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.TestCase;
-
 import org.apache.metamodel.UpdateCallback;
 import org.apache.metamodel.UpdateScript;
 import org.apache.metamodel.create.CreateTable;
@@ -48,10 +46,15 @@ import org.apache.metamodel.schema.Table;
 import org.apache.metamodel.update.Update;
 import org.apache.metamodel.util.MutableRef;
 
+import junit.framework.TestCase;
+
 /**
  * Test case that tests interaction with the H2 embedded database
  */
 public class H2databaseTest extends TestCase {
+    
+    public static final String DRIVER_CLASS = "org.h2.Driver";
+    public static final String URL_MEMORY_DATABASE = "jdbc:h2:mem:";
 
     private final String[] FIRST_NAMES = { "Suzy", "Barbara", "John", "Ken", "Billy", "Larry", "Joe", "Margareth", "Bobby",
             "Elizabeth" };
@@ -62,8 +65,8 @@ public class H2databaseTest extends TestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        Class.forName("org.h2.Driver");
-        conn = DriverManager.getConnection("jdbc:h2:mem:");
+        Class.forName(DRIVER_CLASS);
+        conn = DriverManager.getConnection(URL_MEMORY_DATABASE);
     }
 
     @Override

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/JdbcDataContextFactoryTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/JdbcDataContextFactoryTest.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.jdbc;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.metamodel.DataContext;
+import org.apache.metamodel.factory.DataContextFactoryRegistryImpl;
+import org.apache.metamodel.factory.DataContextPropertiesImpl;
+import org.apache.metamodel.jdbc.dialects.H2QueryRewriter;
+import org.junit.Test;
+
+public class JdbcDataContextFactoryTest {
+
+    @Test
+    public void testCreateDataContext() throws Exception {
+        final DataContextPropertiesImpl properties = new DataContextPropertiesImpl();
+        properties.setDataContextType("jdbc");
+        properties.put("driver-class", H2databaseTest.DRIVER_CLASS);
+        properties.put("url", H2databaseTest.URL_MEMORY_DATABASE);
+
+        final DataContext dataContext = DataContextFactoryRegistryImpl.getDefaultInstance().createDataContext(
+                properties);
+        assertTrue(dataContext instanceof JdbcDataContext);
+
+        final JdbcDataContext jdbcDataContext = (JdbcDataContext) dataContext;
+        assertTrue(jdbcDataContext.getQueryRewriter() instanceof H2QueryRewriter);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -376,6 +376,7 @@ under the License.
 							<exclude>**/src/assembly/metamodel-packaged-assembly-descriptor.xml</exclude>
 							<exclude>**/.gitignore/**</exclude>
 							<exclude>.git/**</exclude>
+							<exclude>**/src/main/resources/META-INF/services/**</exclude>
 							<exclude>**/src/test/resources/**</exclude>
 							<exclude>**/src/site/**</exclude>
 							<exclude>**/.project</exclude>


### PR DESCRIPTION
This is my attempt at solving METAMODEL-1099. I've leveraged the standard [ServiceLoader](https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html) for registering resource factories and data context factories. And I implemented this pattern with the various standard resources as well as the CSV data context. In my opinion this approach is pretty good, but I'd like to hear your feedback!

If you think this approach is good, we should obviously expand it to fit all the datacontext implementations. But that would be a rather trivial task I think, once we agree on this.