### PR TITLE
METAMODEL-63: UnionDataSet

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ### Apache MetaModel 5.0
 
  * [METAMODEL-6] - Added update summary containing information about changes on returning UpdateableDataContext.executeUpdate(..)
- * [METAMODEL-63] - Added UnionDataSet, a general purpose utility for doing client-side unions.
+ * [METAMODEL-63] - Added UnionDataSet, a general purpose utility for doing client-side unions from other queries or data sets.
  * [METAMODEL-222] - Added support for Java 8 lambdas, removed support for Java 7.
  * [METAMODEL-1087] - Removed deprecated APIs from MetaModel's codebase.
  * [METAMODEL-1139] - Employed Java 8 functional types (java.util.function) in favor of (now deprecated) Ref, Action, Func. 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ### Apache MetaModel 5.0
 
  * [METAMODEL-6] - Added update summary containing information about changes on returning UpdateableDataContext.executeUpdate(..)
+ * [METAMODEL-63] - Added UnionDataSet, a general purpose utility for doing client-side unions.
  * [METAMODEL-222] - Added support for Java 8 lambdas, removed support for Java 7.
  * [METAMODEL-1087] - Removed deprecated APIs from MetaModel's codebase.
  * [METAMODEL-1139] - Employed Java 8 functional types (java.util.function) in favor of (now deprecated) Ref, Action, Func. 

--- a/core/src/main/java/org/apache/metamodel/MetaModelHelper.java
+++ b/core/src/main/java/org/apache/metamodel/MetaModelHelper.java
@@ -19,7 +19,6 @@
 package org.apache.metamodel;
 
 import java.util.ArrayList;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -46,7 +45,6 @@ import org.apache.metamodel.data.SimpleDataSetHeader;
 import org.apache.metamodel.data.SubSelectionDataSet;
 import org.apache.metamodel.query.FilterItem;
 import org.apache.metamodel.query.FromItem;
-import org.apache.metamodel.query.FunctionType;
 import org.apache.metamodel.query.GroupByItem;
 import org.apache.metamodel.query.OrderByItem;
 import org.apache.metamodel.query.Query;

--- a/core/src/main/java/org/apache/metamodel/data/AbstractDataSet.java
+++ b/core/src/main/java/org/apache/metamodel/data/AbstractDataSet.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.metamodel.MetaModelHelper;
 import org.apache.metamodel.query.SelectItem;
