### PR TITLE
Improved the query builder API by overloading groupBy and having methods

### DIFF
--- a/core/src/main/java/org/apache/metamodel/query/builder/GroupedQueryBuilder.java
+++ b/core/src/main/java/org/apache/metamodel/query/builder/GroupedQueryBuilder.java
@@ -19,6 +19,7 @@
 package org.apache.metamodel.query.builder;
 
 import org.apache.metamodel.query.FunctionType;
+import org.apache.metamodel.query.SelectItem;
 import org.apache.metamodel.schema.Column;
 
 /**
@@ -28,6 +29,10 @@ public interface GroupedQueryBuilder extends
 		SatisfiedQueryBuilder<GroupedQueryBuilder> {
 
 	public HavingBuilder having(FunctionType functionType, Column column);
+	
+	public HavingBuilder having(SelectItem selectItem);
+	
+	public HavingBuilder having(String columnExpression);
 
 	public SatisfiedOrderByBuilder<GroupedQueryBuilder> orderBy(
 			FunctionType function, Column column);

--- a/core/src/main/java/org/apache/metamodel/query/builder/GroupedQueryBuilderCallback.java
+++ b/core/src/main/java/org/apache/metamodel/query/builder/GroupedQueryBuilderCallback.java
@@ -26,6 +26,7 @@ import org.apache.metamodel.query.FilterItem;
 import org.apache.metamodel.query.FunctionType;
 import org.apache.metamodel.query.Query;
 import org.apache.metamodel.query.ScalarFunction;
+import org.apache.metamodel.query.SelectItem;
 import org.apache.metamodel.schema.Column;
 import org.apache.metamodel.util.BaseObject;
 
@@ -139,6 +140,21 @@ abstract class GroupedQueryBuilderCallback extends BaseObject implements Grouped
     @Override
     public HavingBuilder having(FunctionType functionType, Column column) {
         return getQueryBuilder().having(functionType, column);
+    }
+
+    @Override
+    public HavingBuilder having(String columnExpression) {
+        return getQueryBuilder().having(columnExpression);
+    }
+    
+    @Override
+    public HavingBuilder having(SelectItem selectItem) {
+        return getQueryBuilder().having(selectItem);
+    }
+
+    @Override
+    public GroupedQueryBuilder groupBy(String... columnNames) {
+        return getQueryBuilder().groupBy(columnNames);
     }
 
     @Override

--- a/core/src/main/java/org/apache/metamodel/query/builder/HavingBuilderImpl.java
+++ b/core/src/main/java/org/apache/metamodel/query/builder/HavingBuilderImpl.java
@@ -27,61 +27,59 @@ import org.apache.metamodel.query.Query;
 import org.apache.metamodel.query.SelectItem;
 import org.apache.metamodel.schema.Column;
 
-final class HavingBuilderImpl extends
-		AbstractQueryFilterBuilder<SatisfiedHavingBuilder> implements
-		HavingBuilder, SatisfiedHavingBuilder {
+final class HavingBuilderImpl extends AbstractQueryFilterBuilder<SatisfiedHavingBuilder> implements
+        HavingBuilder,
+        SatisfiedHavingBuilder {
 
-	private final Query _query;
-	private final List<FilterItem> _orFilters;
-	private FilterItem _parentOrFilter;
+    private final Query _query;
+    private final List<FilterItem> _orFilters;
+    private FilterItem _parentOrFilter;
 
-	public HavingBuilderImpl(FunctionType function, Column column, Query query,
-			GroupedQueryBuilder queryBuilder) {
-		super(new SelectItem(function, column), queryBuilder);
-		_query = query;
-		_orFilters = new ArrayList<FilterItem>();
-	}
+    public HavingBuilderImpl(SelectItem selectItem, Query query, GroupedQueryBuilder queryBuilder) {
+        super(selectItem, queryBuilder);
+        _query = query;
+        _orFilters = new ArrayList<FilterItem>();
+    }
 
-	public HavingBuilderImpl(FunctionType function, Column column, Query query,
-			FilterItem parentOrFilter, List<FilterItem> orFilters,
-			GroupedQueryBuilder queryBuilder) {
-		super(new SelectItem(function, column), queryBuilder);
-		_query = query;
-		_orFilters = orFilters;
-		_parentOrFilter = parentOrFilter;
-	}
+    public HavingBuilderImpl(FunctionType function, Column column, Query query, GroupedQueryBuilder queryBuilder) {
+        this(new SelectItem(function, column), query, queryBuilder);
+    }
 
-	@Override
-	protected SatisfiedHavingBuilder applyFilter(FilterItem filter) {
-		if (_parentOrFilter == null) {
-			_query.having(filter);
-		} else {
-			if (_parentOrFilter.getChildItemCount() == 1) {
-				_query.getHavingClause().removeItem(_orFilters.get(0));
-				_query.getHavingClause().addItem(_parentOrFilter);
-			}
-		}
-		_orFilters.add(filter);
-		return this;
-	}
+    public HavingBuilderImpl(FunctionType function, Column column, Query query, FilterItem parentOrFilter,
+            List<FilterItem> orFilters, GroupedQueryBuilder queryBuilder) {
+        this(function, column, query, queryBuilder);
+    }
 
-	@Override
-	public HavingBuilder or(FunctionType function, Column column) {
-		if (function == null) {
-			throw new IllegalArgumentException("function cannot be null");
-		}
-		if (column == null) {
-			throw new IllegalArgumentException("column cannot be null");
-		}
-		if (_parentOrFilter == null) {
-			_parentOrFilter = new FilterItem(_orFilters);
-		}
-		return new HavingBuilderImpl(function, column, _query, _parentOrFilter,
-				_orFilters, getQueryBuilder());
-	}
+    @Override
+    protected SatisfiedHavingBuilder applyFilter(FilterItem filter) {
+        if (_parentOrFilter == null) {
+            _query.having(filter);
+        } else {
+            if (_parentOrFilter.getChildItemCount() == 1) {
+                _query.getHavingClause().removeItem(_orFilters.get(0));
+                _query.getHavingClause().addItem(_parentOrFilter);
+            }
+        }
+        _orFilters.add(filter);
+        return this;
+    }
 
-	@Override
-	public HavingBuilder and(FunctionType function, Column column) {
-		return getQueryBuilder().having(function, column);
-	}
+    @Override
+    public HavingBuilder or(FunctionType function, Column column) {
+        if (function == null) {
+            throw new IllegalArgumentException("function cannot be null");
+        }
+        if (column == null) {
+            throw new IllegalArgumentException("column cannot be null");
+        }
+        if (_parentOrFilter == null) {
+            _parentOrFilter = new FilterItem(_orFilters);
+        }
+        return new HavingBuilderImpl(function, column, _query, _parentOrFilter, _orFilters, getQueryBuilder());
+    }
+
+    @Override
+    public HavingBuilder and(FunctionType function, Column column) {
+        return getQueryBuilder().having(function, column);
+    }
 }

--- a/core/src/main/java/org/apache/metamodel/query/builder/SatisfiedQueryBuilder.java
+++ b/core/src/main/java/org/apache/metamodel/query/builder/SatisfiedQueryBuilder.java
@@ -103,10 +103,12 @@ public interface SatisfiedQueryBuilder<B extends SatisfiedQueryBuilder<?>> {
     public SatisfiedOrderByBuilder<B> orderBy(Column column);
 
     public GroupedQueryBuilder groupBy(String columnName);
+    
+    public GroupedQueryBuilder groupBy(String ... columnNames);
 
     public GroupedQueryBuilder groupBy(Column column);
 
-    public B groupBy(Column... columns);
+    public GroupedQueryBuilder groupBy(Column... columns);
 
     /**
      * Gets the built query as a {@link Query} object. Typically the returned

--- a/core/src/test/java/org/apache/metamodel/query/builder/SyntaxExamplesTest.java
+++ b/core/src/test/java/org/apache/metamodel/query/builder/SyntaxExamplesTest.java
@@ -70,6 +70,11 @@ public class SyntaxExamplesTest extends TestCase {
         dc.query().from(table1).selectCount().select(col1).groupBy(col1).having(FunctionType.SUM, col1).greaterThan(3)
                 .orderBy(col1).asc();
     }
+    
+    public void testMultiGroupByAndHaving() throws Exception {
+        dc.query().from(table1).select("foo", "bar", "COUNT(*)").groupBy("foo","bar").having("COUNT(*)").greaterThan(3)
+                .orderBy(col1).asc();
+    }
 
     public void testMultipleTables() throws Exception {
         Query q = dc.query().from(table1).as("t1").and(table2).as("t2").select(col1).where(col1).greaterThan(col2)


### PR DESCRIPTION
A few minor improvements to the query builder API. I ran into these today while building a bit more complex queries than usual and I was missing the method support for it in MetaModel.

See syntax examples.