### PR TITLE
array.set() on a new ArrayList() crashes with index out of bound

### DIFF
--- a/salesforce/src/main/java/org/apache/metamodel/salesforce/SalesforceDataContext.java
+++ b/salesforce/src/main/java/org/apache/metamodel/salesforce/SalesforceDataContext.java
@@ -170,7 +170,7 @@ public class SalesforceDataContext extends QueryPostprocessDataContext implement
             final List<Column> columns = new ArrayList<>(selectItems.size());
             for (SelectItem selectItem : selectItems) {
                 validateSoqlSupportedSelectItem(selectItem);
-                columns.set(i,selectItem.getColumn());
+                columns.add(selectItem.getColumn());
                 if (i != 0) {
                     sb.append(", ");
                 }


### PR DESCRIPTION
I'm surprised this works for anyone else, but at least on MacOS JDK 1.8.0_92 having e.g:

List columns = new ArrayList(5);
columns.set(0, "foo");

...crashes with an index out of bounds due to the fact that although the desired capacity of 5 has been specified, the size is zero when set() is called and so it crashes because no element exists at index 0.  See https://stackoverflow.com/questions/8896758/initial-size-for-the-arraylist