### PR TITLE
add support for Oracle "TIMESTAMP WITH (LOCAL_)TIME_ZONE" column type.

### DIFF
--- a/core/src/main/java/org/apache/metamodel/util/NumberComparator.java
+++ b/core/src/main/java/org/apache/metamodel/util/NumberComparator.java
@@ -136,6 +136,10 @@ public final class NumberComparator implements Comparator<Object> {
             } catch (NumberFormatException e) {
             }
             try {
+                return new BigInteger(stringValue);
+            } catch (NumberFormatException e) {
+            }            
+            try {
                 return Double.parseDouble(stringValue);
             } catch (NumberFormatException e) {
             }

--- a/core/src/test/java/org/apache/metamodel/util/NumberComparatorTest.java
+++ b/core/src/test/java/org/apache/metamodel/util/NumberComparatorTest.java
@@ -50,7 +50,10 @@ public class NumberComparatorTest {
     public void testToNumberLong() throws Exception {
         assertEquals(4212000000l, NumberComparator.toNumber("4212000000"));
     }
-
+    @Test
+    public void testToNumberBigInteger() throws Exception {
+        assertEquals(new BigInteger("42120000000000004212"), NumberComparator.toNumber("42120000000000004212"));
+    }    
     @Test
     public void testToNumberDouble() throws Exception {
         assertEquals(42.12, NumberComparator.toNumber("42.12"));

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/OracleQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/OracleQueryRewriter.java
@@ -34,13 +34,13 @@ public class OracleQueryRewriter extends OffsetFetchQueryRewriter {
     }
 
     @Override
-	public ColumnType getColumnType(int jdbcType, String nativeType, Integer columnSize) {
-		// For TIMESTAMP WITH LOCAL_TIME_ZONE/TIME_ZONE, which jdbcType is -102/-101
-		if (nativeType.contains("TIMESTAMP")) {
-			return ColumnType.TIMESTAMP;
-		}
-		return super.getColumnType(jdbcType, nativeType, columnSize);
-	}
+    public ColumnType getColumnType(int jdbcType, String nativeType, Integer columnSize) {
+        // For TIMESTAMP WITH LOCAL_TIME_ZONE/TIME_ZONE, which jdbcType is -102/-101
+        if (nativeType.contains("TIMESTAMP")) {
+            return ColumnType.TIMESTAMP;
+        }
+        return super.getColumnType(jdbcType, nativeType, columnSize);
+    }
 
     @Override
     public String rewriteColumnType(ColumnType columnType, Integer columnSize) {

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/OracleQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/OracleQueryRewriter.java
@@ -34,6 +34,15 @@ public class OracleQueryRewriter extends OffsetFetchQueryRewriter {
     }
 
     @Override
+	public ColumnType getColumnType(int jdbcType, String nativeType, Integer columnSize) {
+		// For TIMESTAMP WITH LOCAL_TIME_ZONE/TIME_ZONE, which jdbcType is -102/-101
+		if (nativeType.contains("TIMESTAMP")) {
+			return ColumnType.TIMESTAMP;
+		}
+		return super.getColumnType(jdbcType, nativeType, columnSize);
+	}
+
+    @Override
     public String rewriteColumnType(ColumnType columnType, Integer columnSize) {
         if (columnType == ColumnType.NUMBER || columnType == ColumnType.NUMERIC || columnType == ColumnType.DECIMAL) {
             // as one of the only relational databases out there, Oracle has a


### PR DESCRIPTION
Oracle has "TIMESTAMP WITH LOCAL_TIME_ZONE" and TIMESTAMP WITH TIME_ZONE" column type, which  MetaModel doesn't support now.