@@ -60,7 +61,7 @@ public abstract class AbstractDataSet extends BaseObject implements DataSet {
     }
 
     public AbstractDataSet(DataSetHeader header) {
-        _header = header;
+        _header = Objects.requireNonNull(header);
     }
 
     public AbstractDataSet(Column[] columns) {

--- a/core/src/main/java/org/apache/metamodel/data/UnionDataSet.java
+++ b/core/src/main/java/org/apache/metamodel/data/UnionDataSet.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.data;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.apache.metamodel.util.ImmutableRef;
+
+/**
+ * A {@link DataSet} that represents the union of two or more other data sets
+ */
+public class UnionDataSet extends AbstractDataSet {
+
+    private final Iterable<Supplier<DataSet>> _dataSetProviders;
+    private Iterator<Supplier<DataSet>> _iterator;
+    private DataSet _currentDataSet;
+
+    public UnionDataSet(DataSetHeader header, Collection<DataSet> dataSets) {
+        this(header, dataSets.stream().map(ds -> ImmutableRef.of(ds)).collect(Collectors.toList()));
+    }
+
+    public UnionDataSet(DataSetHeader header, Iterable<Supplier<DataSet>> dataSetProviders) {
+        super(header);
+        Objects.nonNull(dataSetProviders);
+        _dataSetProviders = dataSetProviders;
+    }
+
+    @Override
+    public boolean next() {
+        if (_iterator == null) {
+            _iterator = _dataSetProviders.iterator();
+        }
+
+        while (_currentDataSet == null || !_currentDataSet.next()) {
+            if (!_iterator.hasNext()) {
+                _currentDataSet = null;
+                return false;
+            }
+            _currentDataSet = _iterator.next().get();
+            assert getHeader().size() == _currentDataSet.getSelectItems().length;
+        }
+        return true;
+    }
+
+    @Override
+    public Row getRow() {
+        if (_currentDataSet == null) {
+            return null;
+        }
+        return _currentDataSet.getRow();
+    }
+
+}

--- a/core/src/main/java/org/apache/metamodel/query/DefaultInvokableQuery.java
+++ b/core/src/main/java/org/apache/metamodel/query/DefaultInvokableQuery.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.query;
+
+import java.util.Objects;
+
+import org.apache.metamodel.DataContext;
+import org.apache.metamodel.data.DataSet;
+
+/**
+ * Default implementation of {@link InvokableQuery}, based on a ready to go {@link Query} and it's {@link DataContext}.
+ */
+final class DefaultInvokableQuery implements InvokableQuery {
+
+    private final Query _query;
+    private final DataContext _dataContext;
+
+    public DefaultInvokableQuery(Query query, DataContext dataContext) {
+        _query = Objects.requireNonNull(query);
+        _dataContext = Objects.requireNonNull(dataContext);
+    }
+
+    @Override
+    public CompiledQuery compile() {
+        return _dataContext.compileQuery(_query);
+    }
+
+    @Override
+    public DataSet execute() {
+        return _dataContext.executeQuery(_query);
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultInvokableQuery[" + _query + "]";
+    }
+}

--- a/core/src/main/java/org/apache/metamodel/query/InvokableQuery.java
+++ b/core/src/main/java/org/apache/metamodel/query/InvokableQuery.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.query;
+
+import org.apache.metamodel.DataContext;
+import org.apache.metamodel.data.DataSet;
+
+/**
+ * Represents a {@link Query} or query-builder object that's aware of it's {@link DataContext} and is ready to execute
+ * or compile.
+ */
+public interface InvokableQuery {
+
+    /**
+     * Compiles the query
+     * 
+     * @return the {@link CompiledQuery} that is is returned by compiling the query.
+     */
+    public CompiledQuery compile();
+
+    /**
+     * Executes the query.
+     * 
+     * @return the {@link DataSet} that is returned by executing the query.
+     */
+    public DataSet execute();
+}

--- a/core/src/main/java/org/apache/metamodel/query/Query.java
+++ b/core/src/main/java/org/apache/metamodel/query/Query.java
@@ -569,6 +569,10 @@ public final class Query extends BaseObject implements Cloneable, Serializable {
     public Integer getFirstRow() {
         return _firstRow;
     }
+    
+    public InvokableQuery invokable(DataContext dataContext) {
+        return new DefaultInvokableQuery(this, dataContext);
+    }
 
     @Override
     protected void decorateIdentity(List<Object> identifiers) {

--- a/core/src/main/java/org/apache/metamodel/query/builder/SatisfiedQueryBuilder.java
+++ b/core/src/main/java/org/apache/metamodel/query/builder/SatisfiedQueryBuilder.java
@@ -18,12 +18,10 @@
  */
 package org.apache.metamodel.query.builder;
 
-import org.apache.metamodel.DataContext;
-import org.apache.metamodel.data.DataSet;
-import org.apache.metamodel.query.CompiledQuery;
 import org.apache.metamodel.query.FilterItem;
 import org.apache.metamodel.query.FunctionType;
 import org.apache.metamodel.query.Query;
+import org.apache.metamodel.query.InvokableQuery;
 import org.apache.metamodel.query.ScalarFunction;
 import org.apache.metamodel.schema.Column;
 
@@ -33,7 +31,7 @@ import org.apache.metamodel.schema.Column;
  * 
  * @param <B>
  */
-public interface SatisfiedQueryBuilder<B extends SatisfiedQueryBuilder<?>> {
+public interface SatisfiedQueryBuilder<B extends SatisfiedQueryBuilder<?>> extends InvokableQuery {
 
     public ColumnSelectBuilder<B> select(Column column);
 
@@ -118,16 +116,6 @@ public interface SatisfiedQueryBuilder<B extends SatisfiedQueryBuilder<?>> {
      * @return a {@link Query} object representing the built query.
      */
     public Query toQuery();
-
-    public CompiledQuery compile();
-
-    /**
-     * Executes the built query. This call is similar to calling
-     * {@link #toQuery()} and then {@link DataContext#executeQuery(Query)}.
-     * 
-     * @return the {@link DataSet} that is returned by executing the query.
-     */
-    public DataSet execute();
 
     /**
      * Finds a column by name within the already defined FROM items

--- a/core/src/test/java/org/apache/metamodel/data/UnionDataSetTest.java
+++ b/core/src/test/java/org/apache/metamodel/data/UnionDataSetTest.java
@@ -53,7 +53,7 @@ public class UnionDataSetTest {
 
         final DataSetHeader unionHeader =
                 new SimpleDataSetHeader(new Column[] { new MutableColumn("fooUnion"), new MutableColumn("barUnion") });
-        final DataSet unionDataSet = new UnionDataSet(unionHeader, Arrays.asList(ds1, ds2, ds3));
+        final DataSet unionDataSet = UnionDataSet.ofDataSets(unionHeader, Arrays.asList(ds1, ds2, ds3));
         assertTrue(unionDataSet.next());
         assertEquals("Row[values=[1, 2]]", unionDataSet.getRow().toString());
         assertTrue(unionDataSet.next());

--- a/core/src/test/java/org/apache/metamodel/data/UnionDataSetTest.java
+++ b/core/src/test/java/org/apache/metamodel/data/UnionDataSetTest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.apache.metamodel.schema.Column;
+import org.apache.metamodel.schema.MutableColumn;
+import org.junit.Test;
+
+public class UnionDataSetTest {
+
+    @Test
+    public void testVanillaUnion() {
+        // data set 1
+        final DataSetHeader header1 =
+                new SimpleDataSetHeader(new Column[] { new MutableColumn("foo1"), new MutableColumn("bar1") });
+        final Row row1 = new DefaultRow(header1, new Object[] { "1", "2" });
+        final Row row2 = new DefaultRow(header1, new Object[] { "3", "4" });
+        final DataSet ds1 = new InMemoryDataSet(header1, row1, row2);
+
+        // data set 2
+        final DataSetHeader header2 =
+                new SimpleDataSetHeader(new Column[] { new MutableColumn("foo2"), new MutableColumn("bar2") });
+        final Row row3 = new DefaultRow(header2, new Object[] { "5", "6" });
+        final DataSet ds2 = new InMemoryDataSet(header2, row3);
+
+        // data set 3
+        final DataSetHeader header3 =
+                new SimpleDataSetHeader(new Column[] { new MutableColumn("foo3"), new MutableColumn("bar3") });
+        final Row row4 = new DefaultRow(header2, new Object[] { "7", "8" });
+        final DataSet ds3 = new InMemoryDataSet(header3, row4);
+
+        final DataSetHeader unionHeader =
+                new SimpleDataSetHeader(new Column[] { new MutableColumn("fooUnion"), new MutableColumn("barUnion") });
+        final DataSet unionDataSet = new UnionDataSet(unionHeader, Arrays.asList(ds1, ds2, ds3));
+        assertTrue(unionDataSet.next());
+        assertEquals("Row[values=[1, 2]]", unionDataSet.getRow().toString());
+        assertTrue(unionDataSet.next());
+        assertEquals("Row[values=[3, 4]]", unionDataSet.getRow().toString());
+        assertTrue(unionDataSet.next());
+        assertEquals("Row[values=[5, 6]]", unionDataSet.getRow().toString());
+        assertTrue(unionDataSet.next());
+        assertEquals("Row[values=[7, 8]]", unionDataSet.getRow().toString());
+        assertFalse(unionDataSet.next());
+        unionDataSet.close();
+    }
+}


### PR DESCRIPTION
Here's my attempt at designing/solving METAMODEL-63.

Ideally we would support UNION also as part of our Query language. But that seems like a huge change and a much more low-hanging fruit would be to allow unions via a special `DataSet` implementation.

I also introduced a new interface, `InvokableQuery`. I've often had the need to pass around both DataContext and Query (because those two are needed in combination to produce the `DataSet`). The new interface allows passing these around in a more coherent and encapsulated way.