### PR TITLE
A new module for Apache Kafka "querying" using MetaModel

### DIFF
--- a/core/src/main/java/org/apache/metamodel/AbstractDataContext.java
+++ b/core/src/main/java/org/apache/metamodel/AbstractDataContext.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.apache.metamodel.annotations.InterfaceStability;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.query.CompiledQuery;
 import org.apache.metamodel.query.DefaultCompiledQuery;
@@ -40,6 +41,7 @@ import org.apache.metamodel.schema.TableType;
  * Abstract implementation of the DataContext interface. Provides convenient implementations of all trivial and
  * datastore-independent methods.
  */
+@InterfaceStability.Evolving
 public abstract class AbstractDataContext implements DataContext {
 
     private static final String NULL_SCHEMA_NAME_TOKEN = "<metamodel.schema.name.null>";

--- a/core/src/main/java/org/apache/metamodel/BatchUpdateScript.java
+++ b/core/src/main/java/org/apache/metamodel/BatchUpdateScript.java
@@ -18,12 +18,15 @@
  */
 package org.apache.metamodel;
 
+import org.apache.metamodel.annotations.InterfaceStability;
+
 /**
  * Indicator sub-interface of {@link UpdateScript}. Implementing your updates
  * using this interface indicates to the underlying
  * {@link UpdateableDataContext} that the update script represents a large batch
  * update and that appropriate optimizations may be taken into use if available.
  */
+@InterfaceStability.Stable
 public interface BatchUpdateScript extends UpdateScript {
 
 }

--- a/core/src/main/java/org/apache/metamodel/DataContext.java
+++ b/core/src/main/java/org/apache/metamodel/DataContext.java
@@ -20,6 +20,7 @@ package org.apache.metamodel;
 
 import java.util.List;
 
+import org.apache.metamodel.annotations.InterfaceStability;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.query.CompiledQuery;
 import org.apache.metamodel.query.Query;
@@ -34,6 +35,7 @@ import org.apache.metamodel.schema.Table;
  * datastores. The DataContext contains of the structure of data (in the form of
  * schemas) and interactions (in the form of queries) with data.
  */
+@InterfaceStability.Stable
 public interface DataContext {
 
     /**

--- a/core/src/main/java/org/apache/metamodel/MetaModelHelper.java
+++ b/core/src/main/java/org/apache/metamodel/MetaModelHelper.java
@@ -769,7 +769,7 @@ public final class MetaModelHelper {
     }
 
     public static SelectItem[] createSelectItems(Column... columns) {
-        SelectItem[] items = new SelectItem[columns.length];
+        final SelectItem[] items = new SelectItem[columns.length];
         for (int i = 0; i < items.length; i++) {
             items[i] = new SelectItem(columns[i]);
         }

--- a/core/src/main/java/org/apache/metamodel/QueryPostprocessDataContext.java
+++ b/core/src/main/java/org/apache/metamodel/QueryPostprocessDataContext.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.metamodel.annotations.InterfaceStability;
 import org.apache.metamodel.convert.ConvertedDataSetInterceptor;
 import org.apache.metamodel.convert.Converters;
 import org.apache.metamodel.convert.HasReadTypeConverters;
@@ -70,6 +71,7 @@ import org.slf4j.LoggerFactory;
  * Instead this superclass only requires that a subclass can materialize a single table at a time. Then the query will
  * be executed by post processing the datasets client-side.
  */
+@InterfaceStability.Evolving
 public abstract class QueryPostprocessDataContext extends AbstractDataContext implements HasReadTypeConverters {
 
     private static final Logger logger = LoggerFactory.getLogger(QueryPostprocessDataContext.class);

--- a/core/src/main/java/org/apache/metamodel/UpdateScript.java
+++ b/core/src/main/java/org/apache/metamodel/UpdateScript.java
@@ -18,6 +18,8 @@
  */
 package org.apache.metamodel;
 
+import org.apache.metamodel.annotations.InterfaceStability;
+
 /**
  * Represents any updating operation or update script that can be executed on a
  * {@link UpdateableDataContext}. Users of MetaModel should implement their own
@@ -26,6 +28,7 @@ package org.apache.metamodel;
  * execution.
  */
 @FunctionalInterface
+@InterfaceStability.Stable
 public interface UpdateScript {
 
 	/**

--- a/core/src/main/java/org/apache/metamodel/UpdateableDataContext.java
+++ b/core/src/main/java/org/apache/metamodel/UpdateableDataContext.java
@@ -18,9 +18,12 @@
  */
 package org.apache.metamodel;
 
+import org.apache.metamodel.annotations.InterfaceStability;
+
 /**
  * Represents a {@link DataContext} that supports updating write-operations.
  */
+@InterfaceStability.Stable
 public interface UpdateableDataContext extends DataContext {
 
     /**

--- a/core/src/main/java/org/apache/metamodel/annotations/InterfaceStability.java
+++ b/core/src/main/java/org/apache/metamodel/annotations/InterfaceStability.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotation to inform users of how much to rely on a particular package, class or method not changing over time.
+ * Currently the stability can be {@link Stable}, {@link Evolving} or {@link Unstable}.
+ */
+@InterfaceStability.Evolving
+public class InterfaceStability {
+
+    /**
+     * Compatibility is maintained in minor and patch releases. Compatibility may only be broken in a major release
+     * (i.e. 0.m), and usually only for APIs that have been deprecated for at least one major/minor release cycle.
+     */
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Stable {
+    }
+
+    /**
+     * Compatibility may be broken at minor release (i.e. m.x).
+     */
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Evolving {
+    }
+
+    /**
+     * No guarantee is provided as to reliability, availability or stability across any level of release granularity.
+     */
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Unstable {
+    }
+}

--- a/core/src/main/java/org/apache/metamodel/data/AbstractDataSet.java
+++ b/core/src/main/java/org/apache/metamodel/data/AbstractDataSet.java
@@ -62,7 +62,6 @@ public abstract class AbstractDataSet extends BaseObject implements DataSet {
         _header = Objects.requireNonNull(header);
     }
 
-
     /**
      * {@inheritDoc}
      */

--- a/core/src/main/java/org/apache/metamodel/query/Query.java
+++ b/core/src/main/java/org/apache/metamodel/query/Query.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.apache.metamodel.DataContext;
 import org.apache.metamodel.MetaModelException;
+import org.apache.metamodel.annotations.InterfaceStability;
 import org.apache.metamodel.query.OrderByItem.Direction;
 import org.apache.metamodel.query.parser.QueryParserException;
 import org.apache.metamodel.query.parser.QueryPartCollectionProcessor;
@@ -64,6 +65,7 @@ import org.apache.metamodel.util.NumberComparator;
  * 
  * @see DataContext
  */
+@InterfaceStability.Stable
 public final class Query extends BaseObject implements Cloneable, Serializable {
 
     private static final long serialVersionUID = -5976325207498574216L;

--- a/core/src/main/java/org/apache/metamodel/schema/Column.java
+++ b/core/src/main/java/org/apache/metamodel/schema/Column.java
@@ -20,12 +20,15 @@ package org.apache.metamodel.schema;
 
 import java.io.Serializable;
 
+import org.apache.metamodel.annotations.InterfaceStability;
+
 /**
  * Represents a column and it's metadata description. Columns reside within a
  * Table and can be used as keys for relationships between tables.
  * 
  * @see Table
  */
+@InterfaceStability.Stable
 public interface Column extends Comparable<Column>, Serializable, NamedStructure {
 
     /**

--- a/core/src/main/java/org/apache/metamodel/schema/ColumnType.java
+++ b/core/src/main/java/org/apache/metamodel/schema/ColumnType.java
@@ -37,11 +37,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import org.apache.metamodel.annotations.InterfaceStability;
 import org.apache.metamodel.util.HasName;
 
 /**
  * Represents the data-type of columns.
  */
+@InterfaceStability.Stable
 public interface ColumnType extends HasName, Serializable {
 
     /*

--- a/core/src/main/java/org/apache/metamodel/schema/Relationship.java
+++ b/core/src/main/java/org/apache/metamodel/schema/Relationship.java
@@ -21,6 +21,8 @@ package org.apache.metamodel.schema;
 import java.io.Serializable;
 import java.util.List;
 
+import org.apache.metamodel.annotations.InterfaceStability;
+
 /**
  * Represents a relationship between two tables where one set of columns is the
  * primary key, and another set is the foreign key.
@@ -28,6 +30,7 @@ import java.util.List;
  * @see Table
  * @see Column
  */
+@InterfaceStability.Stable
 public interface Relationship extends Serializable, Comparable<Relationship> {
 
 	/**

--- a/core/src/main/java/org/apache/metamodel/schema/Schema.java
+++ b/core/src/main/java/org/apache/metamodel/schema/Schema.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.apache.metamodel.DataContext;
+import org.apache.metamodel.annotations.InterfaceStability;
 
 /**
  * Represents a schema and it's metadata description. Schemas represent a
@@ -31,6 +32,7 @@ import org.apache.metamodel.DataContext;
  * @see DataContext
  * @see Table
  */
+@InterfaceStability.Stable
 public interface Schema extends Comparable<Schema>, Serializable, NamedStructure {
 
 	/**

--- a/core/src/main/java/org/apache/metamodel/schema/Table.java
+++ b/core/src/main/java/org/apache/metamodel/schema/Table.java
@@ -22,6 +22,8 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.metamodel.annotations.InterfaceStability;
+
 /**
  * Represents a table and it's metadata description. Tables reside within a
  * schema and contains columns and relationships to other tables.
@@ -29,6 +31,7 @@ import java.util.List;
  * @see Schema
  * @see Column
  */
+@InterfaceStability.Stable
 public interface Table extends Comparable<Table>, Serializable, NamedStructure {
 
     /**

--- a/example-metamodel-integrationtest-configuration.properties
+++ b/example-metamodel-integrationtest-configuration.properties
@@ -45,6 +45,13 @@
 #hbase.zookeeper.hostname=localhost
 #hbase.zookeeper.port=2181
 
+# ------------------------
+# Kafka module properties:
+# ------------------------
+
+#kafka.bootstrap.servers=localhost:9092
+#kafka.topic.prefix=metamodel_test
+
 # -----------------------
 # JDBC module properties:
 # -----------------------

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<parent>
+		<artifactId>MetaModel</artifactId>
+		<groupId>org.apache.metamodel</groupId>
+		<version>5.1.0-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>MetaModel-kafka</artifactId>
+	<name>MetaModel module for Apache Kafka</name>
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.metamodel</groupId>
+			<artifactId>MetaModel-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.kafka</groupId>
+			<artifactId>kafka-clients</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-nop</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -43,5 +43,10 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.easymock</groupId>
+			<artifactId>easymock</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/kafka/pom.xml
+++ b/kafka/pom.xml
@@ -19,6 +19,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>MetaModel-kafka</artifactId>
 	<name>MetaModel module for Apache Kafka</name>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.metamodel</groupId>
@@ -34,7 +35,7 @@
 		<!-- Test dependencies -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-nop</artifactId>
+			<artifactId>slf4j-simple</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/kafka/src/main/java/org/apache/metamodel/kafka/ConsumerAndProducerFactory.java
+++ b/kafka/src/main/java/org/apache/metamodel/kafka/ConsumerAndProducerFactory.java
@@ -19,14 +19,17 @@
 package org.apache.metamodel.kafka;
 
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
 
 /**
- * Factory interface for Kafka {@link Consumer} objects to be used by Apache
- * MetaModel. Since Apache MetaModel may potentially serve multiple queries at
- * the same times, multiple consumers may be needed. This class determines how
- * these are instantiated.
+ * Factory interface for Kafka {@link Consumer} and {@link Producer} objects to
+ * be used by Apache MetaModel. Since Apache MetaModel may potentially serve
+ * multiple queries at the same times, multiple consumers may be needed. This
+ * class determines how these are instantiated.
  */
-public interface ConsumerFactory {
+public interface ConsumerAndProducerFactory {
 
     public <K, V> Consumer<K, V> createConsumer(String topic, Class<K> keyClass, Class<V> valueClass);
+
+    public <K, V> Producer<K, V> createProducer(Class<K> keyClass, Class<V> valueClass);
 }

--- a/kafka/src/main/java/org/apache/metamodel/kafka/ConsumerFactory.java
+++ b/kafka/src/main/java/org/apache/metamodel/kafka/ConsumerFactory.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+
+/**
+ * Factory interface for Kafka {@link Consumer} objects to be used by Apache
+ * MetaModel. Since Apache MetaModel may potentially serve multiple queries at
+ * the same times, multiple consumers may be needed. This class determines how
+ * these are instantiated.
+ */
+public interface ConsumerFactory {
+
+    public <K, V> Consumer<K, V> createConsumer(String topic, Class<K> keyClass, Class<V> valueClass);
+}

--- a/kafka/src/main/java/org/apache/metamodel/kafka/KafkaConsumerAndProducerFactory.java
+++ b/kafka/src/main/java/org/apache/metamodel/kafka/KafkaConsumerAndProducerFactory.java
@@ -24,32 +24,58 @@ import java.util.Properties;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.ByteBufferDeserializer;
+import org.apache.kafka.common.serialization.ByteBufferSerializer;
 import org.apache.kafka.common.serialization.BytesDeserializer;
+import org.apache.kafka.common.serialization.BytesSerializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.DoubleDeserializer;
+import org.apache.kafka.common.serialization.DoubleSerializer;
 import org.apache.kafka.common.serialization.FloatDeserializer;
+import org.apache.kafka.common.serialization.FloatSerializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.ShortDeserializer;
+import org.apache.kafka.common.serialization.ShortSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 
 /**
- * Default {@link ConsumerFactory} implementation.
+ * Default {@link ConsumerAndProducerFactory} implementation.
  */
-public class KafkaConsumerFactory implements ConsumerFactory {
+public class KafkaConsumerAndProducerFactory implements ConsumerAndProducerFactory {
 
     private final Properties baseProperties;
 
-    public KafkaConsumerFactory(String bootstrapServers) {
+    public KafkaConsumerAndProducerFactory(String bootstrapServers) {
         this.baseProperties = new Properties();
         this.baseProperties.setProperty("bootstrap.servers", bootstrapServers);
     }
 
-    public KafkaConsumerFactory(Properties baseProperties) {
+    public KafkaConsumerAndProducerFactory(Properties baseProperties) {
         this.baseProperties = baseProperties;
+    }
+
+    @Override
+    public <K, V> Producer<K, V> createProducer(Class<K> keyClass, Class<V> valueClass) {
+        final Properties properties = new Properties();
+        baseProperties.stringPropertyNames().forEach(k -> {
+            properties.setProperty(k, baseProperties.getProperty(k));
+        });
+
+        properties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, serializerForClass(keyClass).getName());
+        properties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, serializerForClass(keyClass).getName());
+
+        return new KafkaProducer<>(baseProperties);
     }
 
     @Override
@@ -67,6 +93,38 @@ public class KafkaConsumerFactory implements ConsumerFactory {
         properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializerForClass(keyClass)
                 .getName());
         return new KafkaConsumer<>(properties);
+    }
+
+    private static Class<? extends Serializer<?>> serializerForClass(Class<?> cls) {
+        if (cls == String.class || cls == CharSequence.class) {
+            return StringSerializer.class;
+        }
+        if (cls == Double.class) {
+            return DoubleSerializer.class;
+        }
+        if (cls == Integer.class) {
+            return IntegerSerializer.class;
+        }
+        if (cls == Float.class) {
+            return FloatSerializer.class;
+        }
+        if (cls == Long.class) {
+            return LongSerializer.class;
+        }
+        if (cls == Short.class) {
+            return ShortSerializer.class;
+        }
+        if (cls == Bytes.class) {
+            return BytesSerializer.class;
+        }
+        if (cls == ByteBuffer.class) {
+            return ByteBufferSerializer.class;
+        }
+        if (cls == byte[].class || cls == Byte[].class || cls == Object.class) {
+            return ByteArraySerializer.class;
+        }
+        // fall back to doing nothing (byte[])
+        return ByteArraySerializer.class;
     }
 
     private static Class<? extends Deserializer<?>> deserializerForClass(Class<?> cls) {
@@ -97,7 +155,7 @@ public class KafkaConsumerFactory implements ConsumerFactory {
         if (cls == byte[].class || cls == Byte[].class || cls == Object.class) {
             return ByteArrayDeserializer.class;
         }
-        // fall back to doing nothing
+        // fall back to doing nothing (byte[])
         return ByteArrayDeserializer.class;
     }
 

--- a/kafka/src/main/java/org/apache/metamodel/kafka/KafkaConsumerFactory.java
+++ b/kafka/src/main/java/org/apache/metamodel/kafka/KafkaConsumerFactory.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.Properties;
 
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteBufferDeserializer;
@@ -55,10 +56,16 @@ public class KafkaConsumerFactory implements ConsumerFactory {
     public <K, V> Consumer<K, V> createConsumer(String topic, Class<K> keyClass, Class<V> valueClass) {
         final String groupId = "apache_metamodel_" + topic + "_" + System.currentTimeMillis();
 
-        final Properties properties = new Properties(baseProperties);
-        properties.setProperty("group.id", groupId);
-        properties.setProperty("key.deserializer", deserializerForClass(keyClass).getName());
-        properties.setProperty("value.deserializer", deserializerForClass(keyClass).getName());
+        final Properties properties = new Properties();
+        baseProperties.stringPropertyNames().forEach(k -> {
+            properties.setProperty(k, baseProperties.getProperty(k));
+        });
+
+        properties.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        properties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, deserializerForClass(keyClass).getName());
+        properties.setProperty(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializerForClass(keyClass)
+                .getName());
         return new KafkaConsumer<>(properties);
     }
 

--- a/kafka/src/main/java/org/apache/metamodel/kafka/KafkaConsumerFactory.java
+++ b/kafka/src/main/java/org/apache/metamodel/kafka/KafkaConsumerFactory.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.kafka;
+
+import java.nio.ByteBuffer;
+import java.util.Properties;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteBufferDeserializer;
+import org.apache.kafka.common.serialization.BytesDeserializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.DoubleDeserializer;
+import org.apache.kafka.common.serialization.FloatDeserializer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.ShortDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.utils.Bytes;
+
+/**
+ * Default {@link ConsumerFactory} implementation.
+ */
+public class KafkaConsumerFactory implements ConsumerFactory {
+
+    private final Properties baseProperties;
+
+    public KafkaConsumerFactory(String bootstrapServers) {
+        this.baseProperties = new Properties();
+        this.baseProperties.setProperty("bootstrap.servers", bootstrapServers);
+    }
+
+    public KafkaConsumerFactory(Properties baseProperties) {
+        this.baseProperties = baseProperties;
+    }
+
+    @Override
+    public <K, V> Consumer<K, V> createConsumer(String topic, Class<K> keyClass, Class<V> valueClass) {
+        final String groupId = "apache_metamodel_" + topic + "_" + System.currentTimeMillis();
+
+        final Properties properties = new Properties(baseProperties);
+        properties.setProperty("group.id", groupId);
+        properties.setProperty("key.deserializer", deserializerForClass(keyClass).getName());
+        properties.setProperty("value.deserializer", deserializerForClass(keyClass).getName());
+        return new KafkaConsumer<>(properties);
+    }
+
+    private static Class<? extends Deserializer<?>> deserializerForClass(Class<?> cls) {
+        if (cls == String.class || cls == CharSequence.class) {
+            return StringDeserializer.class;
+        }
+        if (cls == Double.class) {
+            return DoubleDeserializer.class;
+        }
+        if (cls == Integer.class) {
+            return IntegerDeserializer.class;
+        }
+        if (cls == Float.class) {
+            return FloatDeserializer.class;
+        }
+        if (cls == Long.class) {
+            return LongDeserializer.class;
+        }
+        if (cls == Short.class) {
+            return ShortDeserializer.class;
+        }
+        if (cls == Bytes.class) {
+            return BytesDeserializer.class;
+        }
+        if (cls == ByteBuffer.class) {
+            return ByteBufferDeserializer.class;
+        }
+        if (cls == byte[].class || cls == Byte[].class || cls == Object.class) {
+            return ByteArrayDeserializer.class;
+        }
+        // fall back to doing nothing
+        return ByteArrayDeserializer.class;
+    }
+
+}

--- a/kafka/src/main/java/org/apache/metamodel/kafka/KafkaDataContext.java
+++ b/kafka/src/main/java/org/apache/metamodel/kafka/KafkaDataContext.java
@@ -18,8 +18,12 @@
  */
 package org.apache.metamodel.kafka;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -29,7 +33,11 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.QueryPostprocessDataContext;
 import org.apache.metamodel.data.DataSet;
+import org.apache.metamodel.data.FirstRowDataSet;
 import org.apache.metamodel.data.MaxRowsDataSet;
+import org.apache.metamodel.query.FilterItem;
+import org.apache.metamodel.query.OperatorType;
+import org.apache.metamodel.query.SelectItem;
 import org.apache.metamodel.schema.Column;
 import org.apache.metamodel.schema.ColumnType;
 import org.apache.metamodel.schema.ColumnTypeImpl;
@@ -48,6 +56,11 @@ public class KafkaDataContext<K, V> extends QueryPostprocessDataContext {
     public static final String COLUMN_TIMESTAMP = "timestamp";
     public static final String COLUMN_KEY = "key";
     public static final String COLUMN_VALUE = "value";
+
+    private static final Set<OperatorType> OPTIMIZED_PARTITION_OPERATORS = new HashSet<>(Arrays.asList(
+            OperatorType.EQUALS_TO, OperatorType.IN));
+    private static final Set<OperatorType> OPTIMIZED_OFFSET_OPERATORS = new HashSet<>(Arrays.asList(
+            OperatorType.GREATER_THAN, OperatorType.GREATER_THAN_OR_EQUAL));
 
     private final Class<K> keyClass;
     private final Class<V> valueClass;
@@ -95,17 +108,148 @@ public class KafkaDataContext<K, V> extends QueryPostprocessDataContext {
         final String topic = table.getName();
         final Consumer<K, V> consumer = consumerFactory.createConsumer(topic, keyClass, valueClass);
         final List<PartitionInfo> partitionInfos = consumer.partitionsFor(topic);
-        List<TopicPartition> partitions = partitionInfos.stream().map(partitionInfo -> {
+        final List<TopicPartition> partitions = partitionInfos.stream().map(partitionInfo -> {
             return new TopicPartition(topic, partitionInfo.partition());
         }).collect(Collectors.toList());
 
-        consumer.seekToBeginning(partitions);
         consumer.assign(partitions);
+        consumer.seekToBeginning(partitions);
 
-        if (maxRows > 0) {
-            return new MaxRowsDataSet(new KafkaDataSet<K, V>(consumer, columns), maxRows);
-        }
-        return new KafkaDataSet<K, V>(consumer, columns);
+        final List<SelectItem> selectItems = columns.stream().map(col -> new SelectItem(col)).collect(Collectors
+                .toList());
+
+        return materializeMainSchemaTableFromConsumer(consumer, selectItems, 0, maxRows);
     }
 
+    protected DataSet materializeMainSchemaTableFromConsumer(Consumer<K, V> consumer, List<SelectItem> selectItems,
+            int offset, int maxRows) {
+        DataSet dataSet = new KafkaDataSet<K, V>(consumer, selectItems);
+        if (offset > 0) {
+            dataSet = new FirstRowDataSet(dataSet, offset);
+        }
+        if (maxRows > 0) {
+            dataSet = new MaxRowsDataSet(dataSet, maxRows);
+        }
+        return dataSet;
+    }
+
+    @Override
+    protected DataSet materializeMainSchemaTable(Table table, List<SelectItem> selectItems, List<FilterItem> whereItems,
+            int firstRow, int maxRows) {
+        // check if we can optimize the consumption when either "partition" or "offset"
+        // are in the where items.
+        if (!whereItems.isEmpty()) {
+            final boolean optimizable = whereItems.stream().allMatch(this::isOptimizable);
+            if (optimizable) {
+                long offset = 0;
+                List<Integer> partitions = null;
+
+                for (FilterItem whereItem : whereItems) {
+                    final OperatorType operator = whereItem.getOperator();
+                    switch (whereItem.getSelectItem().getColumn().getName()) {
+                    case COLUMN_OFFSET:
+                        if (operator == OperatorType.GREATER_THAN) {
+                            offset = toLong(whereItem.getOperand()) + 1;
+                        } else if (operator == OperatorType.GREATER_THAN_OR_EQUAL) {
+                            offset = toLong(whereItem.getOperand());
+                        } else {
+                            throw new UnsupportedOperationException();
+                        }
+                        break;
+                    case COLUMN_PARTITION:
+                        if (operator == OperatorType.EQUALS_TO) {
+                            partitions = Arrays.asList(toInt(whereItem.getOperand()));
+                        } else if (operator == OperatorType.IN) {
+                            partitions = toIntList(whereItem.getOperand());
+                        } else {
+                            throw new UnsupportedOperationException();
+                        }
+                        break;
+                    default:
+                        throw new UnsupportedOperationException();
+                    }
+                }
+
+                final String topic = table.getName();
+                final Consumer<K, V> consumer = consumerFactory.createConsumer(topic, keyClass, valueClass);
+
+                // handle partition filtering
+                final List<TopicPartition> assignedPartitions;
+                if (partitions == null) {
+                    final List<PartitionInfo> partitionInfos = consumer.partitionsFor(topic);
+                    assignedPartitions = partitionInfos.stream().map(partitionInfo -> {
+                        return new TopicPartition(topic, partitionInfo.partition());
+                    }).collect(Collectors.toList());
+                } else {
+                    assignedPartitions = partitions.stream().map(partitionNumber -> {
+                        return new TopicPartition(topic, partitionNumber);
+                    }).collect(Collectors.toList());
+                }
+
+                // handle offset filtering
+                consumer.assign(assignedPartitions);
+                if (offset == 0) {
+                    consumer.seekToBeginning(assignedPartitions);
+                } else {
+                    for (TopicPartition topicPartition : assignedPartitions) {
+                        consumer.seek(topicPartition, offset);
+                    }
+                }
+
+                return materializeMainSchemaTableFromConsumer(consumer, selectItems, firstRow, maxRows);
+            }
+        }
+        return super.materializeMainSchemaTable(table, selectItems, whereItems, firstRow, maxRows);
+    }
+
+    private static List<Integer> toIntList(Object operand) {
+        final List<Integer> list = new ArrayList<>();
+        if (operand instanceof Iterable) {
+            ((Iterable<?>) operand).forEach(o -> {
+                list.add(toInt(o));
+            });
+        }
+        return list;
+    }
+
+    private static int toInt(Object obj) {
+        if (obj instanceof Number) {
+            return ((Number) obj).intValue();
+        }
+        return Integer.parseInt(obj.toString());
+    }
+
+    private static long toLong(Object obj) {
+        if (obj instanceof Number) {
+            return ((Number) obj).longValue();
+        }
+        return Long.parseLong(obj.toString());
+    }
+
+    private boolean isOptimizable(FilterItem whereItem) {
+        if (whereItem.isCompoundFilter()) {
+            return false;
+        }
+        if (whereItem.getExpression() != null) {
+            return false;
+        }
+        final SelectItem selectItem = whereItem.getSelectItem();
+        if (selectItem.getExpression() != null || selectItem.getAggregateFunction() != null || selectItem
+                .getScalarFunction() != null) {
+            return false;
+        }
+        final Column column = selectItem.getColumn();
+        if (column == null) {
+            return false;
+        }
+
+        switch (column.getName()) {
+        case COLUMN_OFFSET:
+            return OPTIMIZED_OFFSET_OPERATORS.contains(whereItem.getOperator());
+        case COLUMN_PARTITION:
+            return OPTIMIZED_PARTITION_OPERATORS.contains(whereItem.getOperator());
+        default:
+            return false;
+        }
+    }
 }

--- a/kafka/src/main/java/org/apache/metamodel/kafka/KafkaDataContext.java
+++ b/kafka/src/main/java/org/apache/metamodel/kafka/KafkaDataContext.java
@@ -36,6 +36,7 @@ import org.apache.metamodel.QueryPostprocessDataContext;
 import org.apache.metamodel.UpdateScript;
 import org.apache.metamodel.UpdateSummary;
 import org.apache.metamodel.UpdateableDataContext;
+import org.apache.metamodel.annotations.InterfaceStability;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.data.FirstRowDataSet;
 import org.apache.metamodel.data.MaxRowsDataSet;
@@ -51,6 +52,7 @@ import org.apache.metamodel.schema.MutableTable;
 import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
 
+@InterfaceStability.Unstable
 public class KafkaDataContext<K, V> extends QueryPostprocessDataContext implements UpdateableDataContext {
 
     public static final String SYSTEM_PROPERTY_CONSUMER_POLL_TIMEOUT = "metamodel.kafka.consumer.poll.timeout";

--- a/kafka/src/main/java/org/apache/metamodel/kafka/KafkaDataContext.java
+++ b/kafka/src/main/java/org/apache/metamodel/kafka/KafkaDataContext.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.kafka;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.metamodel.MetaModelException;
+import org.apache.metamodel.QueryPostprocessDataContext;
+import org.apache.metamodel.data.DataSet;
+import org.apache.metamodel.data.MaxRowsDataSet;
+import org.apache.metamodel.schema.Column;
+import org.apache.metamodel.schema.ColumnType;
+import org.apache.metamodel.schema.ColumnTypeImpl;
+import org.apache.metamodel.schema.MutableColumn;
+import org.apache.metamodel.schema.MutableSchema;
+import org.apache.metamodel.schema.MutableTable;
+import org.apache.metamodel.schema.Schema;
+import org.apache.metamodel.schema.Table;
+
+public class KafkaDataContext<K, V> extends QueryPostprocessDataContext {
+
+    public static final String SYSTEM_PROPERTY_CONSUMER_POLL_TIMEOUT = "metamodel.kafka.consumer.poll.timeout";
+
+    public static final String COLUMN_PARTITION = "partition";
+    public static final String COLUMN_OFFSET = "offset";
+    public static final String COLUMN_TIMESTAMP = "timestamp";
+    public static final String COLUMN_KEY = "key";
+    public static final String COLUMN_VALUE = "value";
+
+    private final Class<K> keyClass;
+    private final Class<V> valueClass;
+    private final ConsumerFactory consumerFactory;
+    private final Supplier<Collection<String>> topicSupplier;
+
+    public KafkaDataContext(Class<K> keyClass, Class<V> valueClass, String bootstrapServers,
+            Collection<String> topics) {
+        this(keyClass, valueClass, new KafkaConsumerFactory(bootstrapServers), () -> topics);
+    }
+
+    public KafkaDataContext(Class<K> keyClass, Class<V> valueClass, ConsumerFactory consumerFactory,
+            Supplier<Collection<String>> topicSupplier) {
+        this.keyClass = keyClass;
+        this.valueClass = valueClass;
+        this.consumerFactory = consumerFactory;
+        this.topicSupplier = topicSupplier;
+    }
+
+    @Override
+    protected Schema getMainSchema() throws MetaModelException {
+        final MutableSchema schema = new MutableSchema(getMainSchemaName());
+
+        final Collection<String> topics = topicSupplier.get();
+
+        for (String topic : topics) {
+            final MutableTable table = new MutableTable(topic, schema);
+            table.addColumn(new MutableColumn(COLUMN_PARTITION, ColumnType.INTEGER));
+            table.addColumn(new MutableColumn(COLUMN_OFFSET, ColumnType.BIGINT));
+            table.addColumn(new MutableColumn(COLUMN_TIMESTAMP, ColumnType.TIMESTAMP));
+            table.addColumn(new MutableColumn(COLUMN_KEY, ColumnTypeImpl.convertColumnType(keyClass)));
+            table.addColumn(new MutableColumn(COLUMN_VALUE, ColumnTypeImpl.convertColumnType(valueClass)));
+            schema.addTable(table);
+        }
+        return schema;
+    }
+
+    @Override
+    protected String getMainSchemaName() throws MetaModelException {
+        return "kafka";
+    }
+
+    @Override
+    protected DataSet materializeMainSchemaTable(Table table, List<Column> columns, int maxRows) {
+        final String topic = table.getName();
+        final Consumer<K, V> consumer = consumerFactory.createConsumer(topic, keyClass, valueClass);
+        final List<PartitionInfo> partitionInfos = consumer.partitionsFor(topic);
+        List<TopicPartition> partitions = partitionInfos.stream().map(partitionInfo -> {
+            return new TopicPartition(topic, partitionInfo.partition());
+        }).collect(Collectors.toList());
+
+        consumer.seekToBeginning(partitions);
+        consumer.assign(partitions);
+
+        if (maxRows > 0) {
+            return new MaxRowsDataSet(new KafkaDataSet<K, V>(consumer, columns), maxRows);
+        }
+        return new KafkaDataSet<K, V>(consumer, columns);
+    }
+
+}

--- a/kafka/src/main/java/org/apache/metamodel/kafka/KafkaDataContext.java
+++ b/kafka/src/main/java/org/apache/metamodel/kafka/KafkaDataContext.java
@@ -203,6 +203,12 @@ public class KafkaDataContext<K, V> extends QueryPostprocessDataContext {
     }
 
     private static List<Integer> toIntList(Object operand) {
+        if (operand == null) {
+            return null;
+        }
+        if (operand.getClass().isArray()) {
+            operand = Arrays.asList((Object[]) operand);
+        }
         final List<Integer> list = new ArrayList<>();
         if (operand instanceof Iterable) {
             ((Iterable<?>) operand).forEach(o -> {

--- a/kafka/src/main/java/org/apache/metamodel/kafka/KafkaDataSet.java
+++ b/kafka/src/main/java/org/apache/metamodel/kafka/KafkaDataSet.java
@@ -20,7 +20,6 @@ package org.apache.metamodel.kafka;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -30,7 +29,6 @@ import org.apache.metamodel.data.CachingDataSetHeader;
 import org.apache.metamodel.data.DefaultRow;
 import org.apache.metamodel.data.Row;
 import org.apache.metamodel.query.SelectItem;
-import org.apache.metamodel.schema.Column;
 
 final class KafkaDataSet<K, V> extends AbstractDataSet {
 
@@ -40,11 +38,15 @@ final class KafkaDataSet<K, V> extends AbstractDataSet {
     private Iterator<ConsumerRecord<K, V>> currentIterator;
     private ConsumerRecord<K, V> currentRow;
 
-    public KafkaDataSet(Consumer<K, V> consumer, List<Column> columns) {
-        super(new CachingDataSetHeader(columns.stream().map(col -> new SelectItem(col)).collect(Collectors.toList())));
+    public KafkaDataSet(Consumer<K, V> consumer, List<SelectItem> selectItems) {
+        super(new CachingDataSetHeader(selectItems));
         this.consumer = consumer;
         this.pollTimeout = Long.parseLong(System.getProperty(KafkaDataContext.SYSTEM_PROPERTY_CONSUMER_POLL_TIMEOUT,
                 "1000"));
+    }
+    
+    public Consumer<K, V> getConsumer() {
+        return consumer;
     }
 
     @Override

--- a/kafka/src/main/java/org/apache/metamodel/kafka/KafkaDataSet.java
+++ b/kafka/src/main/java/org/apache/metamodel/kafka/KafkaDataSet.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.kafka;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.metamodel.data.AbstractDataSet;
+import org.apache.metamodel.data.CachingDataSetHeader;
+import org.apache.metamodel.data.DefaultRow;
+import org.apache.metamodel.data.Row;
+import org.apache.metamodel.query.SelectItem;
+import org.apache.metamodel.schema.Column;
+
+final class KafkaDataSet<K, V> extends AbstractDataSet {
+
+    private final Consumer<K, V> consumer;
+    private final long pollTimeout;
+
+    private Iterator<ConsumerRecord<K, V>> currentIterator;
+    private ConsumerRecord<K, V> currentRow;
+
+    public KafkaDataSet(Consumer<K, V> consumer, List<Column> columns) {
+        super(new CachingDataSetHeader(columns.stream().map(col -> new SelectItem(col)).collect(Collectors.toList())));
+        this.consumer = consumer;
+        this.pollTimeout = Long.parseLong(System.getProperty(KafkaDataContext.SYSTEM_PROPERTY_CONSUMER_POLL_TIMEOUT,
+                "1000"));
+    }
+
+    @Override
+    public boolean next() {
+        if (currentIterator == null || !currentIterator.hasNext()) {
+            final ConsumerRecords<K, V> records = consumer.poll(pollTimeout);
+            if (records == null || records.isEmpty()) {
+                return false;
+            }
+            currentIterator = records.iterator();
+        }
+
+        this.currentRow = currentIterator.next();
+        if (currentRow == null) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public Row getRow() {
+        final Object[] values = getHeader().getSelectItems().stream().map(this::getValue).toArray();
+
+        return new DefaultRow(getHeader(), values);
+    }
+
+    private Object getValue(SelectItem selectItem) {
+        if (currentRow == null) {
+            return null;
+        }
+        switch (selectItem.getColumn().getName()) {
+        case KafkaDataContext.COLUMN_PARTITION:
+            return currentRow.partition();
+        case KafkaDataContext.COLUMN_OFFSET:
+            return currentRow.offset();
+        case KafkaDataContext.COLUMN_TIMESTAMP:
+            return currentRow.timestamp();
+        case KafkaDataContext.COLUMN_KEY:
+            return currentRow.key();
+        case KafkaDataContext.COLUMN_VALUE:
+            return currentRow.value();
+        }
+        return null;
+    }
+
+    @Override
+    public void close() {
+        super.close();
+        currentRow = null;
+        consumer.unsubscribe();
+        consumer.close();
+    }
+}

--- a/kafka/src/main/java/org/apache/metamodel/kafka/KafkaInsertBuilder.java
+++ b/kafka/src/main/java/org/apache/metamodel/kafka/KafkaInsertBuilder.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.kafka;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.metamodel.MetaModelException;
+import org.apache.metamodel.insert.AbstractRowInsertionBuilder;
+import org.apache.metamodel.schema.Column;
+import org.apache.metamodel.schema.Table;
+
+final class KafkaInsertBuilder<K, V> extends AbstractRowInsertionBuilder<KafkaUpdateCallback<K, V>> {
+
+    public KafkaInsertBuilder(KafkaUpdateCallback<K, V> updateCallback, Table table) {
+        super(updateCallback, table);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void execute() throws MetaModelException {
+        final Column[] columns = getColumns();
+        final Object[] values = getValues();
+
+        K key = null;
+        V value = null;
+
+        for (int i = 0; i < columns.length; i++) {
+            if (columns[i].getName() == KafkaDataContext.COLUMN_KEY) {
+                key = (K) values[i];
+            }
+            if (columns[i].getName() == KafkaDataContext.COLUMN_VALUE) {
+                value = (V) values[i];
+            }
+        }
+
+        getUpdateCallback().getProducer().send(new ProducerRecord<K, V>(getTable().getName(), key, value));
+    }
+
+}

--- a/kafka/src/main/java/org/apache/metamodel/kafka/KafkaUpdateCallback.java
+++ b/kafka/src/main/java/org/apache/metamodel/kafka/KafkaUpdateCallback.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.kafka;
+
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.metamodel.AbstractUpdateCallback;
+import org.apache.metamodel.create.TableCreationBuilder;
+import org.apache.metamodel.delete.RowDeletionBuilder;
+import org.apache.metamodel.drop.TableDropBuilder;
+import org.apache.metamodel.insert.RowInsertionBuilder;
+import org.apache.metamodel.schema.Schema;
+import org.apache.metamodel.schema.Table;
+
+final class KafkaUpdateCallback<K, V> extends AbstractUpdateCallback {
+
+    private final Producer<K, V> producer;
+
+    public KafkaUpdateCallback(KafkaDataContext<K, V> kafkaDataContext, Producer<K, V> producer) {
+        super(kafkaDataContext);
+        this.producer = producer;
+    }
+
+    @Override
+    public TableCreationBuilder createTable(Schema schema, String name) throws IllegalArgumentException,
+            IllegalStateException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isDropTableSupported() {
+        return false;
+    }
+
+    @Override
+    public TableDropBuilder dropTable(Table table) throws IllegalArgumentException, IllegalStateException,
+            UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RowInsertionBuilder insertInto(Table table) throws IllegalArgumentException, IllegalStateException,
+            UnsupportedOperationException {
+        return new KafkaInsertBuilder<>(this, table);
+    }
+
+    @Override
+    public boolean isDeleteSupported() {
+        return false;
+    }
+
+    @Override
+    public RowDeletionBuilder deleteFrom(Table table) throws IllegalArgumentException, IllegalStateException,
+            UnsupportedOperationException {
+        throw new UnsupportedOperationException();
+    }
+    
+    public Producer<K, V> getProducer() {
+        return producer;
+    }
+
+    public void flush() {
+        producer.flush();
+    }
+
+    public void close() {
+        producer.close();
+    }
+
+}

--- a/kafka/src/test/java/org/apache/metamodel/kafka/KafkaDataContextIntegrationTest.java
+++ b/kafka/src/test/java/org/apache/metamodel/kafka/KafkaDataContextIntegrationTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.metamodel.kafka;
 
 import java.util.Arrays;

--- a/kafka/src/test/java/org/apache/metamodel/kafka/KafkaDataContextIntegrationTest.java
+++ b/kafka/src/test/java/org/apache/metamodel/kafka/KafkaDataContextIntegrationTest.java
@@ -1,0 +1,156 @@
+package org.apache.metamodel.kafka;
+
+import java.util.Arrays;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.metamodel.DataContext;
+import org.apache.metamodel.data.DataSet;
+import org.apache.metamodel.data.WrappingDataSet;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KafkaDataContextIntegrationTest {
+
+    private static final String BOOTSTRAP_SERVERS = "localhost:9092";
+    private static final Logger logger = LoggerFactory.getLogger(KafkaDataContextIntegrationTest.class);
+
+    @Test
+    public void testGetSchemaInfo() {
+        final DataContext dataContext1 = new KafkaDataContext<>(String.class, String.class, BOOTSTRAP_SERVERS, Arrays
+                .asList("non-existing-topic"));
+
+        Assert.assertEquals("[non-existing-topic, default_table]", dataContext1.getDefaultSchema().getTableNames()
+                .toString());
+
+        final DataContext dataContext2 = new KafkaDataContext<>(String.class, String.class, BOOTSTRAP_SERVERS, Arrays
+                .asList("test1", "test2", "test3"));
+        Assert.assertEquals("[test1, test2, test3]", dataContext2.getDefaultSchema().getTableNames().toString());
+    }
+
+    @Test
+    public void testQueryNoFilters() {
+        final String topic = "test_" + UUID.randomUUID().toString().replaceAll("\\-", "");
+
+        final DataContext dataContext = new KafkaDataContext<>(String.class, String.class, BOOTSTRAP_SERVERS, Arrays
+                .asList(topic));
+
+        Assert.assertEquals("[" + topic + ", default_table]", dataContext.getDefaultSchema().getTableNames()
+                .toString());
+
+        final int numRecords = 10000;
+
+        // create a producer thread
+        new Thread(createProducerRunnable(topic, numRecords), "producer").start();
+
+        int counter = 0;
+        try (DataSet dataSet = dataContext.query().from(topic).selectAll().execute()) {
+            logger.info("c: starting");
+            while (dataSet.next()) {
+                counter++;
+                if (counter % 1000 == 0) {
+                    logger.info("c: " + counter);
+                    logger.info(dataSet.getRow().toString());
+                }
+            }
+            logger.info("c: done - " + counter);
+        }
+
+        Assert.assertEquals(numRecords, counter);
+    }
+
+    @Test
+    public void testQueryUsingOffset() throws InterruptedException {
+        final String topic = "test_" + UUID.randomUUID().toString().replaceAll("\\-", "");
+
+        final DataContext dataContext = new KafkaDataContext<>(String.class, String.class, BOOTSTRAP_SERVERS, Arrays
+                .asList(topic));
+
+        final int numRecords = 1000;
+        final int queriedOffset = 500;
+
+        // create a producer thread
+        final Thread thread = new Thread(createProducerRunnable(topic, numRecords), "producer");
+        thread.start();
+        thread.join(); // await completion so that the queried offset will exist at query time
+
+        int counter = 0;
+        try (DataSet dataSet = dataContext.query().from(topic).selectAll().where("offset").gt(queriedOffset)
+                .execute()) {
+
+            // check the assignment and position created for the consumer
+            @SuppressWarnings("resource")
+            DataSet innerDataSet = dataSet;
+            if (innerDataSet instanceof WrappingDataSet) {
+                innerDataSet = ((WrappingDataSet) dataSet).getWrappedDataSet();
+            }
+            Assert.assertTrue(innerDataSet instanceof KafkaDataSet);
+            final Consumer<?, ?> consumer = ((KafkaDataSet<?, ?>) innerDataSet).getConsumer();
+            final Set<TopicPartition> assignment = consumer.assignment();
+            for (TopicPartition assignedTopic : assignment) {
+                final long position = consumer.position(assignedTopic);
+                Assert.assertEquals(queriedOffset + 1, position);
+            }
+
+            while (dataSet.next()) {
+                counter++;
+            }
+        }
+
+        // offset is 0 based, so "greater than 500" will leave 499 records
+        Assert.assertEquals(499, counter);
+    }
+
+    private Runnable createProducerRunnable(String topic, int numRecords) {
+        return new Runnable() {
+            @Override
+            public void run() {
+                final Properties properties = new Properties();
+                properties.setProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS);
+                properties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+                properties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+                properties.setProperty(ProducerConfig.CLIENT_ID_CONFIG, "metamodel-test");
+
+                final KafkaProducer<String, String> producer = new KafkaProducer<String, String>(properties);
+                int counter = 0;
+                while (counter < numRecords) {
+                    final String key = UUID.randomUUID().toString();
+                    final String value = UUID.randomUUID().toString();
+                    try {
+                        producer.send(new ProducerRecord<String, String>(topic, key, value), new Callback() {
+                            @Override
+                            public void onCompletion(RecordMetadata metadata, Exception exception) {
+                                if (exception != null) {
+                                    logger.info("Callback error");
+                                    exception.printStackTrace();
+                                }
+                            }
+                        });
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        break;
+                    }
+                    if (counter % 1000 == 0) {
+                        logger.info("p: " + counter);
+                    }
+                    counter++;
+                }
+                logger.info("p: closing - " + counter);
+                producer.flush();
+                producer.close();
+                logger.info("p: done - " + counter);
+            }
+        };
+    }
+}

--- a/kafka/src/test/java/org/apache/metamodel/kafka/KafkaDataContextTest.java
+++ b/kafka/src/test/java/org/apache/metamodel/kafka/KafkaDataContextTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.metamodel.kafka;
 
 import java.util.ArrayList;

--- a/kafka/src/test/java/org/apache/metamodel/kafka/KafkaDataContextTest.java
+++ b/kafka/src/test/java/org/apache/metamodel/kafka/KafkaDataContextTest.java
@@ -25,7 +25,7 @@ public class KafkaDataContextTest extends EasyMockSupport {
 
     @Test
     public void testGetSchemaInfo() {
-        final ConsumerFactory consumerFactory = createMock(ConsumerFactory.class);
+        final ConsumerAndProducerFactory consumerFactory = createMock(ConsumerAndProducerFactory.class);
 
         replayAll();
 
@@ -39,7 +39,7 @@ public class KafkaDataContextTest extends EasyMockSupport {
 
     @Test
     public void testQueryWithoutOptimization() {
-        final ConsumerFactory consumerFactory = createMock(ConsumerFactory.class);
+        final ConsumerAndProducerFactory consumerFactory = createMock(ConsumerAndProducerFactory.class);
         @SuppressWarnings("unchecked")
         final Consumer<String, String> consumer = createMock(Consumer.class);
 
@@ -94,7 +94,7 @@ public class KafkaDataContextTest extends EasyMockSupport {
 
     @Test
     public void testQueryOptimizationByPartition() {
-        final ConsumerFactory consumerFactory = createMock(ConsumerFactory.class);
+        final ConsumerAndProducerFactory consumerFactory = createMock(ConsumerAndProducerFactory.class);
         @SuppressWarnings("unchecked")
         final Consumer<String, String> consumer = createMock(Consumer.class);
 

--- a/kafka/src/test/java/org/apache/metamodel/kafka/KafkaDataContextTest.java
+++ b/kafka/src/test/java/org/apache/metamodel/kafka/KafkaDataContextTest.java
@@ -1,0 +1,154 @@
+package org.apache.metamodel.kafka;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.metamodel.DataContext;
+import org.apache.metamodel.data.DataSet;
+import org.easymock.Capture;
+import org.easymock.EasyMock;
+import org.easymock.EasyMockSupport;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class KafkaDataContextTest extends EasyMockSupport {
+
+    @Test
+    public void testGetSchemaInfo() {
+        final ConsumerFactory consumerFactory = createMock(ConsumerFactory.class);
+
+        replayAll();
+
+        final Supplier<Collection<String>> topicSupplier = () -> Arrays.asList("foo", "bar");
+        final DataContext dc = new KafkaDataContext<>(String.class, String.class, consumerFactory, topicSupplier);
+
+        verifyAll();
+
+        Assert.assertEquals("[foo, bar]", dc.getDefaultSchema().getTableNames().toString());
+    }
+
+    @Test
+    public void testQueryWithoutOptimization() {
+        final ConsumerFactory consumerFactory = createMock(ConsumerFactory.class);
+        @SuppressWarnings("unchecked")
+        final Consumer<String, String> consumer = createMock(Consumer.class);
+
+        EasyMock.expect(consumerFactory.createConsumer("myTopic", String.class, String.class)).andReturn(consumer);
+
+        final List<PartitionInfo> partitionInfoList = new ArrayList<>();
+        partitionInfoList.add(new PartitionInfo("myTopic", 0, null, null, null));
+        partitionInfoList.add(new PartitionInfo("myTopic", 1, null, null, null));
+        partitionInfoList.add(new PartitionInfo("myTopic", 2, null, null, null));
+        partitionInfoList.add(new PartitionInfo("myTopic", 3, null, null, null));
+
+        EasyMock.expect(consumer.partitionsFor("myTopic")).andReturn(partitionInfoList);
+
+        final Capture<Collection<TopicPartition>> assignmentCapture = new Capture<>();
+        consumer.assign(EasyMock.capture(assignmentCapture));
+        consumer.seekToBeginning(EasyMock.anyObject());
+
+        final ConsumerRecords<String, String> consumerRecords1 = createConsumerRecords(1, 0, 10);
+        final ConsumerRecords<String, String> consumerRecords2 = createConsumerRecords(2, 20, 10);
+
+        EasyMock.expect(consumer.poll(1000)).andReturn(consumerRecords1);
+        EasyMock.expect(consumer.poll(1000)).andReturn(consumerRecords2);
+        EasyMock.expect(consumer.poll(1000)).andReturn(null);
+
+        consumer.unsubscribe();
+        consumer.close();
+
+        replayAll();
+
+        final Supplier<Collection<String>> topicSupplier = () -> Arrays.asList("myTopic");
+        final DataContext dc = new KafkaDataContext<>(String.class, String.class, consumerFactory, topicSupplier);
+
+        final DataSet dataSet = dc.query().from("myTopic").select("partition", "offset", "value").where("key").eq(
+                "key2").execute();
+        Assert.assertTrue(dataSet.next());
+        Assert.assertEquals("Row[values=[1, 2, value2]]", dataSet.getRow().toString());
+        Assert.assertTrue(dataSet.next());
+        Assert.assertEquals("Row[values=[2, 22, value2]]", dataSet.getRow().toString());
+        Assert.assertFalse(dataSet.next());
+        dataSet.close();
+
+        verifyAll();
+
+        // assert that we assigned exactly the three partitions we queried for
+        final ArrayList<TopicPartition> capturedAssignmentList = new ArrayList<>(assignmentCapture.getValue());
+        Assert.assertEquals(4, capturedAssignmentList.size());
+        Assert.assertEquals(0, capturedAssignmentList.get(0).partition());
+        Assert.assertEquals(1, capturedAssignmentList.get(1).partition());
+        Assert.assertEquals(2, capturedAssignmentList.get(2).partition());
+        Assert.assertEquals(3, capturedAssignmentList.get(3).partition());
+    }
+
+    @Test
+    public void testQueryOptimizationByPartition() {
+        final ConsumerFactory consumerFactory = createMock(ConsumerFactory.class);
+        @SuppressWarnings("unchecked")
+        final Consumer<String, String> consumer = createMock(Consumer.class);
+
+        EasyMock.expect(consumerFactory.createConsumer("myTopic", String.class, String.class)).andReturn(consumer);
+
+        final Capture<Collection<TopicPartition>> assignmentCapture = new Capture<>();
+        consumer.assign(EasyMock.capture(assignmentCapture));
+        consumer.seekToBeginning(EasyMock.anyObject());
+
+        final ConsumerRecords<String, String> consumerRecords1 = createConsumerRecords(1, 0, 2);
+        final ConsumerRecords<String, String> consumerRecords2 = createConsumerRecords(2, 20, 1);
+
+        EasyMock.expect(consumer.poll(1000)).andReturn(consumerRecords1);
+        EasyMock.expect(consumer.poll(1000)).andReturn(consumerRecords2);
+        EasyMock.expect(consumer.poll(1000)).andReturn(null);
+
+        consumer.unsubscribe();
+        consumer.close();
+
+        replayAll();
+
+        final Supplier<Collection<String>> topicSupplier = () -> Arrays.asList("myTopic");
+        final DataContext dc = new KafkaDataContext<>(String.class, String.class, consumerFactory, topicSupplier);
+
+        final DataSet dataSet = dc.query().from("myTopic").select("offset", "value").where("partition").in(1, 2, 42)
+                .execute();
+        Assert.assertTrue(dataSet.next());
+        Assert.assertEquals("Row[values=[0, value0]]", dataSet.getRow().toString());
+        Assert.assertTrue(dataSet.next());
+        Assert.assertEquals("Row[values=[1, value1]]", dataSet.getRow().toString());
+        Assert.assertTrue(dataSet.next());
+        Assert.assertEquals("Row[values=[20, value0]]", dataSet.getRow().toString());
+        Assert.assertFalse(dataSet.next());
+        dataSet.close();
+
+        verifyAll();
+
+        // assert that we assigned exactly the three partitions we queried for
+        final ArrayList<TopicPartition> capturedAssignmentList = new ArrayList<>(assignmentCapture.getValue());
+        Assert.assertEquals(3, capturedAssignmentList.size());
+        Assert.assertEquals(1, capturedAssignmentList.get(0).partition());
+        Assert.assertEquals(2, capturedAssignmentList.get(1).partition());
+        Assert.assertEquals(42, capturedAssignmentList.get(2).partition());
+    }
+
+    private ConsumerRecords<String, String> createConsumerRecords(int partition, int offset, int howMany) {
+        final List<ConsumerRecord<String, String>> list = new ArrayList<>();
+        for (int i = 0; i < howMany; i++) {
+            list.add(new ConsumerRecord<String, String>("myTopic", partition, offset + i, "key" + i, "value" + i));
+        }
+
+        final Map<TopicPartition, List<ConsumerRecord<String, String>>> records = new HashMap<>();
+        records.put(new TopicPartition("myTopic", partition), list);
+        return new ConsumerRecords<>(records);
+    }
+
+}

--- a/kafka/src/test/java/org/apache/metamodel/kafka/KafkaTestServer.java
+++ b/kafka/src/test/java/org/apache/metamodel/kafka/KafkaTestServer.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.metamodel.kafka;
 
 import java.io.File;

--- a/kafka/src/test/java/org/apache/metamodel/kafka/KafkaTestServer.java
+++ b/kafka/src/test/java/org/apache/metamodel/kafka/KafkaTestServer.java
@@ -1,0 +1,74 @@
+package org.apache.metamodel.kafka;
+
+import java.io.File;
+import java.io.FileReader;
+import java.util.Properties;
+
+public class KafkaTestServer {
+
+    private final boolean _configured;
+    private String _bootstrapServers;
+    private String _topicPrefix;
+
+    public KafkaTestServer() {
+        final File file = new File(getPropertyFilePath());
+        if (file.exists()) {
+            _configured = loadPropertyFile(file);
+        } else {
+            // Continuous integration case
+            if (System.getenv("CONTINUOUS_INTEGRATION") != null) {
+                File travisFile = new File("../travis-metamodel-integrationtest-configuration.properties");
+                if (travisFile.exists()) {
+                    _configured = loadPropertyFile(travisFile);
+                } else {
+                    _configured = false;
+                }
+            } else {
+                _configured = false;
+            }
+        }
+    }
+
+    public boolean isConfigured() {
+        return _configured;
+    }
+
+    public String getBootstrapServers() {
+        return _bootstrapServers;
+    }
+
+    public String getTopicPrefix() {
+        return _topicPrefix;
+    }
+
+    private boolean loadPropertyFile(File file) {
+        final Properties properties = new Properties();
+        try {
+            properties.load(new FileReader(file));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        _bootstrapServers = properties.getProperty("kafka.bootstrap.servers");
+        _topicPrefix = properties.getProperty("kafka.topic.prefix");
+
+        final boolean configured = (_bootstrapServers != null && !_bootstrapServers.isEmpty() && _topicPrefix != null
+                && !_topicPrefix.isEmpty());
+
+        if (configured) {
+            System.out.println("Loaded Kafka configuration. BootstrapServers=" + _bootstrapServers + ", TopicPrefix="
+                    + _topicPrefix);
+        }
+        return configured;
+    }
+
+    private String getPropertyFilePath() {
+        String userHome = System.getProperty("user.home");
+        return userHome + "/metamodel-integrationtest-configuration.properties";
+    }
+
+    public String getInvalidConfigurationMessage() {
+        return "!!! WARN !!! Kafka module ignored\r\n" + "Please configure kafka connection locally ("
+                + getPropertyFilePath() + "), to run integration tests";
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@ under the License.
 		<module>json</module>
 		<module>xml</module>
 		<module>jdbc</module>
+		<module>kafka</module>
 		<module>elasticsearch</module>
 		<module>hadoop</module>
 		<module>hbase</module>

--- a/travis-metamodel-integrationtest-configuration.properties
+++ b/travis-metamodel-integrationtest-configuration.properties
@@ -27,6 +27,13 @@ mongodb.collectionName=my_collection
 #hbase.zookeeper.port=2181
 
 # ------------------------
+# Kafka module properties:
+# ------------------------
+
+#kafka.bootstrap.servers=localhost:9092
+#kafka.topic.prefix=metamodel_test
+
+# ------------------------
 # Neo4j module properties:
 # ------------------------
 


### PR DESCRIPTION
Hi all,

I've been playing around with this idea for a while and decided to try it out ... I'm curious what you think!

This is a new MM module which allows you to query Apache Kafka. By "query" I mean: Each topic is represented as a table. And fields in here include `partition`, `offset`, `key`, `value` and `timestamp`.

When querying, the MM module creates a new unique Kafka consumer. This works, but I have one worry, which I don't really know how to mitigate: Consumers are registered in Kafka and cannot be deleted without pulling some tricks that go all the way into Zookeeper. This worries me because then every query fired will leave behind a new consumer ID in Zookeeper. If you use this module a lot then, then it becomes a lot of garbage.

Except for the issue described above, I think this works quite well. Queries are very fast and I've also added ability for the module to insert stuff.