### PR TITLE
Use ColumnNamingStrategy argument in CsvConfiguration constructor

### DIFF
--- a/csv/src/main/java/org/apache/metamodel/csv/CsvConfiguration.java
+++ b/csv/src/main/java/org/apache/metamodel/csv/CsvConfiguration.java
@@ -94,7 +94,7 @@ public final class CsvConfiguration extends BaseObject implements Serializable {
         this.escapeChar = escapeChar;
         this.failOnInconsistentRowLength = failOnInconsistentRowLength;
         this.multilineValues = multilineValues;
-        this.columnNamingStrategy = null;
+        this.columnNamingStrategy = columnNamingStrategy;
     }
     
     /**

--- a/csv/src/test/java/org/apache/metamodel/csv/CsvDataContextTest.java
+++ b/csv/src/test/java/org/apache/metamodel/csv/CsvDataContextTest.java
@@ -48,6 +48,7 @@ import org.apache.metamodel.schema.Column;
 import org.apache.metamodel.schema.MutableColumn;
 import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
+import org.apache.metamodel.schema.naming.CustomColumnNamingStrategy;
 import org.apache.metamodel.util.FileHelper;
 import org.apache.metamodel.util.MutableRef;
 
@@ -828,4 +829,26 @@ public class CsvDataContextTest extends TestCase {
     // e.getMessage());
     // }
     // }
+
+    public void testCustomColumnNames() throws Exception {
+        final String firstColumnName = "first";
+        final String secondColumnName = "second";
+        final String thirdColumnName = "third";
+        final String fourthColumnName = "fourth";
+
+        final CsvConfiguration configuration = new CsvConfiguration(CsvConfiguration.DEFAULT_COLUMN_NAME_LINE,
+                new CustomColumnNamingStrategy(firstColumnName, secondColumnName, thirdColumnName, fourthColumnName),
+                FileHelper.DEFAULT_ENCODING, CsvConfiguration.DEFAULT_SEPARATOR_CHAR,
+                CsvConfiguration.DEFAULT_QUOTE_CHAR, CsvConfiguration.DEFAULT_ESCAPE_CHAR, false, true);
+
+        final DataContext dataContext = new CsvDataContext(new File("src/test/resources/csv_people.csv"),
+                configuration);
+
+        final Table table = dataContext.getDefaultSchema().getTable(0);
+
+        assertNotNull(table.getColumnByName(firstColumnName));
+        assertNotNull(table.getColumnByName(secondColumnName));
+        assertNotNull(table.getColumnByName(thirdColumnName));
+        assertNotNull(table.getColumnByName(fourthColumnName));
+    }
 }

--- a/excel/src/test/java/org/apache/metamodel/excel/ExcelDataContextTest.java
+++ b/excel/src/test/java/org/apache/metamodel/excel/ExcelDataContextTest.java
@@ -36,6 +36,7 @@ import org.apache.metamodel.query.Query;
 import org.apache.metamodel.schema.Column;
 import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
+import org.apache.metamodel.schema.naming.CustomColumnNamingStrategy;
 import org.apache.metamodel.util.DateUtils;
 import org.apache.metamodel.util.FileHelper;
 import org.apache.metamodel.util.Month;
@@ -774,5 +775,21 @@ public class ExcelDataContextTest extends TestCase {
 
         assertNotNull(ds);
         ds.close();
+    }
+
+    public void testCustomColumnNames() throws Exception {
+        final String firstColumnName = "first";
+        final String secondColumnName = "second";
+        final String thirdColumnName = "third";
+
+        final ExcelConfiguration configuration = new ExcelConfiguration(ExcelConfiguration.DEFAULT_COLUMN_NAME_LINE,
+                new CustomColumnNamingStrategy(firstColumnName, secondColumnName, thirdColumnName), true, false);
+        final DataContext dataContext = new ExcelDataContext(copyOf("src/test/resources/Spreadsheet2007.xlsx"),
+                configuration);
+        final Table table = dataContext.getDefaultSchema().getTable(0);
+
+        assertNotNull(table.getColumnByName(firstColumnName));
+        assertNotNull(table.getColumnByName(secondColumnName));
+        assertNotNull(table.getColumnByName(thirdColumnName));
     }
 }

--- a/fixedwidth/src/test/java/org/apache/metamodel/fixedwidth/FixedWidthDataContextTest.java
+++ b/fixedwidth/src/test/java/org/apache/metamodel/fixedwidth/FixedWidthDataContextTest.java
@@ -28,6 +28,7 @@ import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.query.Query;
 import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
+import org.apache.metamodel.schema.naming.CustomColumnNamingStrategy;
 
 public class FixedWidthDataContextTest extends TestCase {
 
@@ -220,5 +221,21 @@ public class FixedWidthDataContextTest extends TestCase {
         assertTrue(ds.next());
         assertEquals("[3, howdy, partner]", Arrays.toString(ds.getRow().getValues()));
         assertFalse(ds.next());
+    }
+
+    public void testCustomColumnNames() throws Exception {
+        final String firstColumnName = "first";
+        final String secondColumnName = "second";
+
+        final FixedWidthConfiguration configuration = new FixedWidthConfiguration(
+                FixedWidthConfiguration.DEFAULT_COLUMN_NAME_LINE, new CustomColumnNamingStrategy(firstColumnName,
+                        secondColumnName), "UTF8", new int[] { 10, 10 }, true);
+
+        final DataContext dataContext = new FixedWidthDataContext(new File("src/test/resources/example_simple1.txt"),
+                configuration);
+        final Table table = dataContext.getDefaultSchema().getTable(0);
+
+        assertNotNull(table.getColumnByName(firstColumnName));
+        assertNotNull(table.getColumnByName(secondColumnName));
     }
 }


### PR DESCRIPTION
Fixes METAMODEL-1113.

Added unit tests to the different types of datastores which can make use of the ColumnNamingStrategies mechanism and fixed the CsvConfiguration constructor which takes a ColumnNamingStrategy as an arguments but doesn't assign it to its columnNamingStrategy field.