### PR TITLE
MSSQL datetime format language neutral

### DIFF
--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/SQLServerQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/SQLServerQueryRewriter.java
@@ -112,7 +112,7 @@ public class SQLServerQueryRewriter extends DefaultQueryRewriter {
 
                 final Date date = (Date) operand;
 
-                final DateFormat format = DateUtils.createDateFormat("yyyy-MM-dd HH:mm:ss");
+                final DateFormat format = DateUtils.createDateFormat("yyyyMMdd HH:mm:ss");
                 final String dateTimeValue = "CAST('" + format.format(date) + "' AS DATETIME)";
 
                 sb.append(dateTimeValue);

--- a/jdbc/src/test/java/org/apache/metamodel/dialects/SQLServerQueryRewriterTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/dialects/SQLServerQueryRewriterTest.java
@@ -87,7 +87,7 @@ public class SQLServerQueryRewriterTest extends TestCase {
                         .toDate("2014-06-28 14:06:00")));
 
         assertEquals(
-                "SELECT MY_SCHEMA.\"foo\".\"bar\", timestamp FROM MY_SCHEMA.\"foo\" WHERE timestamp < CAST('2014-06-28 14:06:00' AS DATETIME)",
+                "SELECT MY_SCHEMA.\"foo\".\"bar\", timestamp FROM MY_SCHEMA.\"foo\" WHERE timestamp < CAST('20140628 14:06:00' AS DATETIME)",
                 qr.rewriteQuery(q));
     }
 

--- a/salesforce/src/main/java/org/apache/metamodel/salesforce/SalesforceTable.java
+++ b/salesforce/src/main/java/org/apache/metamodel/salesforce/SalesforceTable.java
@@ -105,6 +105,7 @@ final class SalesforceTable extends AbstractTable {
         case _int:
             return ColumnType.INTEGER;
         case _double:
+        case currency:
             return ColumnType.DOUBLE;
         case date:
             return ColumnType.DATE;
@@ -120,7 +121,6 @@ final class SalesforceTable extends AbstractTable {
         case textarea:
         case encryptedstring:
         case base64:
-        case currency:
         case id:
         case picklist:
             return ColumnType.VARCHAR;


### PR DESCRIPTION
Currently, creating a date time condition filter, the format is hardcoded yyyy-MM-dd
yyyy-MM-dd for US language setting
yyyy-dd-MM for British settings
yyyy-MMM-dd or yyyyMMdd for universal settings
we would need to change the hardcoded part to yyyyMMdd or yyy-MMM-dd so that it would work on any language settings.
