### PR TITLE
METAMODEL-1111 Empty string treatment in Oracle

### DIFF
--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/OracleQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/OracleQueryRewriter.java
@@ -81,8 +81,8 @@ public class OracleQueryRewriter extends DefaultQueryRewriter {
 
     @Override
     public String rewriteFilterItem(final FilterItem item) {
-        // What I actually want is "rewriteOperatorType: if '' then null, because in Oracle '' is null
         if (item.getOperand() instanceof String && item.getOperand().equals("")) {
+            // In Oracle empty strings are treated as null. Typical SQL constructs with an empty string do not work.
             return super.rewriteFilterItem(new FilterItem(item.getSelectItem(), item.getOperator(), null));
         } else {
             return super.rewriteFilterItem(item);

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/OracleQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/OracleQueryRewriter.java
@@ -19,6 +19,7 @@
 package org.apache.metamodel.jdbc.dialects;
 
 import org.apache.metamodel.jdbc.JdbcDataContext;
+import org.apache.metamodel.query.FilterItem;
 import org.apache.metamodel.schema.ColumnType;
 
 /**
@@ -76,5 +77,15 @@ public class OracleQueryRewriter extends DefaultQueryRewriter {
             super.rewriteColumnType(ColumnType.DATE, columnSize);
         }
         return super.rewriteColumnType(columnType, columnSize);
+    }
+
+    @Override
+    public String rewriteFilterItem(final FilterItem item) {
+        // What I actually want is "rewriteOperatorType: if '' then null, because in Oracle '' is null
+        if (item.getOperand() instanceof String && item.getOperand().equals("")) {
+            return super.rewriteFilterItem(new FilterItem(item.getSelectItem(), item.getOperator(), null));
+        } else {
+            return super.rewriteFilterItem(item);
+        }
     }
 }

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/OracleQueryRewriterTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/OracleQueryRewriterTest.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.jdbc.dialects;
+
+import org.apache.metamodel.query.FilterItem;
+import org.apache.metamodel.query.OperatorType;
+import org.apache.metamodel.query.SelectItem;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class OracleQueryRewriterTest {
+
+    @Test
+    public void testReplaceEmptyStringWithNull() throws Exception {
+        final OracleQueryRewriter rewriter = new OracleQueryRewriter(null);
+        final String alias = "alias";
+        SelectItem selectItem = new SelectItem("expression", alias);
+        final FilterItem filterItem = new FilterItem(selectItem, OperatorType.DIFFERENT_FROM, "");
+        final String rewrittenValue = rewriter.rewriteFilterItem(filterItem);
+        final String expectedValue = alias + " IS NOT NULL";
+        
+        assertEquals(expectedValue, rewrittenValue);
+    }
+}


### PR DESCRIPTION
Fixes Oracle '' = null problem. In OracleQueryRewriter empty string operand is reaplaced by null. 