### PR TITLE
METAMODEL-1217 - Fixes dropping JDBC Tables with view as TableType

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### Apache MetaModel _WIP_
 
+ * [METAMODEL-1217] - Fixes dropping JDBC Tables with view as TableType
  * [METAMODEL-1215] - Removed deprecated code from pre-Java 8 times.
  * [METAMODEL-1214] - CompositeDataContext uses wrappedSchema for comparison when searching for it in the cache.
  * [METAMODEL-1213] - Fixed concurrency bug in single-line CSV parallel reader.

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDropTableBuilder.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDropTableBuilder.java
@@ -66,12 +66,12 @@ final class JdbcDropTableBuilder extends AbstractTableDropBuilder implements Tab
     protected String createSqlStatement() {
         final Table table = getTable();
         final FromItem fromItem = new FromItem(table);
-        final String tableLabel = _queryRewriter.rewriteFromItem(fromItem);
+        final String qualifiedTableName = _queryRewriter.rewriteFromItem(fromItem);
 
         if (table.getType() != null && table.getType() == TableType.VIEW) {
-            return "DROP VIEW " + tableLabel;
+            return "DROP VIEW " + qualifiedTableName;
         } else {
-            return "DROP TABLE " + tableLabel;
+            return "DROP TABLE " + qualifiedTableName;
         }
     }
 

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDropTableBuilder.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/JdbcDropTableBuilder.java
@@ -29,6 +29,7 @@ import org.apache.metamodel.jdbc.dialects.IQueryRewriter;
 import org.apache.metamodel.query.FromItem;
 import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
+import org.apache.metamodel.schema.TableType;
 
 /**
  * {@link TableDropBuilder} that issues an SQL DROP TABLE statement
@@ -63,10 +64,15 @@ final class JdbcDropTableBuilder extends AbstractTableDropBuilder implements Tab
     }
 
     protected String createSqlStatement() {
-        FromItem fromItem = new FromItem(getTable());
-        String tableLabel = _queryRewriter.rewriteFromItem(fromItem);
+        final Table table = getTable();
+        final FromItem fromItem = new FromItem(table);
+        final String tableLabel = _queryRewriter.rewriteFromItem(fromItem);
 
-        return "DROP TABLE " + tableLabel;
+        if (table.getType() != null && table.getType() == TableType.VIEW) {
+            return "DROP VIEW " + tableLabel;
+        } else {
+            return "DROP TABLE " + tableLabel;
+        }
     }
 
 }


### PR DESCRIPTION
Fixes: [METAMODEL-1217 - Drop table doesn't work for views with JDBC Tables](https://issues.apache.org/jira/browse/METAMODEL-1217)