### PR TITLE
METAMODEL-1201 Remove guava dependency in package jdbc

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -29,10 +29,6 @@
 			<groupId>commons-pool</groupId>
 			<artifactId>commons-pool</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-		</dependency>
 
 		<!-- Test dependencies -->
 		<dependency>


### PR DESCRIPTION
The actual code using guava class CharMatcher was removed in PR https://github.com/apache/metamodel/pull/195 (METAMODEL-1205)
But the guava dependency is still part of POM.
Since the dependency is no more required removing the same