### PR TITLE
METAMODEL-82 - Fix integers in double columns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ### Apache MetaModel _WIP_
+ * [METAMODEL-82] - Detect Column Types with Excel datastores
  * [METAMODEL-1221] - Upgrade to Elasticsearch 7.3
  * Bind Travis build to Trusty distribution to avoid CI build failures.
 

--- a/excel/src/main/java/org/apache/metamodel/excel/ExcelUtils.java
+++ b/excel/src/main/java/org/apache/metamodel/excel/ExcelUtils.java
@@ -275,20 +275,20 @@ final class ExcelUtils {
 
     private static Object evaluateCell(final Workbook workbook, final Cell cell, final ColumnType expectedColumnType) {
         final Object value = getCellValueAsObject(workbook, cell);
-        if (value == null || value.getClass().equals(expectedColumnType.getJavaEquivalentClass())) {
+        if (value == null || value.getClass().equals(expectedColumnType.getJavaEquivalentClass()) || (value
+                .getClass()
+                .equals(Integer.class) && expectedColumnType.getJavaEquivalentClass().equals(Double.class))) {
             return value;
+        } else {
+            if (logger.isWarnEnabled()) {
+                logger
+                        .warn("Cell ({},{}) has the value '{}' of data type '{}', which doesn't match the detected "
+                                + "column's data type '{}'. This cell gets value NULL in the DataSet.", cell
+                                        .getRowIndex(), cell.getColumnIndex(), value, value.getClass().getSimpleName(),
+                                expectedColumnType);
+            }
+            return null;
         }
-
-        // Don't log when an Integer value is in a Double column type
-        if (!(value.getClass().equals(Integer.class) && expectedColumnType
-                .getJavaEquivalentClass()
-                .equals(Double.class)) && logger.isWarnEnabled()) {
-            logger
-                    .warn("Cell ({},{}) has the value '{}' of data type '{}', which doesn't match the detected "
-                            + "column's data type '{}'. This cell gets value NULL in the DataSet.", cell.getRowIndex(),
-                            cell.getColumnIndex(), value, value.getClass().getSimpleName(), expectedColumnType);
-        }
-        return null;
     }
 
     private static String getFormulaCellValue(Workbook workbook, Cell cell) {

--- a/excel/src/test/java/org/apache/metamodel/excel/ExcelDataContextTest.java
+++ b/excel/src/test/java/org/apache/metamodel/excel/ExcelDataContextTest.java
@@ -841,7 +841,11 @@ public class ExcelDataContextTest extends TestCase {
                 .from(table)
                 .select("MIXING_DOUBLE_AND_INT")
                 .execute();
-        IntStream.range(0, 20).forEach(i -> assertTrue(testWrongDatatypeDataSet.next()));
+        IntStream.range(0, 19).forEach(i -> {
+            assertTrue(testWrongDatatypeDataSet.next());
+            assertNotNull(testWrongDatatypeDataSet.getRow().getValue(0));
+        });
+        assertTrue(testWrongDatatypeDataSet.next());
         assertNull(testWrongDatatypeDataSet.getRow().getValue(0));
         assertFalse(testWrongDatatypeDataSet.next());
     }
@@ -919,7 +923,7 @@ public class ExcelDataContextTest extends TestCase {
         final ExcelDataContext dataContext = new ExcelDataContext(copyOf("src/test/resources/different_datatypes.xls"),
                 new ExcelConfiguration(ExcelConfiguration.DEFAULT_COLUMN_NAME_LINE, null, true, false, true, 19));
         final Table table = dataContext.getDefaultSchema().getTable(0);
-        dataContext.executeUpdate(new InsertInto(table).value("INTEGER", 123));
+        dataContext.executeUpdate(new InsertInto(table).value("INTEGER", Integer.valueOf(123)));
         final DataSet dataSet = dataContext.query().from(table).selectAll().where("INTEGER").eq(123).execute();
         assertTrue(dataSet.next());
     }
@@ -936,7 +940,7 @@ public class ExcelDataContextTest extends TestCase {
         final ExcelDataContext dataContext = new ExcelDataContext(copyOf("src/test/resources/different_datatypes.xls"),
                 new ExcelConfiguration(ExcelConfiguration.DEFAULT_COLUMN_NAME_LINE, null, true, false, true, 19));
         final Table table = dataContext.getDefaultSchema().getTable(0);
-        dataContext.executeUpdate(new Update(table).value("INTEGER", 1).value("INTEGER", 123));
+        dataContext.executeUpdate(new Update(table).value("INTEGER", 1).value("INTEGER", Integer.valueOf(123)));
         final DataSet dataSet = dataContext.query().from(table).selectAll().where("INTEGER").eq(123).execute();
         assertTrue(dataSet.next());
     }


### PR DESCRIPTION
Closes: [METAMODEL-82](https://issues.apache.org/jira/browse/METAMODEL-82)

I found a bug in my implementation [MM-PR234](https://github.com/apache/metamodel/pull/234): When Integer values were in a Double column, then these values were set to NULL when querying the result.