### PR TITLE
Don't get killed by Hive SQLExceptions when finding default schema name

### DIFF
--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/HiveQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/HiveQueryRewriter.java
@@ -35,6 +35,10 @@ public class HiveQueryRewriter extends DefaultQueryRewriter {
         if (columnType == ColumnType.INTEGER) {
             return "INT";
         }
+        // Hive does not support VARCHAR without a width, nor VARCHAR(MAX).
+        if (columnType == ColumnType.STRING && columnSize == null) {
+            return super.rewriteColumnType(columnType, 65535);
+        }
         return super.rewriteColumnType(columnType, columnSize);
     }
     

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/HiveQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/HiveQueryRewriter.java
@@ -35,8 +35,14 @@ public class HiveQueryRewriter extends DefaultQueryRewriter {
         if (columnType == ColumnType.INTEGER) {
             return "INT";
         }
+
+        if(columnType == ColumnType.STRING) {
+            return "STRING";
+        }
+
         // Hive does not support VARCHAR without a width, nor VARCHAR(MAX).
-        if (columnType == ColumnType.STRING && columnSize == null) {
+        // Returning max allowable column size instead.
+        if (columnType == ColumnType.VARCHAR && columnSize == null) {
             return super.rewriteColumnType(columnType, 65535);
         }
         return super.rewriteColumnType(columnType, columnSize);

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/HiveIntegrationTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/HiveIntegrationTest.java
@@ -18,6 +18,10 @@
  */
 package org.apache.metamodel.jdbc.integrationtests;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
 import org.apache.metamodel.UpdateCallback;
 import org.apache.metamodel.UpdateScript;
 import org.apache.metamodel.create.CreateTable;
@@ -28,12 +32,59 @@ import org.apache.metamodel.jdbc.dialects.HiveQueryRewriter;
 import org.apache.metamodel.schema.ColumnType;
 import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HiveIntegrationTest extends AbstractJdbIntegrationTest {
+    private static final Logger logger = LoggerFactory.getLogger(HiveIntegrationTest.class);
 
     @Override
     protected String getPropertyPrefix() {
         return "hive";
+    }
+
+    private void createSchemas() throws SQLException {
+        Connection connection = getConnection();
+        final Statement st = connection.createStatement();
+        final String createFirstSql = "CREATE SCHEMA IF NOT EXISTS a_metamodel_test";
+        logger.info("SQL updated fired (return {}): {}", st.executeUpdate(createFirstSql), createFirstSql);
+        final String createLastSql = "CREATE SCHEMA IF NOT EXISTS z_metamodel_test";
+        logger.info("SQL updated fired (return {}): {}", st.executeUpdate(createLastSql), createLastSql);
+    }
+
+    private void deleteSchemas() throws SQLException {
+        Connection connection = getConnection();
+        final Statement st = connection.createStatement();
+        final String deleteFirstSql = "DROP SCHEMA IF EXISTS a_metamodel_test";
+        logger.info("SQL updated fired (return {}): {}", st.executeUpdate(deleteFirstSql), deleteFirstSql);
+        final String deleteLastSql = "DROP SCHEMA IF EXISTS z_metamodel_test";
+        logger.info("SQL updated fired (return {}): {}", st.executeUpdate(deleteLastSql), deleteLastSql);
+    }
+
+    public void testDefaultGetSchema() throws Exception {
+        if (!isConfigured()) {
+            return;
+        }
+
+        try {
+            try {
+                createSchemas();
+            } catch (SQLException e) {
+                fail("Schema creation failed");
+            }
+
+            final JdbcDataContext dataContext = getDataContext();
+            final Schema schema = dataContext.getDefaultSchema();
+
+            assertEquals("Schema[name=default]", schema.toString());
+
+        } finally {
+            try {
+                deleteSchemas();
+            } catch (SQLException e) {
+                logger.warn("Weird, couldn't delete test schemas");
+            }
+        }
     }
 
     public void testGetSchema() throws Exception {
@@ -45,7 +96,7 @@ public class HiveIntegrationTest extends AbstractJdbIntegrationTest {
         final Schema schema = dataContext.getSchemaByName("default");
         assertEquals("Schema[name=default]", schema.toString());
     }
-    
+
     public void testUseCorrectRewriter() throws Exception {
         if (!isConfigured()) {
             return;

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/HiveIntegrationTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/HiveIntegrationTest.java
@@ -116,19 +116,19 @@ public class HiveIntegrationTest extends AbstractJdbIntegrationTest {
         final Schema schema = dataContext.getDefaultSchema();
 
         dataContext.executeUpdate(new CreateTable(schema, tableName).withColumn("foo").ofType(ColumnType.STRING)
-                .withColumn("bar").ofType(ColumnType.INTEGER));
+                .withColumn("bar").ofType(ColumnType.INTEGER).withColumn("baz").ofType(ColumnType.VARCHAR));
         try {
             final Table table = dataContext.getTableByQualifiedLabel(tableName);
             assertNotNull(table);
             
             dataContext.executeUpdate(new UpdateScript() {
-                
+
                 @Override
                 public void run(UpdateCallback callback) {
-                    callback.insertInto(table).value("foo", "Hello world").value("bar", 42).execute();
-                    callback.insertInto(table).value("foo", "Lorem ipsum").value("bar", 42).execute();
-                    callback.insertInto(table).value("foo", "Apache").value("bar", 43).execute();
-                    callback.insertInto(table).value("foo", "MetaModel").value("bar", 44).execute();
+                    callback.insertInto(table).value("foo", "Hello world").value("bar", 42).value("baz", "Hive").execute();
+                    callback.insertInto(table).value("foo", "Lorem ipsum").value("bar", 42).value("baz", "Five").execute();
+                    callback.insertInto(table).value("foo", "Apache").value("bar", 43).value("baz", "Live").execute();
+                    callback.insertInto(table).value("foo", "MetaModel").value("bar", 44).value("baz", "Jive").execute();
                 }
             });
             
@@ -140,9 +140,9 @@ public class HiveIntegrationTest extends AbstractJdbIntegrationTest {
             
             final DataSet ds2 = dataContext.query().from(table).selectAll().where("bar").eq(42).execute();
             assertTrue(ds2.next());
-            assertEquals("Row[values=[Hello world, 42]]", ds2.getRow().toString());
+            assertEquals("Row[values=[Hello world, 42, Hive]]", ds2.getRow().toString());
             assertTrue(ds2.next());
-            assertEquals("Row[values=[Lorem ipsum, 42]]", ds2.getRow().toString());
+            assertEquals("Row[values=[Lorem ipsum, 42, Five]]", ds2.getRow().toString());
             assertFalse(ds2.next());
             ds2.close();
         } finally {


### PR DESCRIPTION
This will allow Hive to throw its exceptions while we're trying to determine the default schema name, without that failing.

Also fixes a problem where columns types without a width would fail by specifying maximum allowed column width for VARCHAR types. (Maybe I should have fixed this in another PR, but it broke the Hive integration test, which drove me mad... Let me know if I should split them).

Fixes METAMODEL-1119