### PR TITLE
Added primary key lookup optimization for Apache Cassandra module

### DIFF
--- a/cassandra/.gitignore
+++ b/cassandra/.gitignore
@@ -2,3 +2,4 @@
 /target
 /.classpath
 /.project
+/.toDelete

--- a/cassandra/src/test/java/org/apache/metamodel/cassandra/CassandraDataContextTest.java
+++ b/cassandra/src/test/java/org/apache/metamodel/cassandra/CassandraDataContextTest.java
@@ -32,6 +32,7 @@ import javax.swing.table.TableModel;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.data.DataSetTableModel;
 import org.apache.metamodel.data.FilteredDataSet;
+import org.apache.metamodel.data.InMemoryDataSet;
 import org.apache.metamodel.query.Query;
 import org.apache.metamodel.query.parser.QueryParserException;
 import org.apache.metamodel.schema.ColumnType;
@@ -113,10 +114,25 @@ public class CassandraDataContextTest {
 
     @Test
     public void testWhereColumnEqualsValues() throws Exception {
-        DataSet ds = dc.query().from(testTableName).select("id").and("title").where("id").isEquals(firstRowId)
+        DataSet ds = dc.query().from(testTableName).select("id").and("title").where("title").isEquals(firstRowTitle)
                 .execute();
 
         assertEquals(FilteredDataSet.class, ds.getClass());
+        try {
+            assertTrue(ds.next());
+            assertEquals("Row[values=[" + firstRowId + ", " + firstRowTitle + "]]", ds.getRow().toString());
+            assertFalse(ds.next());
+        } finally {
+            ds.close();
+        }
+    }
+    
+    @Test
+    public void testPrimaryKeyLookup() throws Exception {
+        DataSet ds = dc.query().from(testTableName).select("id").and("title").where("id").isEquals(firstRowId)
+                .execute();
+
+        assertEquals(InMemoryDataSet.class, ds.getClass());
         try {
             assertTrue(ds.next());
             assertEquals("Row[values=[" + firstRowId + ", " + firstRowTitle + "]]", ds.getRow().toString());


### PR DESCRIPTION
I think the PR title says it all ... I was working a bit with Cassandra and found that it was easy (and really missing) in our connector to add optimized support for primary key lookup queries.