### PR TITLE
Elasticsearch native build failure

### DIFF
--- a/elasticsearch/common/src/test/java/org/apache/metamodel/elasticsearch/common/ElasticSearchMetaDataParserTest.java
+++ b/elasticsearch/common/src/test/java/org/apache/metamodel/elasticsearch/common/ElasticSearchMetaDataParserTest.java
@@ -16,15 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.metamodel.elasticsearch.nativeclient;
+package org.apache.metamodel.elasticsearch.common;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import junit.framework.TestCase;
 
-import org.apache.metamodel.elasticsearch.common.ElasticSearchMetaData;
-import org.apache.metamodel.elasticsearch.common.ElasticSearchMetaDataParser;
 import org.apache.metamodel.schema.ColumnType;
 import org.elasticsearch.common.collect.MapBuilder;
 

--- a/elasticsearch/native/pom.xml
+++ b/elasticsearch/native/pom.xml
@@ -26,7 +26,7 @@
 				<plugin>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<configuration>
-						<runOrder>alphabetical</runOrder>
+						<runOrder>reversealphabetical</runOrder>
 					</configuration>
 				</plugin>
 			</plugins>

--- a/elasticsearch/native/pom.xml
+++ b/elasticsearch/native/pom.xml
@@ -19,20 +19,6 @@
 
 	<artifactId>MetaModel-elasticsearch-native</artifactId>
 	<name>MetaModel module for ElasticSearch via native (Node or Transport) client</name>
-
-	<build>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<artifactId>maven-surefire-plugin</artifactId>
-					<configuration>
-						<runOrder>reversealphabetical</runOrder>
-					</configuration>
-				</plugin>
-			</plugins>
-		</pluginManagement>	
-	</build>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.metamodel</groupId>

--- a/elasticsearch/native/pom.xml
+++ b/elasticsearch/native/pom.xml
@@ -19,6 +19,20 @@
 
 	<artifactId>MetaModel-elasticsearch-native</artifactId>
 	<name>MetaModel module for ElasticSearch via native (Node or Transport) client</name>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<configuration>
+						<runOrder>alphabetical</runOrder>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>	
+	</build>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.metamodel</groupId>


### PR DESCRIPTION
Running unit test in `MetaModel-elasticsearch-native` module in reverse alphabetical order to make sure that the `ElasticSearchDataContextTest` unit test class is executed last, because it will fail the build if it is executed before other unit tests in the module. 

This is caused by a mismatch between the Apache maven surefire-plugin and the `org.elasticsearch.test.ESSingleNodeTestCase` class provided by the Elasticsearch test framework, which seems to set a custom SecurityManager on the JVM when it runs.