### PR TITLE
METAMODEL-1224: Fixed PostgreSQL compatibility (upgrading driver+tests)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,9 @@
+### Apache MetaModel [WIP]
+
+ * [METAMODEL-1224] - Ensured compatibility with newer versions of PostgreSQL
+
 ### Apache MetaModel 5.3.2
+
  * Upgrade to Jackson 2.10.1
  * Upgrade to Spring 5.2.2
  * [METAMODEL-82] - Detect Column Types with Excel datastores

--- a/core/src/main/java/org/apache/metamodel/query/FromItem.java
+++ b/core/src/main/java/org/apache/metamodel/query/FromItem.java
@@ -222,7 +222,8 @@ public class FromItem extends BaseObject implements QueryItem, Cloneable {
         }
         StringBuilder sb = new StringBuilder();
         if (_table != null) {
-            if (_table.getSchema() != null && _table.getSchema().getName() != null && !_table.getSchema().getName().isEmpty()) {
+            if (_table.getSchema() != null && _table.getSchema().getName() != null
+                    && !_table.getSchema().getName().isEmpty()) {
                 sb.append(_table.getSchema().getName());
                 sb.append('.');
             }

--- a/core/src/main/java/org/apache/metamodel/query/FromItem.java
+++ b/core/src/main/java/org/apache/metamodel/query/FromItem.java
@@ -222,7 +222,7 @@ public class FromItem extends BaseObject implements QueryItem, Cloneable {
         }
         StringBuilder sb = new StringBuilder();
         if (_table != null) {
-            if (_table.getSchema() != null && _table.getSchema().getName() != null) {
+            if (_table.getSchema() != null && _table.getSchema().getName() != null && !_table.getSchema().getName().isEmpty()) {
                 sb.append(_table.getSchema().getName());
                 sb.append('.');
             }

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>9.3-1104-jdbc4</version>
+			<version>42.2.11</version>
 			<!-- optional instead of test-scoped because we code against it in the rewriter class -->
 			<optional>true</optional>
 		</dependency>

--- a/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/PostgresqlQueryRewriter.java
+++ b/jdbc/src/main/java/org/apache/metamodel/jdbc/dialects/PostgresqlQueryRewriter.java
@@ -135,7 +135,7 @@ public class PostgresqlQueryRewriter extends LimitOffsetQueryRewriter {
             Schema schema = table.getSchema();
             if (schema != null) {
                 String schemaName = schema.getName();
-                if (schemaName != null) {
+                if (schemaName != null && !schemaName.isEmpty()) {
                     result = result.replaceFirst(schemaName, '\"' + schema.getName() + '\"');
                 }
             }

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/PostgresqlQueryRewriterTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/PostgresqlQueryRewriterTest.java
@@ -18,12 +18,17 @@
  */
 package org.apache.metamodel.jdbc.dialects;
 
+import static org.junit.Assert.assertEquals;
+
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
+import org.apache.metamodel.query.Query;
+import org.apache.metamodel.query.SelectItem;
 import org.apache.metamodel.schema.Column;
 import org.apache.metamodel.schema.ColumnType;
 import org.apache.metamodel.schema.MutableColumn;
+import org.apache.metamodel.schema.MutableTable;
 import org.easymock.EasyMock;
 import org.junit.Test;
 
@@ -45,5 +50,19 @@ public class PostgresqlQueryRewriterTest {
         queryRewriter.setStatementParameter(statementMock, 0, column, value);
 
         EasyMock.verify(statementMock);
+    }
+    
+    @Test
+    public void testApproximateCountQuery() {
+        final SelectItem selectItem = SelectItem.getCountAllItem();
+        selectItem.setFunctionApproximationAllowed(true);
+        final Query query = new Query();
+        query.select(selectItem);
+        query.from(new MutableTable("tbl"));
+        assertEquals("SELECT APPROXIMATE COUNT(*) FROM tbl", query.toSql());
+        
+        final PostgresqlQueryRewriter queryRewriter = new PostgresqlQueryRewriter(null);
+        final String sql = queryRewriter.rewriteQuery(query);
+        assertEquals("SELECT COUNT(*) FROM tbl", sql);
     }
 }

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/PostgresqlQueryRewriterTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/PostgresqlQueryRewriterTest.java
@@ -28,6 +28,7 @@ import org.apache.metamodel.query.SelectItem;
 import org.apache.metamodel.schema.Column;
 import org.apache.metamodel.schema.ColumnType;
 import org.apache.metamodel.schema.MutableColumn;
+import org.apache.metamodel.schema.MutableSchema;
 import org.apache.metamodel.schema.MutableTable;
 import org.easymock.EasyMock;
 import org.junit.Test;
@@ -53,12 +54,12 @@ public class PostgresqlQueryRewriterTest {
     }
     
     @Test
-    public void testApproximateCountQuery() {
+    public void testApproximateCountQueryAndBlankSchemaName() {
         final SelectItem selectItem = SelectItem.getCountAllItem();
         selectItem.setFunctionApproximationAllowed(true);
         final Query query = new Query();
         query.select(selectItem);
-        query.from(new MutableTable("tbl"));
+        query.from(new MutableTable("tbl").setSchema(new MutableSchema("")));
         assertEquals("SELECT APPROXIMATE COUNT(*) FROM tbl", query.toSql());
         
         final PostgresqlQueryRewriter queryRewriter = new PostgresqlQueryRewriter(null);

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/PostgresqlQueryRewriterTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/dialects/PostgresqlQueryRewriterTest.java
@@ -61,7 +61,7 @@ public class PostgresqlQueryRewriterTest {
         query.select(selectItem);
         query.from(new MutableTable("tbl").setSchema(new MutableSchema("")));
         assertEquals("SELECT APPROXIMATE COUNT(*) FROM tbl", query.toSql());
-        
+
         final PostgresqlQueryRewriter queryRewriter = new PostgresqlQueryRewriter(null);
         final String sql = queryRewriter.rewriteQuery(query);
         assertEquals("SELECT COUNT(*) FROM tbl", sql);

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
@@ -504,15 +504,14 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         });
         
         try {
-            
             final Optional<Integer> insertedRows = updateSummary.getInsertedRows();
             assertTrue(insertedRows.isPresent());
             assertEquals(2, insertedRows.get().intValue());
-            
+
             final Optional<Iterable<Object>> generatedKeys = updateSummary.getGeneratedKeys();
             assertTrue(generatedKeys.isPresent());
             assertEquals("[1, 2]", generatedKeys.get().toString());
-            
+
         } finally {
             if (schema.getTableByName(tableName) != null) {
                 dc.executeUpdate(new DropTable(schema, tableName));

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
@@ -502,15 +502,22 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
                 cb.insertInto(table).value("foo", "world").execute();
             }
         });
-
-        final Optional<Integer> insertedRows = updateSummary.getInsertedRows();
-        assertTrue(insertedRows.isPresent());
-        assertEquals(2, insertedRows.get().intValue());
         
-        final Optional<Iterable<Object>> generatedKeys = updateSummary.getGeneratedKeys();
-        assertTrue(generatedKeys.isPresent());
-        assertEquals("[1, 2]", generatedKeys.get().toString());
-        
+        try {
+            
+            final Optional<Integer> insertedRows = updateSummary.getInsertedRows();
+            assertTrue(insertedRows.isPresent());
+            assertEquals(2, insertedRows.get().intValue());
+            
+            final Optional<Iterable<Object>> generatedKeys = updateSummary.getGeneratedKeys();
+            assertTrue(generatedKeys.isPresent());
+            assertEquals("[1, 2]", generatedKeys.get().toString());
+            
+        } finally {
+            if (schema.getTableByName(tableName) != null) {
+                dc.executeUpdate(new DropTable(schema, tableName));
+            }
+        }
     }
 
     public void testBlob() throws Exception {
@@ -737,7 +744,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         } catch (Exception e) {
             String message = e.getMessage().replaceAll("\n", " ");
             assertEquals(
-                    "Could not execute batch: INSERT INTO \"public\".\"my_table\" (\"person name\",age) VALUES ('John Doe','42'): Batch entry 0 INSERT INTO \"public\".\"my_table\" (\"person name\",age) VALUES ('John Doe','42') was aborted.  Call getNextException to see the cause.",
+                    "java.sql.BatchUpdateException: Batch entry 0 INSERT INTO \"public\".\"my_table\" (\"person name\",age) VALUES ('John Doe','42') was aborted: ERROR: column \"age\" is of type integer but expression is of type character varying   Hint: You will need to rewrite or cast the expression.   Position: 64  Call getNextException to see other errors in the batch.",
                     message);
         } finally {
             dc.refreshSchemas();


### PR DESCRIPTION
Reproduced the issue in METAMODEL-1224 and tried upgrading the driver. This fixed the issue it seems, so here's an updated test since a few error messages have been updated from the driver's side as well.

Also, with the old driver the underlying issue seems to be that the schema name comes out as blank. I'm not sure why, but probably just a driver-and-database version conflict. I updated the code to not generate queries with blank schema names, but in those cases follow the routes of not prefixing tables with schema names.