### PR TITLE
METAMODEL-1207: fix regex pattern in order to fetch the correct version in all cases

### DIFF
--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/AbstractQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/AbstractQueryRewriter.java
@@ -31,6 +31,8 @@ import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.metamodel.jdbc.JdbcDataContext;
 import org.apache.metamodel.query.AbstractQueryClause;
@@ -473,8 +475,11 @@ public abstract class AbstractQueryRewriter implements IQueryRewriter {
     private int getDatabaseMajorVersion(String version) {
         int firstDot = -1;
         if(version != null) {
-            version = version.replaceAll("[^0-9.]+", "");
-            firstDot = version.indexOf('.');
+            Matcher matcher = Pattern.compile("[0-9]+(\\.[0-9]+)+").matcher(version);
+            if (matcher.find()){
+                version = matcher.group();
+                firstDot = version.indexOf('.');
+            }
         }
         if(firstDot >= 0) {
             return Integer.valueOf(version.substring(0, firstDot));

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/AbstractQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/AbstractQueryRewriter.java
@@ -31,8 +31,6 @@ import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.apache.metamodel.jdbc.JdbcDataContext;
 import org.apache.metamodel.query.AbstractQueryClause;
@@ -466,25 +464,9 @@ public abstract class AbstractQueryRewriter implements IQueryRewriter {
     protected boolean isSupportedVersion(String databaseProductName, int databaseVersion) {
 
         if(databaseProductName.equals(_dataContext.getDatabaseProductName())
-                && databaseVersion <= getDatabaseMajorVersion(_dataContext.getDatabaseVersion())) {
+                && databaseVersion <= VersionParser.getMajorVersion(_dataContext.getDatabaseVersion())) {
             return true;
         }
         return false;
-    }
-
-    private int getDatabaseMajorVersion(String version) {
-        int firstDot = -1;
-        if(version != null) {
-            Matcher matcher = Pattern.compile("[0-9]+(\\.[0-9]+)+").matcher(version);
-            if (matcher.find()){
-                version = matcher.group();
-                firstDot = version.indexOf('.');
-            }
-        }
-        if(firstDot >= 0) {
-            return Integer.valueOf(version.substring(0, firstDot));
-        } else {
-            return 0;
-        }
     }
 }

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/VersionParser.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/VersionParser.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.jdbc.dialects;
+
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Responsible to parse an input string and return a substring that
+ * represents the version based on {@link VERSION_REGEX}.
+ */
+class VersionParser {
+    private static final String VERSION_REGEX = "[0-9]+(\\.[0-9]+)+";
+
+
+    /**
+     * @param stringToParse the string that contains the version.
+     * @return If the version exists returns the full version else empty string.
+     */
+    public static String getVersion(String stringToParse){
+        if(stringToParse != null) {
+            Matcher matcher = Pattern.compile(VERSION_REGEX).matcher(stringToParse);
+            if (matcher.find()){
+                return matcher.group();
+            }
+        }
+        return "";
+    }
+
+    /**
+     * @param stringToParse the string that contains the version.
+     * @return If the version exists returns only the number(s) before the first dot else 0.
+     */
+    public static int getMajorVersion(String stringToParse){
+        String fullVersion = getVersion(stringToParse);
+        if(fullVersion != null) {
+            int firstDot = fullVersion.indexOf('.');
+            if(firstDot >= 0) {
+                return Integer.valueOf(fullVersion.substring(0, firstDot));
+            }
+        }
+        return 0;
+    }
+}

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/VersionParser.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/VersionParser.java
@@ -23,12 +23,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Responsible to parse an input string and return a substring that
- * represents the version based on {@link VERSION_REGEX}.
+ * This class is responsible for parsing version numbers in software products.
+ * Version strings are expected to be numeric and dot-separated.
  */
 class VersionParser {
-    private static final String VERSION_REGEX = "[0-9]+(\\.[0-9]+)+";
+    private static final Pattern versionPattern = Pattern.compile( "[0-9]+(\\.[0-9]+)+");
 
+    private VersionParser(){}
 
     /**
      * @param stringToParse the string that contains the version.
@@ -36,7 +37,7 @@ class VersionParser {
      */
     public static String getVersion(String stringToParse){
         if(stringToParse != null) {
-            Matcher matcher = Pattern.compile(VERSION_REGEX).matcher(stringToParse);
+            Matcher matcher = versionPattern.matcher(stringToParse);
             if (matcher.find()){
                 return matcher.group();
             }
@@ -56,6 +57,6 @@ class VersionParser {
                 return Integer.valueOf(fullVersion.substring(0, firstDot));
             }
         }
-        return 0;
+        return -1;
     }
 }

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/OracleQueryRewriterTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/OracleQueryRewriterTest.java
@@ -93,6 +93,14 @@ public class OracleQueryRewriterTest {
     }
 
     @Test
+    public void testOffsetFetchVersionSpecialCaseCheck() throws SQLException {
+        setMetaData(DATABASE_PRODUCT_ORACLE, "Oracle Database 11g Enterprise Edition Release 11.2.0.1.0 - 64bit Production");
+
+        Query query = new Query().from(table).select(column).setFirstRow(1000).setMaxRows(100);
+        Assert.assertEquals("The query shouldn't be rewritten.", query.toSql(), qr.rewriteQuery(query));
+    }
+
+    @Test
     public void testOffsetFetchVersionIsNull() throws SQLException {
         setMetaData(DATABASE_PRODUCT_ORACLE, null);
 

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/OracleQueryRewriterTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/OracleQueryRewriterTest.java
@@ -93,14 +93,6 @@ public class OracleQueryRewriterTest {
     }
 
     @Test
-    public void testOffsetFetchVersionSpecialCaseCheck() throws SQLException {
-        setMetaData(DATABASE_PRODUCT_ORACLE, "Oracle Database 11g Enterprise Edition Release 11.2.0.1.0 - 64bit Production");
-
-        Query query = new Query().from(table).select(column).setFirstRow(1000).setMaxRows(100);
-        Assert.assertEquals("The query shouldn't be rewritten.", query.toSql(), qr.rewriteQuery(query));
-    }
-
-    @Test
     public void testOffsetFetchVersionIsNull() throws SQLException {
         setMetaData(DATABASE_PRODUCT_ORACLE, null);
 

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/VersionParserTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/VersionParserTest.java
@@ -22,61 +22,61 @@ import junit.framework.TestCase;
 
 public class VersionParserTest extends TestCase {
 
-	public void testGetVersion() throws Exception {
-		String version = VersionParser.getVersion("10.11.0");
-		assertEquals("10.11.0", version);
-	}
-	public void testGetVersionEmpty() throws Exception {
-		String version = VersionParser.getVersion("string with out version");
-		assertEquals("", version);
-	}
-	public void testGetVersionNull() throws Exception {
-		String version = VersionParser.getVersion(null);
-		assertEquals("", version);
-	}
-	public void testGetVersionWithLetters() throws Exception {
-		String version = VersionParser.getVersion("test 10.11.0V test");
-		assertEquals("10.11.0", version);
-	}
+    public void testGetVersion() throws Exception {
+        String version = VersionParser.getVersion("10.11.0");
+        assertEquals("10.11.0", version);
+    }
+    public void testGetVersionEmpty() throws Exception {
+	    String version = VersionParser.getVersion("string with out version");
+	    assertEquals("", version);
+    }
+    public void testGetVersionNull() throws Exception {
+        String version = VersionParser.getVersion(null);
+        assertEquals("", version);
+    }
+    public void testGetVersionWithLetters() throws Exception {
+        String version = VersionParser.getVersion("test 10.11.0V test");
+        assertEquals("10.11.0", version);
+    }
 	public void testGetVersionWithSpecialChars() throws Exception {
-		String version = VersionParser.getVersion("!@#test. 10.11.0V .test");
-		assertEquals("10.11.0", version);
-	}
+	    String version = VersionParser.getVersion("!@#test. 10.11.0V .test");
+	    assertEquals("10.11.0", version);
+    }
 	public void testGetVersionWithLettersAndNumbers() throws Exception {
-		String version = VersionParser.getVersion("10 55g test 10.11.0 test 100");
-		assertEquals("10.11.0", version);
-	}
-	public void testGetVersionMultipleVersions() throws Exception {
-		String version = VersionParser.getVersion("test 10.11.0 11.11 test");
-		assertEquals("10.11.0", version);
-	}
+	    String version = VersionParser.getVersion("10 55g test 10.11.0 test 100");
+	    assertEquals("10.11.0", version);
+    }
+    public void testGetVersionMultipleVersions() throws Exception {
+        String version = VersionParser.getVersion("test 10.11.0 11.11 test");
+        assertEquals("10.11.0", version);
+    }
 
-	public void testGetMajorVersion() throws Exception {
-		int version = VersionParser.getMajorVersion("10.11.0");
-		assertEquals(10, version);
-	}
-	public void testGetMajorVersionEmpty() throws Exception {
-		int version = VersionParser.getMajorVersion("string with out version");
-		assertEquals(0, version);
-	}
+    public void testGetMajorVersion() throws Exception {
+        int version = VersionParser.getMajorVersion("10.11.0");
+        assertEquals(10, version);
+    }
+    public void testGetMajorVersionEmpty() throws Exception {
+        int version = VersionParser.getMajorVersion("string with out version");
+        assertEquals(-1, version);
+    }
 	public void testGetMajorVersionNull() throws Exception {
-		int version = VersionParser.getMajorVersion(null);
-		assertEquals(0, version);
-	}
-	public void testGetMajorVersionWithLetters() throws Exception {
-		int version = VersionParser.getMajorVersion("test 10.11.0V test");
-		assertEquals(10, version);
-	}
-	public void testGetMajorVersionWithSpecialChars() throws Exception {
-		int version = VersionParser.getMajorVersion("!@#test. .10.11.0V .test");
-		assertEquals(10, version);
-	}
-	public void testGetMajorVersionWithLettersAndNumbers() throws Exception {
-		int version = VersionParser.getMajorVersion("10 55g test 10.11.0 test 100");
-		assertEquals(10, version);
-	}
-	public void testGetMajorVersionMultipleVersions() throws Exception {
-		int version = VersionParser.getMajorVersion("test 10.11.0V 11.11 test");
-		assertEquals(10, version);
-	}
+        int version = VersionParser.getMajorVersion(null);
+        assertEquals(-1, version);
+    }
+    public void testGetMajorVersionWithLetters() throws Exception {
+        int version = VersionParser.getMajorVersion("test 10.11.0V test");
+        assertEquals(10, version);
+    }
+    public void testGetMajorVersionWithSpecialChars() throws Exception {
+        int version = VersionParser.getMajorVersion("!@#test. .10.11.0V .test");
+        assertEquals(10, version);
+    }
+    public void testGetMajorVersionWithLettersAndNumbers() throws Exception {
+        int version = VersionParser.getMajorVersion("10 55g test 10.11.0 test 100");
+        assertEquals(10, version);
+    }
+    public void testGetMajorVersionMultipleVersions() throws Exception {
+        int version = VersionParser.getMajorVersion("test 10.11.0V 11.11 test");
+        assertEquals(10, version);
+    }
 }

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/VersionParserTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/VersionParserTest.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.jdbc.dialects;
+
+import junit.framework.TestCase;
+
+public class VersionParserTest extends TestCase {
+
+	public void testGetVersion() throws Exception {
+		String version = VersionParser.getVersion("10.11.0");
+		assertEquals("10.11.0", version);
+	}
+	public void testGetVersionEmpty() throws Exception {
+		String version = VersionParser.getVersion("string with out version");
+		assertEquals("", version);
+	}
+	public void testGetVersionNull() throws Exception {
+		String version = VersionParser.getVersion(null);
+		assertEquals("", version);
+	}
+	public void testGetVersionWithLetters() throws Exception {
+		String version = VersionParser.getVersion("test 10.11.0V test");
+		assertEquals("10.11.0", version);
+	}
+	public void testGetVersionWithSpecialChars() throws Exception {
+		String version = VersionParser.getVersion("!@#test. 10.11.0V .test");
+		assertEquals("10.11.0", version);
+	}
+	public void testGetVersionWithLettersAndNumbers() throws Exception {
+		String version = VersionParser.getVersion("10 55g test 10.11.0 test 100");
+		assertEquals("10.11.0", version);
+	}
+	public void testGetVersionMultipleVersions() throws Exception {
+		String version = VersionParser.getVersion("test 10.11.0 11.11 test");
+		assertEquals("10.11.0", version);
+	}
+
+	public void testGetMajorVersion() throws Exception {
+		int version = VersionParser.getMajorVersion("10.11.0");
+		assertEquals(10, version);
+	}
+	public void testGetMajorVersionEmpty() throws Exception {
+		int version = VersionParser.getMajorVersion("string with out version");
+		assertEquals(0, version);
+	}
+	public void testGetMajorVersionNull() throws Exception {
+		int version = VersionParser.getMajorVersion(null);
+		assertEquals(0, version);
+	}
+	public void testGetMajorVersionWithLetters() throws Exception {
+		int version = VersionParser.getMajorVersion("test 10.11.0V test");
+		assertEquals(10, version);
+	}
+	public void testGetMajorVersionWithSpecialChars() throws Exception {
+		int version = VersionParser.getMajorVersion("!@#test. .10.11.0V .test");
+		assertEquals(10, version);
+	}
+	public void testGetMajorVersionWithLettersAndNumbers() throws Exception {
+		int version = VersionParser.getMajorVersion("10 55g test 10.11.0 test 100");
+		assertEquals(10, version);
+	}
+	public void testGetMajorVersionMultipleVersions() throws Exception {
+		int version = VersionParser.getMajorVersion("test 10.11.0V 11.11 test");
+		assertEquals(10, version);
+	}
+}


### PR DESCRIPTION
Resolves METAMODEL-1207

The Regex pattern used to fetch the database major version is repleced with the correct one that covers all possible cases. Also the fix is confimed with unit test.
