### PR TITLE
MM-1218 Compare schemas with name null

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ### Apache MetaModel _WIP_
 
- * [METAMODEL-1217] - Fixes dropping JDBC Tables with view as TableType
+ * [METAMODEL-1218] - Fixed comparing schemas with name null.
+ * [METAMODEL-1217] - Fixed dropping JDBC Tables with view as TableType.
  * [METAMODEL-1215] - Removed deprecated code from pre-Java 8 times.
  * [METAMODEL-1214] - CompositeDataContext uses wrappedSchema for comparison when searching for it in the cache.
  * [METAMODEL-1213] - Fixed concurrency bug in single-line CSV parallel reader.

--- a/core/src/main/java/org/apache/metamodel/schema/AbstractSchema.java
+++ b/core/src/main/java/org/apache/metamodel/schema/AbstractSchema.java
@@ -173,10 +173,16 @@ public abstract class AbstractSchema implements Schema {
 
     @Override
     public final int compareTo(Schema that) {
-        int diff = getQualifiedLabel().compareTo(that.getQualifiedLabel());
-        if (diff == 0) {
-            diff = toString().compareTo(that.toString());
+        if (getQualifiedLabel() == null) {
+            return that.getQualifiedLabel() == null ? 0 : -1;
+        } else if (that.getQualifiedLabel() == null) {
+            return 1;
+        } else {
+            int diff = getQualifiedLabel().compareTo(that.getQualifiedLabel());
+            if (diff == 0) {
+                diff = toString().compareTo(that.toString());
+            }
+            return diff;
         }
-        return diff;
     }
 }


### PR DESCRIPTION
Closes: [METAMODEL-1218 - Can't compare schema's without a name](https://issues.apache.org/jira/browse/METAMODEL-1218)