### PR TITLE
Use Scan.addColumn(...) instead  of Scan.addFamily(...) when has qualifier.

### DIFF
--- a/hbase/src/main/java/org/apache/metamodel/hbase/HBaseDataContext.java
+++ b/hbase/src/main/java/org/apache/metamodel/hbase/HBaseDataContext.java
@@ -222,9 +222,11 @@ public class HBaseDataContext extends QueryPostprocessDataContext implements Upd
         for (Column column : columns) {
             if (!column.isPrimaryKey()) {
                 final int colonIndex = column.getName().indexOf(':');
+                final int len = column.getName().length();
                 if (colonIndex != -1) {
                     String family = column.getName().substring(0, colonIndex);
-                    scan.addFamily(family.getBytes());
+                    String colName = column.getName().substring(colonIndex + 1, len);
+                    scan.addColumn(family.getBytes(),colName.getBytes());
                 } else {
                     scan.addFamily(column.getName().getBytes());
                 }

--- a/hbase/src/main/java/org/apache/metamodel/hbase/HBaseDataContext.java
+++ b/hbase/src/main/java/org/apache/metamodel/hbase/HBaseDataContext.java
@@ -224,9 +224,9 @@ public class HBaseDataContext extends QueryPostprocessDataContext implements Upd
                 final int colonIndex = column.getName().indexOf(':');
                 final int len = column.getName().length();
                 if (colonIndex != -1) {
-                    String family = column.getName().substring(0, colonIndex);
-                    String colName = column.getName().substring(colonIndex + 1, len);
-                    scan.addColumn(family.getBytes(),colName.getBytes());
+                    final String family = column.getName().substring(0, colonIndex);
+                    final String colName = column.getName().substring(colonIndex + 1, len);
+                    scan.addColumn(family.getBytes(), colName.getBytes());
                 } else {
                     scan.addFamily(column.getName().getBytes());
                 }


### PR DESCRIPTION
when columns contain family and column name,using Scan.addColumn(...) method to reduce network pressure and decrease unnecessary columns.