### PR TITLE
Anchor WildcardPattern to start

### DIFF
--- a/core/src/main/java/org/apache/metamodel/util/WildcardPattern.java
+++ b/core/src/main/java/org/apache/metamodel/util/WildcardPattern.java
@@ -40,8 +40,12 @@ public final class WildcardPattern implements Serializable {
 	public WildcardPattern(String pattern, char wildcard) {
 		_pattern = pattern;
 		_wildcard = wildcard;
-		_startsWithDelim = (_pattern.charAt(0) == _wildcard);
-		_endsWithDelim = (_pattern.charAt(pattern.length() - 1) == _wildcard);
+		if(_pattern.isEmpty()){
+			_startsWithDelim = _endsWithDelim = false;
+		} else {
+			_startsWithDelim = _pattern.charAt(0) == _wildcard;
+			_endsWithDelim = _pattern.charAt(pattern.length() - 1) == _wildcard;
+		}
 	}
 
 	public boolean matches(String value) {

--- a/core/src/main/java/org/apache/metamodel/util/WildcardPattern.java
+++ b/core/src/main/java/org/apache/metamodel/util/WildcardPattern.java
@@ -32,13 +32,15 @@ import org.apache.metamodel.query.FilterItem;
 public final class WildcardPattern implements Serializable {
 
 	private static final long serialVersionUID = 857462137797209624L;
+	private final boolean _startsWithDelim;
+	private final boolean _endsWithDelim;
 	private String _pattern;
 	private char _wildcard;
-	private boolean _endsWithDelim;
 
 	public WildcardPattern(String pattern, char wildcard) {
 		_pattern = pattern;
 		_wildcard = wildcard;
+		_startsWithDelim = (_pattern.charAt(0) == _wildcard);
 		_endsWithDelim = (_pattern.charAt(pattern.length() - 1) == _wildcard);
 	}
 
@@ -50,9 +52,10 @@ public final class WildcardPattern implements Serializable {
 				Character.toString(_wildcard));
 		int charIndex = 0;
 		while (st.hasMoreTokens()) {
+			int oldIndex = charIndex;
 			String token = st.nextToken();
 			charIndex = value.indexOf(token, charIndex);
-			if (charIndex == -1) {
+			if (charIndex == -1 || !_startsWithDelim && oldIndex == 0 && charIndex != 0) {
 				return false;
 			}
 			charIndex = charIndex + token.length();

--- a/core/src/test/java/org/apache/metamodel/util/WildcardPatternTest.java
+++ b/core/src/test/java/org/apache/metamodel/util/WildcardPatternTest.java
@@ -48,5 +48,9 @@ public class WildcardPatternTest extends TestCase {
 		pattern = new WildcardPattern("bar", '%');
 		assertTrue(pattern.matches("bar"));
 		assertFalse(pattern.matches("foobar"));
+
+		pattern = new WildcardPattern("", '%');
+		assertTrue(pattern.matches(""));
+		assertFalse(pattern.matches("foo"));
 	}
 }

--- a/core/src/test/java/org/apache/metamodel/util/WildcardPatternTest.java
+++ b/core/src/test/java/org/apache/metamodel/util/WildcardPatternTest.java
@@ -41,5 +41,12 @@ public class WildcardPatternTest extends TestCase {
 		assertTrue(pattern.matches("foobarbar"));
 		assertFalse(pattern.matches("w00p"));
 
+		pattern = new WildcardPattern("oba%", '%');
+		assertTrue(pattern.matches("obar"));
+		assertFalse(pattern.matches("foobar"));
+
+		pattern = new WildcardPattern("bar", '%');
+		assertTrue(pattern.matches("bar"));
+		assertFalse(pattern.matches("foobar"));
 	}
 }


### PR DESCRIPTION
This makes sure the `WildcardPattern` anchors its test to the start of the string, not only the end.

This comes with a minor performance penalty (quick test said 5-10%), but I think correctness trumps speed here.

I would have liked to compare speed with pre-compiled regexes (`Pattern.quote()` the operand, replace `%` with `.*?` and anchor it with `^` and `$`), but if the LIKE operand is inside a `SelectItem`, that would mean compiling a new regex pattern for every row, which would probably be _very_ expensive, so I opted not to try. There seem to be some similar optimization of the IN operator, so I might be wrong, though.

Fixes METAMODEL-1103