### PR TITLE
METAMODEL-1205: Made CassandraUnit based test skip on JDK 9+

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -20,8 +20,8 @@
 	<name>MetaModel module for Apache Cassandra database</name>
 
 	<properties>
-		<cassandra.driver.latest.version>3.0.2</cassandra.driver.latest.version>
-		<cassandraunit.latest.version>2.2.2.1</cassandraunit.latest.version>
+		<cassandra.driver.latest.version>3.6.0</cassandra.driver.latest.version>
+		<cassandraunit.latest.version>3.5.0.1</cassandraunit.latest.version>
 	</properties>
 
 	<dependencies>

--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -9,7 +9,9 @@
 	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
 	OF ANY KIND, either express or implied. See the License for the specific 
 	language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<parent>
 		<artifactId>MetaModel</artifactId>
 		<groupId>org.apache.metamodel</groupId>
@@ -49,8 +51,9 @@
 		</dependency>
 		<!-- test -->
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
+			<groupId>ch.qos.logback</groupId>
+			<artifactId>logback-classic</artifactId>
+			<version>1.2.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/cassandra/src/test/resources/logback.xml
+++ b/cassandra/src/test/resources/logback.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<configuration>
+
+	<appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<logger name="org.apache.metamodel" level="info" />
+
+	<root level="warn">
+		<appender-ref ref="consoleAppender" />
+	</root>
+</configuration>

