### PR TITLE
close ResultSet after get result

### DIFF
--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataContext.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataContext.java
@@ -289,6 +289,7 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
         } catch (SQLException e) {
             throw JdbcUtils.wrapException(e, "retrieve schema and catalog metadata", JdbcActionType.METADATA);
         } finally {
+            FileHelper.safeClose(rs);
             close(null);
         }
         return result;
@@ -580,6 +581,7 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
         } catch (SQLException e) {
             logger.error("Error retrieving catalog metadata", e);
         } finally {
+            FileHelper.safeClose(rs);
             close(connection);
             logger.debug("Retrieved {} catalogs", catalogs.size());
         }
@@ -756,6 +758,7 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
         while (rs.next()) {
             schemas.add(rs.getString("TABLE_SCHEM"));
         }
+        FileHelper.safeClose(rs);
         return schemas;
     }
 
@@ -797,7 +800,7 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
                     logger.debug("Found schemaName: {}", schemaName);
                     result.add(schemaName);
                 }
-                rs.close();
+                FileHelper.safeClose(rs);
             }
 
             if (DATABASE_PRODUCT_MYSQL.equals(_databaseProductName)) {

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataContext.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataContext.java
@@ -289,13 +289,6 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
         } catch (SQLException e) {
             throw JdbcUtils.wrapException(e, "retrieve schema and catalog metadata", JdbcActionType.METADATA);
         } finally {
-            if(rs != null) {
-                try {
-                    rs.close();
-                } catch (SQLException e) {
-                    e.printStackTrace();
-                }
-            }
             close(null);
         }
         return result;
@@ -587,13 +580,6 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
         } catch (SQLException e) {
             logger.error("Error retrieving catalog metadata", e);
         } finally {
-            if(rs != null){
-                try {
-                    rs.close();
-                } catch (SQLException e) {
-                    e.printStackTrace();
-                }
-            }
             close(connection);
             logger.debug("Retrieved {} catalogs", catalogs.size());
         }
@@ -769,9 +755,6 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
         ResultSet rs = metaData.getTables(_catalogName, null, null, JdbcUtils.getTableTypesAsStrings(_tableTypes));
         while (rs.next()) {
             schemas.add(rs.getString("TABLE_SCHEM"));
-        }
-        if(rs != null){
-            rs.close();
         }
         return schemas;
     }

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataContext.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataContext.java
@@ -289,7 +289,6 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
         } catch (SQLException e) {
             throw JdbcUtils.wrapException(e, "retrieve schema and catalog metadata", JdbcActionType.METADATA);
         } finally {
-            FileHelper.safeClose(rs);
             close(null);
         }
         return result;
@@ -581,7 +580,6 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
         } catch (SQLException e) {
             logger.error("Error retrieving catalog metadata", e);
         } finally {
-            FileHelper.safeClose(rs);
             close(connection);
             logger.debug("Retrieved {} catalogs", catalogs.size());
         }
@@ -758,7 +756,6 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
         while (rs.next()) {
             schemas.add(rs.getString("TABLE_SCHEM"));
         }
-        FileHelper.safeClose(rs);
         return schemas;
     }
 
@@ -800,7 +797,7 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
                     logger.debug("Found schemaName: {}", schemaName);
                     result.add(schemaName);
                 }
-                FileHelper.safeClose(rs);
+                rs.close();
             }
 
             if (DATABASE_PRODUCT_MYSQL.equals(_databaseProductName)) {

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataContext.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDataContext.java
@@ -289,6 +289,13 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
         } catch (SQLException e) {
             throw JdbcUtils.wrapException(e, "retrieve schema and catalog metadata", JdbcActionType.METADATA);
         } finally {
+            if(rs != null) {
+                try {
+                    rs.close();
+                } catch (SQLException e) {
+                    e.printStackTrace();
+                }
+            }
             close(null);
         }
         return result;
@@ -580,6 +587,13 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
         } catch (SQLException e) {
             logger.error("Error retrieving catalog metadata", e);
         } finally {
+            if(rs != null){
+                try {
+                    rs.close();
+                } catch (SQLException e) {
+                    e.printStackTrace();
+                }
+            }
             close(connection);
             logger.debug("Retrieved {} catalogs", catalogs.size());
         }
@@ -755,6 +769,9 @@ public class JdbcDataContext extends AbstractDataContext implements UpdateableDa
         ResultSet rs = metaData.getTables(_catalogName, null, null, JdbcUtils.getTableTypesAsStrings(_tableTypes));
         while (rs.next()) {
             schemas.add(rs.getString("TABLE_SCHEM"));
+        }
+        if(rs != null){
+            rs.close();
         }
         return schemas;
     }


### PR DESCRIPTION
 Call ResultSet.close() method when after getting result from ResultSet, otherwise it will cause memory overflow.(for example use impala
 jdbc)

https://issues.apache.org/jira/projects/METAMODEL/issues/METAMODEL-1208