### PR TITLE
METAMODEL-1194 Don't support primary keys with Hive

### DIFF
--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcCreateTableBuilder.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcCreateTableBuilder.java
@@ -115,21 +115,23 @@ final class JdbcCreateTableBuilder extends AbstractTableCreationBuilder<JdbcUpda
                 sb.append(" NOT NULL");
             }
         }
-        boolean primaryKeyExists = false;
-        for (int i = 0; i < columns.size(); i++) {
-            if (columns.get(i).isPrimaryKey()) {
-                if (!primaryKeyExists) {
-                    sb.append(", PRIMARY KEY(");
-                    sb.append(columns.get(i).getName());
-                    primaryKeyExists = true;
-                } else {
-                    sb.append(",");
-                    sb.append(columns.get(i).getName());
+        if (queryRewriter.isPrimaryKeySupported()) {
+            boolean primaryKeyExists = false;
+            for (int i = 0; i < columns.size(); i++) {
+                if (columns.get(i).isPrimaryKey()) {
+                    if (!primaryKeyExists) {
+                        sb.append(", PRIMARY KEY(");
+                        sb.append(columns.get(i).getName());
+                        primaryKeyExists = true;
+                    } else {
+                        sb.append(",");
+                        sb.append(columns.get(i).getName());
+                    }
                 }
             }
-        }
-        if (primaryKeyExists) {
-            sb.append(")");
+            if (primaryKeyExists) {
+                sb.append(")");
+            }
         }
         sb.append(")");
         return sb.toString();

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/DefaultQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/DefaultQueryRewriter.java
@@ -220,4 +220,9 @@ public class DefaultQueryRewriter extends AbstractQueryRewriter {
     public String escapeQuotes(String item) {
         return item.replaceAll("\\'", "\\'\\'");
     }
+
+	@Override
+	public boolean isPrimaryKeySupported() {
+		return true;
+	}
 }

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/HiveQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/HiveQueryRewriter.java
@@ -52,4 +52,9 @@ public class HiveQueryRewriter extends DefaultQueryRewriter {
     public boolean isTransactional() {
         return false;
     }
+    
+	@Override
+	public boolean isPrimaryKeySupported() {
+		return false;
+	}
 }

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/IQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/IQueryRewriter.java
@@ -162,4 +162,11 @@ public interface IQueryRewriter {
      * @return
      */
     public boolean isTransactional();
+
+    /**
+     * Determines if the JDBC data source supports primary keys or not.
+     *
+     * @return
+     */
+    public boolean isPrimaryKeySupported();
 }

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/HiveIntegrationTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/HiveIntegrationTest.java
@@ -149,4 +149,34 @@ public class HiveIntegrationTest extends AbstractJdbIntegrationTest {
             dataContext.executeUpdate(new DropTable(schema, tableName));
         }
     }
+
+    /**
+     * Hive doesn't support primary keys. If a column is defined as a primary key,
+     * MetaModel should ignore that for Hive datastores when creating a table.
+     * @throws Exception
+     */
+    public void testCreateTableWithPrimaryKey() throws Exception {
+        if (!isConfigured()) {
+            return;
+        }
+        final JdbcDataContext dataContext = getDataContext();
+
+        final String tableName = "metamodel_" + System.currentTimeMillis();
+        final Schema schema = dataContext.getDefaultSchema();
+
+        dataContext.executeUpdate(new CreateTable(schema, tableName)
+                .withColumn("foo")
+                .ofType(ColumnType.STRING)
+                .asPrimaryKey()
+                .withColumn("bar")
+                .ofType(ColumnType.INTEGER)
+                .withColumn("baz")
+                .ofType(ColumnType.VARCHAR));
+        try {
+            final Table table = dataContext.getTableByQualifiedLabel(tableName);
+            assertNotNull(table);
+        } finally {
+            dataContext.executeUpdate(new DropTable(schema, tableName));
+        }
+    }
 }


### PR DESCRIPTION
Hive doesn't support primary keys. This PR makes sure, that when a column is defined as a primary key, then  this is ignored in the create table statement.