### PR TITLE
Set the MutableColumn.table value in Kafka columns (two-way reference).

### DIFF
--- a/core/src/main/java/org/apache/metamodel/schema/MutableColumn.java
+++ b/core/src/main/java/org/apache/metamodel/schema/MutableColumn.java
@@ -56,6 +56,12 @@ public class MutableColumn extends AbstractColumn implements Serializable {
         setType(type);
     }
 
+    public MutableColumn(String name, ColumnType type, Table table) {
+        this(name);
+        setType(type);
+        setTable(table);
+    }
+
     public MutableColumn(String name, ColumnType type, Table table, int columnNumber, Boolean nullable) {
         this(name, type);
         setColumnNumber(columnNumber);

--- a/kafka/src/main/java/org/apache/metamodel/kafka/KafkaDataContext.java
+++ b/kafka/src/main/java/org/apache/metamodel/kafka/KafkaDataContext.java
@@ -94,11 +94,11 @@ public class KafkaDataContext<K, V> extends QueryPostprocessDataContext implemen
 
         for (String topic : topics) {
             final MutableTable table = new MutableTable(topic, schema);
-            table.addColumn(new MutableColumn(COLUMN_PARTITION, ColumnType.INTEGER));
-            table.addColumn(new MutableColumn(COLUMN_OFFSET, ColumnType.BIGINT));
-            table.addColumn(new MutableColumn(COLUMN_TIMESTAMP, ColumnType.TIMESTAMP));
-            table.addColumn(new MutableColumn(COLUMN_KEY, ColumnTypeImpl.convertColumnType(keyClass)));
-            table.addColumn(new MutableColumn(COLUMN_VALUE, ColumnTypeImpl.convertColumnType(valueClass)));
+            table.addColumn(new MutableColumn(COLUMN_PARTITION, ColumnType.INTEGER, table).setPrimaryKey(true));
+            table.addColumn(new MutableColumn(COLUMN_OFFSET, ColumnType.BIGINT, table).setPrimaryKey(true));
+            table.addColumn(new MutableColumn(COLUMN_TIMESTAMP, ColumnType.TIMESTAMP, table));
+            table.addColumn(new MutableColumn(COLUMN_KEY, ColumnTypeImpl.convertColumnType(keyClass), table));
+            table.addColumn(new MutableColumn(COLUMN_VALUE, ColumnTypeImpl.convertColumnType(valueClass), table));
             schema.addTable(table);
         }
         return schema;


### PR DESCRIPTION
Here is a Pull Request where I am fixing the two-way reference from MutableColumn back to Table for the new Apache Kafka MetaModel project. I am trying to connect Kafka to the project DataCleaner, which use MetaModel a lot. and have built some initial code, but it right now is not working because something in there tries to reference the table using Column.getTable() and so on. This Pull Request should fix that.