--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -27,19 +27,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
-			<artifactId>hadoop-common</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-client</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>commons-beanutils</groupId>
-			<artifactId>commons-beanutils</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>net.sourceforge.findbugs</groupId>
-			<artifactId>annotations</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/hadoop/src/main/java/org/apache/metamodel/util/HdfsDirectoryInputStream.java
+++ b/hadoop/src/main/java/org/apache/metamodel/util/HdfsDirectoryInputStream.java
@@ -46,7 +46,7 @@ class HdfsDirectoryInputStream extends AbstractDirectoryInputStream<FileStatus> 
                 @Override
                 public boolean accept(final Path path) {
                     try {
-                        return _fs.isFile(path);
+                        return _fs.getFileStatus(path).isFile();
                     } catch (IOException e) {
                         return false;
                     }

--- a/hadoop/src/main/java/org/apache/metamodel/util/HdfsResource.java
+++ b/hadoop/src/main/java/org/apache/metamodel/util/HdfsResource.java
@@ -201,7 +201,7 @@ public class HdfsResource extends AbstractResource implements Serializable {
     public long getSize() {
         final FileSystem fs = getHadoopFileSystem();
         try {
-            if (fs.isFile(getHadoopPath())) {
+            if (fs.getFileStatus(getHadoopPath()).isFile()) {
                 return fs.getFileStatus(getHadoopPath()).getLen();
             } else {
                 return fs.getContentSummary(getHadoopPath()).getLength();
@@ -258,7 +258,7 @@ public class HdfsResource extends AbstractResource implements Serializable {
         try {
             final Path hadoopPath = getHadoopPath();
             // return a wrapper InputStream which manages the 'fs' closeable
-            if (fs.isFile(hadoopPath)) {
+            if (fs.getFileStatus(hadoopPath).isFile()) {
                 in = fs.open(hadoopPath);
                 return new HdfsFileInputStream(in, fs);
             } else {

--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -20,7 +20,7 @@
 	<name>MetaModel module for Apache HBase</name>
 
 	<properties>
-		<hbase.version>1.1.1</hbase.version>
+		<hbase.version>2.1.1</hbase.version>
 	</properties>
 
 	<dependencies>
@@ -28,10 +28,6 @@
 			<groupId>org.apache.metamodel</groupId>
 			<artifactId>MetaModel-hadoop</artifactId>
 			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.hadoop</groupId>
-			<artifactId>hadoop-common</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.hbase</groupId>
@@ -63,9 +59,9 @@
 					<groupId>org.mortbay.jetty</groupId>
 				</exclusion>
 				<exclusion>
-						<groupId>com.github.stephenc.findbugs</groupId>
-						<artifactId>findbugs-annotations</artifactId>
-					</exclusion>
+					<groupId>com.github.stephenc.findbugs</groupId>
+					<artifactId>findbugs-annotations</artifactId>
+				</exclusion>
 				<exclusion>
 					<groupId>tomcat</groupId>
 					<artifactId>jasper-runtime</artifactId>
@@ -139,10 +135,6 @@
 					<artifactId>jackson-xc</artifactId>
 				</exclusion>
 			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>net.sourceforge.findbugs</groupId>
-			<artifactId>annotations</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>

--- a/hbase/pom.xml
+++ b/hbase/pom.xml
@@ -63,6 +63,10 @@
 					<artifactId>findbugs-annotations</artifactId>
 				</exclusion>
 				<exclusion>
+					<groupId>net.jcip</groupId>
+					<artifactId>jcip-annotations</artifactId>
+				</exclusion>
+				<exclusion>
 					<groupId>tomcat</groupId>
 					<artifactId>jasper-runtime</artifactId>
 				</exclusion>

--- a/hbase/src/main/java/org/apache/metamodel/hbase/HBaseClient.java
+++ b/hbase/src/main/java/org/apache/metamodel/hbase/HBaseClient.java
@@ -21,15 +21,16 @@ package org.apache.metamodel.hbase;
 import java.io.IOException;
 import java.util.Set;
 
-import org.apache.hadoop.hbase.HColumnDescriptor;
-import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.metamodel.MetaModelException;
 import org.slf4j.Logger;
@@ -155,15 +156,16 @@ final class HBaseClient {
         }
         try (final Admin admin = _connection.getAdmin()) {
             final TableName hBasetableName = TableName.valueOf(tableName);
-            final HTableDescriptor tableDescriptor = new HTableDescriptor(hBasetableName);
+            final TableDescriptorBuilder tableBuilder = TableDescriptorBuilder.newBuilder(hBasetableName);
             // Add all columnFamilies to the tableDescriptor.
-            for (final String columnFamilie : columnFamilies) {
+            for (final String columnFamily : columnFamilies) {
                 // The ID-column isn't needed because, it will automatically be created.
-                if (!columnFamilie.equals(HBaseDataContext.FIELD_ID)) {
-                    tableDescriptor.addFamily(new HColumnDescriptor(columnFamilie));
+                if (!columnFamily.equals(HBaseDataContext.FIELD_ID)) {
+                    final ColumnFamilyDescriptor columnDescriptor = ColumnFamilyDescriptorBuilder.of(columnFamily);
+                    tableBuilder.setColumnFamily(columnDescriptor);
                 }
             }
-            admin.createTable(tableDescriptor);
+            admin.createTable(tableBuilder.build());
         } catch (IOException e) {
             throw new MetaModelException(e);
         }

--- a/hbase/src/main/java/org/apache/metamodel/hbase/HBaseColumn.java
+++ b/hbase/src/main/java/org/apache/metamodel/hbase/HBaseColumn.java
@@ -23,6 +23,9 @@ import org.apache.metamodel.schema.MutableColumn;
 import org.apache.metamodel.schema.Table;
 
 final class HBaseColumn extends MutableColumn {
+    
+    private static final long serialVersionUID = 1L;
+    
     public static final ColumnType DEFAULT_COLUMN_TYPE_FOR_ID_COLUMN = ColumnType.BINARY;
     public static final ColumnType DEFAULT_COLUMN_TYPE_FOR_COLUMN_FAMILIES = ColumnType.LIST;
 

--- a/hbase/src/main/java/org/apache/metamodel/hbase/HBaseDataContext.java
+++ b/hbase/src/main/java/org/apache/metamodel/hbase/HBaseDataContext.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
@@ -31,6 +30,7 @@ import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.filter.PageFilter;
 import org.apache.metamodel.DataContext;
 import org.apache.metamodel.MetaModelException;
@@ -129,10 +129,11 @@ public class HBaseDataContext extends QueryPostprocessDataContext implements Upd
         SimpleTableDef[] tableDefinitions = _configuration.getTableDefinitions();
         if (tableDefinitions == null) {
             try {
-                final HTableDescriptor[] tables = getAdmin().listTables();
-                tableDefinitions = new SimpleTableDef[tables.length];
-                for (int i = 0; i < tables.length; i++) {
-                    SimpleTableDef emptyTableDef = new SimpleTableDef(tables[i].getNameAsString(), new String[0]);
+                final List<TableDescriptor> tables = getAdmin().listTableDescriptors();
+                tableDefinitions = new SimpleTableDef[tables.size()];
+                for (int i = 0; i < tables.size(); i++) {
+                    final String tableName = tables.get(i).getTableName().getNameAsString();
+                    final SimpleTableDef emptyTableDef = new SimpleTableDef(tableName, new String[0]);
                     tableDefinitions[i] = emptyTableDef;
                 }
             } catch (IOException e) {

--- a/hbase/src/main/java/org/apache/metamodel/hbase/HBaseTable.java
+++ b/hbase/src/main/java/org/apache/metamodel/hbase/HBaseTable.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.schema.Column;
 import org.apache.metamodel.schema.ColumnType;
@@ -45,13 +45,14 @@ final class HBaseTable extends MutableTable {
     private final transient ColumnType _defaultRowKeyColumnType;
 
     /**
-     * Creates an HBaseTable. If the tableDef variable doesn't include the ID-column (see {@link HBaseDataContext#FIELD_ID}).
-     * Then it's first added.
+     * Creates an HBaseTable. If the tableDef variable doesn't include the ID-column (see
+     * {@link HBaseDataContext#FIELD_ID}). Then it's first added.
+     * 
      * @param dataContext
      * @param tableDef Table definition. The tableName, columnNames and columnTypes variables are used.
      * @param schema {@link MutableSchema} where the table belongs to.
-     * @param defaultRowKeyColumnType This variable determines the {@link ColumnType},
-     * used when the tableDef doesn't include the ID column (see {@link HBaseDataContext#FIELD_ID}).
+     * @param defaultRowKeyColumnType This variable determines the {@link ColumnType}, used when the tableDef doesn't
+     *            include the ID column (see {@link HBaseDataContext#FIELD_ID}).
      */
     public HBaseTable(final HBaseDataContext dataContext, final SimpleTableDef tableDef, final MutableSchema schema,
             final ColumnType defaultRowKeyColumnType) {
@@ -63,6 +64,7 @@ final class HBaseTable extends MutableTable {
 
     /**
      * Add multiple columns to this table
+     * 
      * @param tableDef
      */
     private void addColumns(final SimpleTableDef tableDef) {
@@ -135,7 +137,7 @@ final class HBaseTable extends MutableTable {
                 // What about timestamp?
 
                 // Add the other column (with columnNumbers starting from 2)
-                final HColumnDescriptor[] columnFamilies = table.getTableDescriptor().getColumnFamilies();
+                final ColumnFamilyDescriptor[] columnFamilies = table.getDescriptor().getColumnFamilies();
                 for (int i = 0; i < columnFamilies.length; i++) {
                     addColumn(columnFamilies[i].getNameAsString(), HBaseColumn.DEFAULT_COLUMN_TYPE_FOR_COLUMN_FAMILIES,
                             i + 2);
@@ -153,11 +155,7 @@ final class HBaseTable extends MutableTable {
      * @return {@link Set}<{@link String}> of columnFamilies
      */
     Set<String> getColumnFamilies() {
-        return getColumnsInternal()
-                .stream()
-                .map(column -> (HBaseColumn) column)
-                .map(HBaseColumn::getColumnFamily)
-                .distinct()
-                .collect(Collectors.toSet());
+        return getColumnsInternal().stream().map(column -> (HBaseColumn) column).map(HBaseColumn::getColumnFamily)
+                .distinct().collect(Collectors.toSet());
     }
 }

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/HsqldbQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/HsqldbQueryRewriter.java
@@ -26,8 +26,6 @@ import org.apache.metamodel.query.SelectItem;
 import org.apache.metamodel.schema.Column;
 import org.apache.metamodel.schema.ColumnType;
 
-import com.google.common.base.CharMatcher;
-
 /**
  * Query rewriter for HSQLDB
  */
@@ -106,8 +104,7 @@ public class HsqldbQueryRewriter extends DefaultQueryRewriter {
      */
     @Override
     public boolean needsQuoting(String alias, String identifierQuoteString) {
-
-        boolean containsLowerCase = CharMatcher.JAVA_LOWER_CASE.matchesAnyOf(identifierQuoteString);
+        final boolean containsLowerCase = identifierQuoteString.chars().anyMatch(Character::isLowerCase);
 
         return containsLowerCase || super.needsQuoting(alias, identifierQuoteString);
     }

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/OracleQueryRewriterTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/OracleQueryRewriterTest.java
@@ -66,7 +66,6 @@ public class OracleQueryRewriterTest {
     public void testOffsetFetchConstruct() {
         final int offset = 1000;
         final int rows = 100;
-        final String where = "x > 1";
 
         final String offsetClause = " OFFSET " + (offset - 1) + " ROWS";
         final String fetchClause = " FETCH NEXT " + rows + " ROWS ONLY";

--- a/pom.xml
+++ b/pom.xml
@@ -1,23 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -316,8 +310,11 @@ under the License.
 										<exclude>stax:stax-api:*</exclude>
 										<exclude>javax.xml.stream:stax-api</exclude>
 
-										<!-- findbugs-annotations is overlapping with annotations -->
+										<!-- findbugs-annotations is overlapping with net.sourceforge.findbugs:annotations -->
 										<exclude>com.github.stephenc.findbugs:findbugs-annotations:*</exclude>
+
+										<!-- net.jcip:jcip-annotations is overlapping with net.sourceforge.findbugs:annotations -->
+										<exclude>net.jcip:jcip-annotations</exclude>
 									</excludes>
 								</bannedDependencies>
 							</rules>
@@ -389,7 +386,8 @@ under the License.
 					<artifactId>apache-rat-plugin</artifactId>
 					<configuration>
 						<licenses>
-							<license implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
+							<license
+								implementation="org.apache.rat.analysis.license.SimplePatternBasedLicense">
 								<licenseFamilyCategory>ASL20</licenseFamilyCategory>
 								<licenseFamilyName>Apache Software License, 2.0</licenseFamilyName>
 								<notes>Single licensed ASL v2.0</notes>
@@ -577,28 +575,28 @@ under the License.
 				<artifactId>hsqldb</artifactId>
 				<version>1.8.0.10</version>
 			</dependency>
-			
+
 			<!-- Spring -->
 			<dependency>
 				<groupId>org.springframework</groupId>
 				<artifactId>spring-core</artifactId>
 				<version>${spring.version}</version>
-			    <exclusions>
-			    	<exclusion>
-			    		<groupId>commons-logging</groupId>
-			    		<artifactId>commons-logging</artifactId>
-			    	</exclusion>
-			    </exclusions>
+				<exclusions>
+					<exclusion>
+						<groupId>commons-logging</groupId>
+						<artifactId>commons-logging</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
-			    <groupId>org.springframework</groupId>
-			    <artifactId>spring-context</artifactId>
-			    <version>${spring.version}</version>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-context</artifactId>
+				<version>${spring.version}</version>
 			</dependency>
 			<dependency>
-			    <groupId>org.springframework</groupId>
-			    <artifactId>spring-test</artifactId>
-			    <version>${spring.version}</version>
+				<groupId>org.springframework</groupId>
+				<artifactId>spring-test</artifactId>
+				<version>${spring.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework</groupId>
@@ -615,6 +613,10 @@ under the License.
 					<exclusion>
 						<artifactId>jetty-util</artifactId>
 						<groupId>org.mortbay.jetty</groupId>
+					</exclusion>
+					<exclusion>
+						<groupId>net.jcip</groupId>
+						<artifactId>jcip-annotations</artifactId>
 					</exclusion>
 					<exclusion>
 						<groupId>com.github.stephenc.findbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,11 +23,11 @@ under the License.
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<sshwagon.version>2.6</sshwagon.version>
 		<javadoc.version>2.10.3</javadoc.version>
-		<slf4j.version>1.7.7</slf4j.version>
+		<slf4j.version>1.7.25</slf4j.version>
 		<junit.version>4.12</junit.version>
-		<guava.version>16.0.1</guava.version>
-		<hadoop.version>2.6.0</hadoop.version>
-		<jackson.version>2.6.3</jackson.version>
+		<guava.version>27.0.1-jre</guava.version>
+		<hadoop.version>3.1.1</hadoop.version>
+		<jackson.version>2.9.7</jackson.version>
 		<easymock.version>3.2</easymock.version>
 		<spring.version>4.2.6.RELEASE</spring.version>
 		<httpcomponents.version>4.4.1</httpcomponents.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
-	license agreements. See the NOTICE file distributed with this work for additional 
-	information regarding copyright ownership. The ASF licenses this file to 
-	you under the Apache License, Version 2.0 (the "License"); you may not use 
-	this file except in compliance with the License. You may obtain a copy of 
-	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
-	by applicable law or agreed to in writing, software distributed under the 
-	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
-	OF ANY KIND, either express or implied. See the License for the specific 
-	language governing permissions and limitations under the License. -->
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
@@ -21,7 +29,7 @@
 		<junit.version>4.12</junit.version>
 		<guava.version>27.0.1-jre</guava.version>
 		<hadoop.version>3.1.1</hadoop.version>
-		<jackson.version>2.9.7</jackson.version>
+		<jackson.version>2.6.7</jackson.version>
 		<easymock.version>3.2</easymock.version>
 		<spring.version>4.2.6.RELEASE</spring.version>
 		<httpcomponents.version>4.4.1</httpcomponents.version>


### PR DESCRIPTION
It seems that CassandraUnit simply does not work on JDK 9+, see related comments in the code. For now I've added a JUnit `Assume` call which ensures that the test code is skipped when CassandraUnit fails to come up. Eventually, when they fix CassandraUnit, we should be able to upgrade the CassandraUnit dependency and it would presumably start working again.

**Update**: This PR now also updates versions of: Guava, Hadoop, HBase, Jackson and SLF4j. I got into a situation with Cassandra Unit and Cassandra itself requiring a newer Guava, which then required an upgrade of Hadoop, which then required an update of HBase. Hurray for JAR hell. Luckily it seems to work just fine when everything is on latest and greatest versions. And as a developer I quite prefer that anyway. Should set us on a better path to support JDK 9, 10 and 11.