### PR TITLE
METAMODEL-1165: Fixed queries w/o table names (syntax: "FROM tables[0]")

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@
  * [METAMODEL-1151] - Added DataContextFactory classes for instantiating DataContexts of many types based on properties.
  * [METAMODEL-1160] - Fixed bug when deserializing v4.x CsvTable objects
  * [METAMODEL-1163] - Fixed bug when deserializing v4.x MutableRelationship and ImmutableRelationship objects
+ * [METAMODEL-1165] - Added support for querying by table index instead of name, ie. "FROM tables[0]".
 
 ### Apache MetaModel 4.6.0
 

--- a/core/src/main/java/org/apache/metamodel/AbstractDataContext.java
+++ b/core/src/main/java/org/apache/metamodel/AbstractDataContext.java
@@ -387,7 +387,7 @@ public abstract class AbstractDataContext implements DataContext {
         if (tableName == null) {
             return null;
         }
-
+        
         final String[] tokens = tokenizePath(tableName, 2);
         if (tokens != null) {
             Schema schema = getSchemaByToken(tokens[0]);

--- a/core/src/main/java/org/apache/metamodel/schema/AbstractSchema.java
+++ b/core/src/main/java/org/apache/metamodel/schema/AbstractSchema.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.metamodel.util.EqualsBuilder;
@@ -37,6 +39,8 @@ public abstract class AbstractSchema implements Schema {
     private static final long serialVersionUID = 1L;
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractSchema.class);
+
+    private static final Pattern TABLE_ARRAY_TOKEN_PATTERN = Pattern.compile("^tables\\[(\\d+)\\]$");
 
     @Override
     public final String getQuotedName() {
@@ -90,6 +94,12 @@ public abstract class AbstractSchema implements Schema {
     public final Table getTableByName(String tableName) {
         if (tableName == null) {
             return null;
+        }
+        
+        final Matcher tableArrayTokenMatcher = TABLE_ARRAY_TOKEN_PATTERN.matcher(tableName);
+        if (tableArrayTokenMatcher.matches()) {
+            final String indexAsString = tableArrayTokenMatcher.group(1);
+            return getTable(Integer.parseInt(indexAsString));
         }
 
         final List<Table> foundTables = new ArrayList<Table>(1);

--- a/core/src/test/java/org/apache/metamodel/query/parser/QueryParserTest.java
+++ b/core/src/test/java/org/apache/metamodel/query/parser/QueryParserTest.java
@@ -70,6 +70,19 @@ public class QueryParserTest extends TestCase {
                 q.toSql());
     }
 
+    public void testQueryTablesArray() throws Exception {
+        Query q = MetaModelHelper.parseQuery(dc, "select * from tables[0] t");
+        assertEquals("SELECT t.foo, t.bar, t.baz FROM sch.tbl t", q.toSql());
+    }
+    
+    public void testQuerySchemaQualifiedTablesArray() throws Exception {
+        Query q = MetaModelHelper.parseQuery(dc, "select name from information_schema.tables[0] t");
+        assertEquals("SELECT t.name FROM information_schema.tables t", q.toSql());
+        
+        q = MetaModelHelper.parseQuery(dc, "select name from information_schema.tables[1] t");
+        assertEquals("SELECT t.name FROM information_schema.columns t", q.toSql());
+    }
+    
     public void testParseScalarFunctions() throws Exception {
         Query q = MetaModelHelper.parseQuery(dc, "select TO_NUM(a.foo) from sch.tbl a WHERE BOOLEAN(a.bar) = false");
         assertEquals("SELECT TO_NUMBER(a.foo) FROM sch.tbl a WHERE TO_BOOLEAN(a.bar) = FALSE", q.toSql());


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/METAMODEL-1165 by adding a "tables[0]" syntax support