### PR TITLE
Fixed File path and URI-based test

### DIFF
--- a/core/src/test/java/org/apache/metamodel/factory/ResourceFactoryRegistryImplTest.java
+++ b/core/src/test/java/org/apache/metamodel/factory/ResourceFactoryRegistryImplTest.java
@@ -36,7 +36,8 @@ public class ResourceFactoryRegistryImplTest {
     @Test
     public void testGetQualifiedFileResource() throws Exception {
         final File file = new File("src/test/resources/unicode-text-utf8.txt");
-        final Resource res = registry.createResource(new SimpleResourceProperties("file:///" + file.getAbsolutePath()));
+        final Resource res = registry.createResource(new SimpleResourceProperties("file:///" + file.getAbsolutePath()
+                .replace('\\', '/')));
         assertTrue(res.isExists());
         assertEquals("unicode-text-utf8.txt", res.getName());
     }


### PR DESCRIPTION
This is my suggested fix for METAMODEL-1104 (ResourceFactoryRegsitryImplTest broken on Windows).