### PR TITLE
Demonstrated issue with AVG function and fixed/adapted in JDBC module

### DIFF
--- a/core/src/main/java/org/apache/metamodel/query/AverageAggregateFunction.java
+++ b/core/src/main/java/org/apache/metamodel/query/AverageAggregateFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.metamodel.query;
 
+import org.apache.metamodel.schema.ColumnType;
 import org.apache.metamodel.util.AggregateBuilder;
 
 public class AverageAggregateFunction extends DefaultAggregateFunction<Double> {
@@ -34,4 +35,8 @@ public class AverageAggregateFunction extends DefaultAggregateFunction<Double> {
         return new AverageAggregateBuilder();
     }
 
+    @Override
+    public ColumnType getExpectedColumnType(ColumnType type) {
+        return ColumnType.DOUBLE;
+    }
 }

--- a/core/src/test/java/org/apache/metamodel/query/AverageAggregateFunctionTest.java
+++ b/core/src/test/java/org/apache/metamodel/query/AverageAggregateFunctionTest.java
@@ -18,28 +18,20 @@
  */
 package org.apache.metamodel.query;
 
-import org.apache.metamodel.schema.ColumnType;
-import org.apache.metamodel.util.AggregateBuilder;
+import static org.junit.Assert.assertEquals;
 
-public class SumAggregateFunction extends DefaultAggregateFunction<Double> {
-    
-    private static final long serialVersionUID = 1L;
+import org.apache.metamodel.MockDataContext;
+import org.apache.metamodel.data.DataSet;
+import org.junit.Test;
 
-    @Override
-    public String getFunctionName() {
-        return "SUM";
-    }
+public class AverageAggregateFunctionTest {
 
-    @Override
-    public AggregateBuilder<Double> createAggregateBuilder() {
-        return new SumAggregateBuilder();
-    }
-
-    @Override
-    public ColumnType getExpectedColumnType(ColumnType type) {
-        if (type == ColumnType.BIT || type == ColumnType.INTEGER || type == ColumnType.BIGINT) {
-            return ColumnType.BIGINT;
+    @Test
+    public void testEvaluateAvgOfIntegersWithQueryPostprocessor() throws Exception {
+        final MockDataContext dc = new MockDataContext("sch", "tbl", "foo");
+        try (final DataSet ds = dc.query().from("tbl").select("AVG(foo)", "SUM(foo)", "COUNT(*)").execute()) {
+            ds.next();
+            assertEquals("Row[values=[2.5, 10.0, 4]]", ds.getRow().toString());
         }
-        return ColumnType.DOUBLE;
     }
 }

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataSet.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataSet.java
@@ -31,7 +31,6 @@ import org.apache.metamodel.jdbc.dialects.DefaultQueryRewriter;
 import org.apache.metamodel.jdbc.dialects.IQueryRewriter;
 import org.apache.metamodel.query.Query;
 import org.apache.metamodel.query.SelectItem;
-import org.apache.metamodel.schema.Column;
 import org.apache.metamodel.util.FileHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -145,19 +144,14 @@ final class JdbcDataSet extends AbstractDataSet {
     private Object getValue(ResultSet resultSet, int i) throws SQLException {
         final SelectItem selectItem = getHeader().getSelectItem(i);
         final int columnIndex = i + 1;
-        if (selectItem.getAggregateFunction() == null) {
-            final Column column = selectItem.getColumn();
-            if (column != null) {
-                final IQueryRewriter queryRewriter;
-                if (_jdbcDataContext == null) {
-                    queryRewriter = new DefaultQueryRewriter(null);
-                } else {
-                    queryRewriter = _jdbcDataContext.getQueryRewriter();
-                }
-                return queryRewriter.getResultSetValue(resultSet, columnIndex, column);
-            }
+        selectItem.getExpectedColumnType();
+        final IQueryRewriter queryRewriter;
+        if (_jdbcDataContext == null) {
+            queryRewriter = new DefaultQueryRewriter(null);
+        } else {
+            queryRewriter = _jdbcDataContext.getQueryRewriter();
         }
-        return resultSet.getObject(columnIndex);
+        return queryRewriter.getResultSetValue(resultSet, columnIndex, selectItem);
     }
 
     /**

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/IQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/IQueryRewriter.java
@@ -29,6 +29,7 @@ import org.apache.metamodel.query.FilterItem;
 import org.apache.metamodel.query.FromItem;
 import org.apache.metamodel.query.Query;
 import org.apache.metamodel.query.ScalarFunction;
+import org.apache.metamodel.query.SelectItem;
 import org.apache.metamodel.schema.Column;
 import org.apache.metamodel.schema.ColumnType;
 
@@ -65,15 +66,17 @@ public interface IQueryRewriter {
             final Object value) throws SQLException;
 
     /**
-     * Retrieves a value from a JDBC {@link ResultSet} when the anticipated value is mapped to a particular column.
+     * Retrieves a value from a JDBC {@link ResultSet} when the anticipated
+     * value is mapped to a particular column.
      * 
      * @param resultSet
      * @param columnIndex
-     * @param column
+     * @param selectItem
      * @throws SQLException
      * @return
      */
-    public Object getResultSetValue(ResultSet resultSet, int columnIndex, Column column) throws SQLException;
+    public Object getResultSetValue(ResultSet resultSet, int columnIndex, SelectItem selectItem)
+            throws SQLException;
 
     /**
      * Gets whether this query rewriter is able to write the "Max rows" query

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/JdbcTestTemplates.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/JdbcTestTemplates.java
@@ -332,6 +332,13 @@ public class JdbcTestTemplates {
         assertEquals("Row[values=[2]]", ds.getRow().toString());
         assertFalse(ds.next());
         ds.close();
+        
+        ds = dc.query().from("test_table").select("AVG(id)", "SUM(id)", "COUNT(*)").execute();
+        assertTrue(ds.next());
+        assertEquals("Row[values=[1.5, 3, 2]]", ds.getRow().toString());
+        assertTrue(ds.getRow().getValue(0) instanceof Number);
+        assertFalse(ds.next());
+        ds.close();
 
         dc.executeUpdate(new UpdateScript() {
             @Override


### PR DESCRIPTION
I was looking at METAMODEL-193 because I found it a bit strange that it was reported that e.g. `AVG(an-integer-column)` would always return an integer. After some digging around I realized that this is common RDBMS behaviour. But common or not, it is inconsistent with all the other MetaModel connectors.

So I thought to fix it so that there is consistency: I made it so that the `AVG` function will return a double no matter what. This requires the native SQL to be rewritten slightly to make the RDBMS pick it up. So my fix was to rewrite it into `AVG(1.0*an-integer-column)`. Granted this is a pretty dirty rewrite. So I am curious for review remarks and open for improvement ideas.

Note that this PR does NOT fix METAMODEL-193, but it fixes one of the use-cases causing that issue to be relevant at all.
