### PR TITLE
Don't use Object.finalize()

### DIFF
--- a/core/src/main/java/org/apache/metamodel/data/RowPublisherDataSet.java
+++ b/core/src/main/java/org/apache/metamodel/data/RowPublisherDataSet.java
@@ -76,7 +76,6 @@ public final class RowPublisherDataSet extends AbstractDataSet {
 
     @Override
     protected void finalize() throws Throwable {
-        super.finalize();
         if (!_closed) {
             logger.warn("finalize() invoked, but DataSet is not closed. Invoking close() on {}", this);
             close();

--- a/core/src/main/java/org/apache/metamodel/schema/MutableRelationship.java
+++ b/core/src/main/java/org/apache/metamodel/schema/MutableRelationship.java
@@ -104,12 +104,6 @@ public class MutableRelationship extends AbstractRelationship implements
 		}
 	}
 
-	@Override
-	protected void finalize() throws Throwable {
-		super.finalize();
-		remove();
-	}
-
 	public static Relationship createRelationship(Column primaryColumn,
 			Column foreignColumn) {
 		List<Column> pcols = new ArrayList<>();

--- a/csv/src/main/java/org/apache/metamodel/csv/CsvDataSet.java
+++ b/csv/src/main/java/org/apache/metamodel/csv/CsvDataSet.java
@@ -63,7 +63,6 @@ final class CsvDataSet extends AbstractDataSet {
 
     @Override
     protected void finalize() throws Throwable {
-        super.finalize();
         // close is always safe to invoke
         close();
     }

--- a/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/AbstractElasticSearchDataSet.java
+++ b/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/AbstractElasticSearchDataSet.java
@@ -65,7 +65,6 @@ public abstract class AbstractElasticSearchDataSet extends AbstractDataSet {
     
     @Override
     protected void finalize() throws Throwable {
-        super.finalize();
         if (!_closed.get()) {
             logger.warn("finalize() invoked, but DataSet is not closed. Invoking close() on {}", this);
             close();

--- a/elasticsearch/native/pom.xml
+++ b/elasticsearch/native/pom.xml
@@ -64,7 +64,6 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>

--- a/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthDataSet.java
+++ b/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthDataSet.java
@@ -53,7 +53,6 @@ class FixedWidthDataSet extends AbstractDataSet {
 
 	@Override
 	protected void finalize() throws Throwable {
-		super.finalize();
 		// close is always safe to invoke
 		close();
 	}

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcCompiledQuery.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcCompiledQuery.java
@@ -148,7 +148,6 @@ final class JdbcCompiledQuery extends DefaultCompiledQuery implements CompiledQu
 
     @Override
     protected void finalize() throws Throwable {
-        super.finalize();
         if (!_closed) {
             logger.warn("finalize() invoked, but DataSet is not closed. Invoking close() on {}", this);
             close();

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataSet.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataSet.java
@@ -190,7 +190,6 @@ final class JdbcDataSet extends AbstractDataSet {
 
     @Override
     protected void finalize() throws Throwable {
-        super.finalize();
         if (!_closed) {
             logger.warn("finalize() invoked, but DataSet is not closed. Invoking close() on {}", this);
             close();

--- a/mongodb/mongo2/src/main/java/org/apache/metamodel/mongodb/mongo2/MongoDbDataSet.java
+++ b/mongodb/mongo2/src/main/java/org/apache/metamodel/mongodb/mongo2/MongoDbDataSet.java
@@ -40,8 +40,6 @@ final class MongoDbDataSet extends AbstractDataSet {
     private boolean _closed;
     private volatile DBObject _dbObject;
 
-
-
     public MongoDbDataSet(DBCursor cursor, List<SelectItem> selectItems, boolean queryPostProcessed) {
         super(selectItems);
         _cursor = cursor;
@@ -62,7 +60,6 @@ final class MongoDbDataSet extends AbstractDataSet {
 
     @Override
     protected void finalize() throws Throwable {
-        super.finalize();
         if (!_closed) {
             logger.warn("finalize() invoked, but DataSet is not closed. Invoking close() on {}", this);
             close();

--- a/mongodb/mongo3/src/main/java/org/apache/metamodel/mongodb/mongo3/MongoDbDataSet.java
+++ b/mongodb/mongo3/src/main/java/org/apache/metamodel/mongodb/mongo3/MongoDbDataSet.java
@@ -61,7 +61,6 @@ final class MongoDbDataSet extends AbstractDataSet {
 
     @Override
     protected void finalize() throws Throwable {
-        super.finalize();
         if (!_closed) {
             logger.warn("finalize() invoked, but DataSet is not closed. Invoking close() on {}", this);
             close();

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@ under the License.
 		<sshwagon.version>2.6</sshwagon.version>
 		<javadoc.version>2.10.3</javadoc.version>
 		<slf4j.version>1.7.7</slf4j.version>
-		<junit.version>4.11</junit.version>
+		<junit.version>4.12</junit.version>
 		<guava.version>16.0.1</guava.version>
 		<hadoop.version>2.6.0</hadoop.version>
 		<jackson.version>2.6.3</jackson.version>


### PR DESCRIPTION
Since JDK9 the `Object.finalize()` method has been marked as `@Deprecated`. In this PR I removed references to `Objects`s `finalize` method, and tried to get rid of our own `finalize` method where possible without introducing potential issues.

Oh and there was a small junit dependency inconsistency.

I guess I just decided to weed out a couple of warnings really :-)