### PR TITLE
METAMODEL-1109: FixedWidthReader diacritics bug fix 

### DIFF
--- a/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/EbcdicReader.java
+++ b/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/EbcdicReader.java
@@ -26,6 +26,8 @@ import java.io.IOException;
  */
 class EbcdicReader extends FixedWidthReader {
 
+    private final BufferedInputStream _stream;
+    private final String _charsetName;
     private final boolean _skipEbcdicHeader;
     private final boolean _eolPresent;
     private boolean _headerSkipped;
@@ -33,6 +35,8 @@ class EbcdicReader extends FixedWidthReader {
     public EbcdicReader(BufferedInputStream stream, String charsetName, int[] valueWidths,
             boolean failOnInconsistentLineWidth, boolean skipEbcdicHeader, boolean eolPresent) {
         super(stream, charsetName, valueWidths, failOnInconsistentLineWidth);
+        _stream = stream;
+        _charsetName = charsetName;
         _skipEbcdicHeader = skipEbcdicHeader;
         _eolPresent = eolPresent;
     }

--- a/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthReader.java
+++ b/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthReader.java
@@ -19,9 +19,13 @@
 package org.apache.metamodel.fixedwidth;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
 import java.util.ArrayList;
@@ -43,6 +47,7 @@ class FixedWidthReader implements Closeable {
     private final boolean _constantWidth;
     private volatile int _rowNumber;
     protected final BufferedInputStream _stream;
+    protected Reader _reader;
     protected final int _expectedLineLength;
 
     public FixedWidthReader(InputStream stream, String charsetName, int fixedValueWidth,
@@ -54,6 +59,7 @@ class FixedWidthReader implements Closeable {
             boolean failOnInconsistentLineWidth) {
         _stream = stream;
         _charsetName = charsetName;
+        initReader();
         _fixedValueWidth = fixedValueWidth;
         _failOnInconsistentLineWidth = failOnInconsistentLineWidth;
         _rowNumber = 0;
@@ -71,6 +77,7 @@ class FixedWidthReader implements Closeable {
             boolean failOnInconsistentLineWidth) {
         _stream = stream;
         _charsetName = charsetName;
+        initReader();
         _fixedValueWidth = -1;
         _valueWidths = valueWidths;
         _failOnInconsistentLineWidth = failOnInconsistentLineWidth;
@@ -85,6 +92,15 @@ class FixedWidthReader implements Closeable {
         _expectedLineLength = expectedLineLength;
     }
 
+    private void initReader() {
+        try {
+            InputStreamReader inputStreamReader = new InputStreamReader(_stream, _charsetName);
+            _reader = new BufferedReader(inputStreamReader);
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalArgumentException(String.format("Encoding '%s' was not recognized. ", _charsetName));
+        }
+    }
+    
     /**
      * This reads and returns the next record from the file. Usually, it is a line but in case the new line characters
      * are not present, the length of the content depends on the column-widths setting.
@@ -106,7 +122,6 @@ class FixedWidthReader implements Closeable {
      * Empty hook that enables special behavior in sub-classed readers (by overriding this method). 
      */
     protected void beforeReadLine() {
-        return;
     }
 
     private String[] getValues() throws IOException {
@@ -167,8 +182,8 @@ class FixedWidthReader implements Closeable {
         StringBuilder line = new StringBuilder();
         int ch;
 
-        for (ch = _stream.read(); !isEndingCharacter(ch); ch = _stream.read()) {
-            line.append((char) ch);
+        for (ch = _reader.read(); !isEndingCharacter(ch); ch = _reader.read()) {
+            line.append((char)ch);
         }
 
         if (ch == CARRIAGE_RETURN) {
@@ -179,10 +194,10 @@ class FixedWidthReader implements Closeable {
     }
     
     private void readLineFeedIfFollows() throws IOException {
-        _stream.mark(1);
-
-        if (_stream.read() != LINE_FEED) {
-            _stream.reset();
+        _reader.mark(1);
+        
+        if (_reader.read() != LINE_FEED) {
+            _reader.reset();
         }
     }
 

--- a/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthReader.java
+++ b/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthReader.java
@@ -39,15 +39,13 @@ class FixedWidthReader implements Closeable {
     private static final int LINE_FEED = '\n';
     private static final int CARRIAGE_RETURN = '\r';
     
-    protected final String _charsetName;
     private final int _fixedValueWidth;
     private final int[] _valueWidths;
     private int _valueIndex = 0;
     private final boolean _failOnInconsistentLineWidth;
     private final boolean _constantWidth;
     private volatile int _rowNumber;
-    protected final BufferedInputStream _stream;
-    protected Reader _reader;
+    protected final Reader _reader;
     protected final int _expectedLineLength;
 
     public FixedWidthReader(InputStream stream, String charsetName, int fixedValueWidth,
@@ -57,9 +55,7 @@ class FixedWidthReader implements Closeable {
 
     private FixedWidthReader(BufferedInputStream stream, String charsetName, int fixedValueWidth,
             boolean failOnInconsistentLineWidth) {
-        _stream = stream;
-        _charsetName = charsetName;
-        initReader();
+        _reader = initReader(stream, charsetName);
         _fixedValueWidth = fixedValueWidth;
         _failOnInconsistentLineWidth = failOnInconsistentLineWidth;
         _rowNumber = 0;
@@ -75,9 +71,7 @@ class FixedWidthReader implements Closeable {
 
     FixedWidthReader(BufferedInputStream stream, String charsetName, int[] valueWidths,
             boolean failOnInconsistentLineWidth) {
-        _stream = stream;
-        _charsetName = charsetName;
-        initReader();
+        _reader = initReader(stream, charsetName);
         _fixedValueWidth = -1;
         _valueWidths = valueWidths;
         _failOnInconsistentLineWidth = failOnInconsistentLineWidth;
@@ -92,12 +86,12 @@ class FixedWidthReader implements Closeable {
         _expectedLineLength = expectedLineLength;
     }
 
-    private void initReader() {
+    private Reader initReader(BufferedInputStream stream, String charsetName) {
         try {
-            InputStreamReader inputStreamReader = new InputStreamReader(_stream, _charsetName);
-            _reader = new BufferedReader(inputStreamReader);
+            InputStreamReader inputStreamReader = new InputStreamReader(stream, charsetName);
+            return new BufferedReader(inputStreamReader);
         } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException(String.format("Encoding '%s' was not recognized. ", _charsetName));
+            throw new IllegalArgumentException(String.format("Encoding '%s' was not recognized. ", charsetName));
         }
     }
     
@@ -262,6 +256,6 @@ class FixedWidthReader implements Closeable {
 
     @Override
     public void close() throws IOException {
-        _stream.close();
+        _reader.close();
     }
 }

--- a/fixedwidth/src/test/java/org/apache/metamodel/fixedwidth/FixedWidthReaderTest.java
+++ b/fixedwidth/src/test/java/org/apache/metamodel/fixedwidth/FixedWidthReaderTest.java
@@ -37,6 +37,34 @@ public class FixedWidthReaderTest {
     public final ExpectedException exception = ExpectedException.none();
     
     @Test
+    public void testDiacritics() throws IOException {
+        assertExpectedDiacritics(CHARSET);
+    }
+
+    @Test(expected=AssertionError.class)
+    public void testDiacriticsFails() throws IOException {
+        assertExpectedDiacritics("Windows-1250");
+    }
+
+    private void assertExpectedDiacritics(String charset) throws IOException {
+        final File file = new File("src/test/resources/example_diacritics_utf8.txt");
+        final BufferedInputStream stream = new BufferedInputStream(new FileInputStream(file));
+        int[] widths = new int[] { 10, 10 };
+        final String[] expectedValues = {
+                "[name, surname]",
+                "[Štěpán, Knížek]",
+                "[Lukáš, Žáček]",
+                "[Přemysl, Hývl]",
+        };
+        try (final FixedWidthReader fixedWidthReader = new FixedWidthReader(stream, charset, widths, false)) {
+            for (String expectedLine : expectedValues) {
+                final String[] line = fixedWidthReader.readLine();
+                assertEquals(expectedLine, Arrays.asList(line).toString());
+            }
+        }
+    }
+
+    @Test
     public void testBufferedReader1() throws IOException {
         final File file = new File("src/test/resources/example_simple1.txt");
         final BufferedInputStream stream = new BufferedInputStream(new FileInputStream(file));

--- a/fixedwidth/src/test/resources/example_diacritics_utf8.txt
+++ b/fixedwidth/src/test/resources/example_diacritics_utf8.txt
@@ -1,0 +1,4 @@
+name      surname   
+Štěpán    Knížek
+Lukáš     Žáček
+Přemysl   Hývl


### PR DESCRIPTION
Refactoring of FixedWidthReader in PR #103 introduced a bug related to charset (which was not used). So, input containing diacritic characters was not read correctly.

JUnit FixedWidthReaderTest was updated with charset tests.
