### PR TITLE
Recursively get SelectItems from FilterItems when using nested loop join

### DIFF
--- a/core/src/main/java/org/apache/metamodel/MetaModelHelper.java
+++ b/core/src/main/java/org/apache/metamodel/MetaModelHelper.java
@@ -253,20 +253,25 @@ public final class MetaModelHelper {
      */
     private static Set<FilterItem> applicableFilters(Collection<FilterItem> filters,
             Collection<SelectItem> selectItemList) {
+        final Set<SelectItem> items = new HashSet<>(selectItemList);
 
-        Set<SelectItem> items = new HashSet<SelectItem>(selectItemList);
+        return filters.stream().filter(fi -> items.containsAll(getSelectItems(fi))).collect(Collectors.toSet());
+    }
 
-        return filters.stream().filter(fi -> {
-            Collection<SelectItem> fiSelectItems = new ArrayList<>();
-            fiSelectItems.add(fi.getSelectItem());
-            Object operand = fi.getOperand();
+    private static Set<SelectItem> getSelectItems(final FilterItem filterItem) {
+        final Set<SelectItem> itemsInFilter = new HashSet<>();
+        if (filterItem.getChildItemCount() == 0) {
+            itemsInFilter.add(filterItem.getSelectItem());
+            final Object operand = filterItem.getOperand();
             if (operand instanceof SelectItem) {
-                fiSelectItems.add((SelectItem) operand);
+                itemsInFilter.add((SelectItem) operand);
             }
-
-            return items.containsAll(fiSelectItems);
-
-        }).collect(Collectors.toSet());
+        } else {
+            for (FilterItem childFilterItem : filterItem.getChildItems()) {
+                itemsInFilter.addAll(getSelectItems(childFilterItem));
+            }
+        }
+        return itemsInFilter;
     }
 
     public static DataSet getFiltered(DataSet dataSet, Iterable<FilterItem> filterItems) {

--- a/pojo/src/test/java/org/apache/metamodel/pojo/Role.java
+++ b/pojo/src/test/java/org/apache/metamodel/pojo/Role.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.pojo;
+
+class Role {
+    private int id; 
+    private String name;
+
+    public Role(final int id, final String name) {
+        this.name = name;
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(final int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+}

--- a/pojo/src/test/java/org/apache/metamodel/pojo/User.java
+++ b/pojo/src/test/java/org/apache/metamodel/pojo/User.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.pojo;
+
+import java.util.Date;
+
+class User {
+    private String name;
+    private Date expirationDate;
+    private int roleId;
+
+    public User(final String name, final Date expirationDate, final int roleId) {
+        this.name = name;
+        this.expirationDate = expirationDate;
+        this.roleId = roleId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public Date getExpirationDate() {
+        return expirationDate;
+    }
+
+    public void setExpirationDate(final Date expirationDate) {
+        this.expirationDate = expirationDate;
+    }
+
+    public int getRoleId() {
+        return roleId;
+    }
+
+    public void setRole(final int roleId) {
+        this.roleId = roleId;
+    }
+}


### PR DESCRIPTION
Fixes MM-1211.

When determining the Carthesian product for a query over multiple tables make sure that when determining which FilterItems are applicable for the query the SelectItems for compound FilterItems are also taken into consideration by recursively inspecting the children of the compound FilterItems.