### PR TITLE
Added code to remove TIMESTAMP tokens from SQLServer queries

### DIFF
--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/SQLServerQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/SQLServerQueryRewriter.java
@@ -116,6 +116,14 @@ public class SQLServerQueryRewriter extends DefaultQueryRewriter {
                 final String dateTimeValue = "CAST('" + format.format(date) + "' AS DATETIME)";
 
                 sb.append(dateTimeValue);
+
+                //Remove TIMESTAMP token as SQL Server doesn't support it
+                int timestampIndex = sb.lastIndexOf("TIMESTAMP");
+                if(timestampIndex != -1)
+                {
+                    sb.replace(timestampIndex, timestampIndex + "TIMESTAMP".length(), "");
+                }
+                
                 return sb.toString();
             }
         }


### PR DESCRIPTION
SQL Server doesn't allow for the TIMESTAMP token in where clauses.

Related to JIRA Issue METAMODEL-1112
