### PR TITLE
Update hive-jdbc to version 2.3.4, addressing CVE-2018-1314

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -118,7 +118,7 @@
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-jdbc</artifactId>
-			<version>2.3.2</version>
+			<version>2.3.4</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2018-1314 for details on the vulnerability in the previous versions.