### PR TITLE
Fix DefaultCompiledQuery.copyFilterItem

### DIFF
--- a/core/src/main/java/org/apache/metamodel/query/DefaultCompiledQuery.java
+++ b/core/src/main/java/org/apache/metamodel/query/DefaultCompiledQuery.java
@@ -101,7 +101,7 @@ public class DefaultCompiledQuery implements CompiledQuery {
                 final FilterItem newChildItem = copyFilterItem(childItem, values, parameterIndex);
                 newChildItems[i] = newChildItem;
             }
-            final FilterItem newFilter = new FilterItem(newChildItems);
+            final FilterItem newFilter = new FilterItem(item.getLogicalOperator(), newChildItems);
             return newFilter;
         } else {
             if (item.getOperand() instanceof QueryParameter) {


### PR DESCRIPTION
Previous version was missing the use of logical operator while calling FilterItem constructor