### PR TITLE
Change doclint suppression in javadoc pluging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@ under the License.
 				</executions>
 				<configuration>
 					<excludePackageNames>com.sugarcrm.ws.soap</excludePackageNames>
-					<additionalparam>-Xdoclint:none</additionalparam>
+					<doclint>none</doclint>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
For some reason having the -Xdoclint:none in the additionalParam tag no longer works for me (probably because of my java version) for ignoring javadoc problems, so I'm changing this to using the doclint tag.

The normal travis build for MetaModel doesn't fail on this, so I think it is introduced by newer java version, for me it fails both with openjdk 8.0.212.04 and Oracle jdk 1.8.0_211. I haven't installed an older version of java 8 to see if the old implementation works there, but I think it does, because travis builds successfull. This change however seems to work on all java versions. It was inspired by https://stackoverflow.com/questions/52547306/maven-javadoc-plugin-not-accepting-additionalparam-xdoclintnone-additionalpa.
