### PR TITLE
Make it possible to use column naming strategy for EBCDIC files

### DIFF
--- a/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/EbcdicConfiguration.java
+++ b/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/EbcdicConfiguration.java
@@ -18,6 +18,8 @@
  */
 package org.apache.metamodel.fixedwidth;
 
+import org.apache.metamodel.schema.naming.ColumnNamingStrategy;
+
 /**
  * Special fixed-width configuration for EBCDIC files. 
  */
@@ -35,7 +37,12 @@ public final class EbcdicConfiguration extends FixedWidthConfiguration {
 
     public EbcdicConfiguration(int columnNameLineNumber, String encoding, int[] valueWidths,
             boolean failOnInconsistentLineWidth, boolean skipEbcdicHeader, boolean eolPresent) {
-        super(columnNameLineNumber, null, encoding, valueWidths, failOnInconsistentLineWidth);
+        this(columnNameLineNumber, null, encoding, valueWidths, failOnInconsistentLineWidth, skipEbcdicHeader, eolPresent);
+    }
+
+    public EbcdicConfiguration(int columnNameLineNumber, ColumnNamingStrategy columnNamingStrategy, String encoding,
+            int[] valueWidths, boolean failOnInconsistentLineWidth, boolean skipEbcdicHeader, boolean eolPresent) {
+        super(columnNameLineNumber, columnNamingStrategy, encoding, valueWidths, failOnInconsistentLineWidth);
         _skipEbcdicHeader = skipEbcdicHeader;
         _eolPresent = eolPresent;
     }

--- a/fixedwidth/src/test/java/org/apache/metamodel/fixedwidth/EBCDICTest.java
+++ b/fixedwidth/src/test/java/org/apache/metamodel/fixedwidth/EBCDICTest.java
@@ -20,12 +20,15 @@ package org.apache.metamodel.fixedwidth;
 
 import java.io.File;
 
+import org.apache.metamodel.DataContext;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
+import org.apache.metamodel.schema.naming.CustomColumnNamingStrategy;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class EBCDICTest {
     private static final int[] COLUMN_WIDTHS = new int[] { 2, 7, 10, 10 };
@@ -72,6 +75,21 @@ public class EBCDICTest {
                 assertEquals(EXPECTED_ROWS[i], dataSet.getRow().toString());
                 i++;
             }
+        }
+    }
+
+    @Test
+    public void testCustomColumnNames() throws Exception {
+        final String[] columnNames = {"first", "second", "third", "fourth"};
+        final FixedWidthConfiguration configuration = new EbcdicConfiguration(
+                FixedWidthConfiguration.NO_COLUMN_NAME_LINE, new CustomColumnNamingStrategy(columnNames), ENCODING,
+                COLUMN_WIDTHS, false, true, false);
+        final DataContext dataContext = new FixedWidthDataContext(new File(
+                "src/test/resources/fixed-width-2-7-10-10.ebc"), configuration);
+        final Table table = dataContext.getDefaultSchema().getTable(0);
+
+        for (int i = 0; i < columnNames.length; i++) {
+            assertNotNull(table.getColumnByName(columnNames[i]));
         }
     }
 }


### PR DESCRIPTION
Fixes METAMODEL-1114.

Introducing a new EbcdicConfiguration constructor which takes ColumnNamingStrategy as an argument.