### PR TITLE
Update Hive version

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -118,7 +118,7 @@
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-jdbc</artifactId>
-			<version>1.2.1</version>
+			<version>2.3.2</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
@@ -132,6 +132,10 @@
 				<exclusion>
 					<groupId>javax.xml.stream</groupId>
 					<artifactId>stax-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.github.stephenc.findbugs</groupId>
+					<artifactId>findbugs-annotations</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>


### PR DESCRIPTION
This PR updates Hive from version 1.2.1 to 2.3.2, which is the latest version.