### PR TITLE
METAMODEL-1225 Add ColumnTypingStrategies and use them in CSV module.

### DIFF
--- a/core/src/main/java/org/apache/metamodel/schema/typing/ColumnTypingContext.java
+++ b/core/src/main/java/org/apache/metamodel/schema/typing/ColumnTypingContext.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.schema.typing;
+
+import org.apache.metamodel.schema.ColumnType;
+import org.apache.metamodel.schema.Table;
+
+/**
+ * Defines the context for configuring the type for a single column in a
+ * {@link ColumnTypingStrategy} session.
+ */
+public interface ColumnTypingContext {
+
+    /**
+     * Gets the index of the column being configured.
+     *
+     * @return the column index
+     */
+    int getColumnIndex();
+
+    /**
+     * Gets the {@link Table} that the column is to pertain to. If the table is
+     * not yet available then this may return null.
+     *
+     * @return the associated table
+     */
+    Table getTable();
+
+    /**
+     * Gets the intrinsic column type, if this is defined in the datastore
+     * itself. This may be in the form of a header or such.
+     *
+     * @return the column type representing the datastore's column type
+     */
+    ColumnType getIntrinsicColumnType();
+}

--- a/core/src/main/java/org/apache/metamodel/schema/typing/ColumnTypingContextImpl.java
+++ b/core/src/main/java/org/apache/metamodel/schema/typing/ColumnTypingContextImpl.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.schema.typing;
+
+import org.apache.metamodel.schema.ColumnType;
+import org.apache.metamodel.schema.Table;
+
+
+/**
+ * An implementation of {@link ColumnTypingContext} that holds necessary context about the column being configured.
+ */
+public class ColumnTypingContextImpl implements ColumnTypingContext {
+
+    private final int columnIndex;
+
+    private final Table table;
+
+    private final ColumnType intrinsicColumnType;
+
+
+    /**
+     * Creates a context to conifgure a column for a specific table.
+     * @param table               The table that contains the column
+     * @param intrinsicColumnType The column type that represents the type configured in the datastore
+     * @param columnIndex         the index in the table of the column being configured.
+     */
+    public ColumnTypingContextImpl( Table table, ColumnType intrinsicColumnType, int columnIndex ) {
+        this.table = table;
+        this.intrinsicColumnType = intrinsicColumnType;
+        this.columnIndex = columnIndex;
+    }
+
+
+    /**
+     * Creates a context a column to be configured.
+     * @param columnIndex the index in the table of the column being configured.
+     */
+    public ColumnTypingContextImpl( int columnIndex ) {
+        this( null, null, columnIndex );
+    }
+
+
+    @Override
+    public int getColumnIndex() {
+        return columnIndex;
+    }
+
+
+    @Override
+    public Table getTable() {
+        return table;
+    }
+
+
+    @Override
+    public ColumnType getIntrinsicColumnType() {
+        return intrinsicColumnType;
+    }
+
+}

--- a/core/src/main/java/org/apache/metamodel/schema/typing/ColumnTypingSession.java
+++ b/core/src/main/java/org/apache/metamodel/schema/typing/ColumnTypingSession.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.schema.typing;
+
+
+import org.apache.metamodel.schema.Column;
+import org.apache.metamodel.schema.ColumnType;
+import org.apache.metamodel.schema.Table;
+
+import java.io.Closeable;
+
+/**
+ * Represents a 'session' in which a single {@link Table}'s {@link Column}s are
+ * assigned {@link ColumnType}s.
+ */
+public interface ColumnTypingSession extends Closeable {
+
+    /**
+     * Provides the type to apply for a given column.
+     *
+     * @param ctx the context of the column naming taking place. This contains
+     *            column index, intrinsic type etc. if available.
+     * @return the type to provide to the column.
+     */
+    public ColumnType getNextColumnType( ColumnTypingContext ctx );
+
+    /**
+     * Ends the column typing session.
+     */
+    @Override
+    void close();
+}

--- a/core/src/main/java/org/apache/metamodel/schema/typing/ColumnTypingStrategies.java
+++ b/core/src/main/java/org/apache/metamodel/schema/typing/ColumnTypingStrategies.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.schema.typing;
+
+import org.apache.metamodel.schema.ColumnType;
+
+import java.util.List;
+
+/**
+ * Constructors and common utilities for {@link ColumnTypingStrategy} objects.
+ */
+public class ColumnTypingStrategies {
+
+    private static final DefaultColumnTypingStrategy DEFAULT_STRATEGY = new DefaultColumnTypingStrategy();
+
+
+    private ColumnTypingStrategies() {
+    }
+
+
+    /**
+     * The default strategy assumes all column types are text.
+     *
+     * @return a strategy that defaults to text
+     */
+    public static ColumnTypingStrategy defaultStrategy() {
+        return DEFAULT_STRATEGY;
+    }
+
+
+    /**
+     * Utility to create a {@link CustomColumnTypingStrategy}.
+     *
+     * @param columnTypes the types of each column
+     * @return a strategy for custom type configuration
+     */
+    public static ColumnTypingStrategy customTypes( List<ColumnType> columnTypes ) {
+        return new CustomColumnTypingStrategy( columnTypes );
+    }
+
+
+    /**
+     * Utility to create a {@link CustomColumnTypingStrategy}.
+     *
+     * @param columnTypes the types of each column
+     * @return a strategy for custom type configuration
+     */
+    public static ColumnTypingStrategy customTypes( ColumnType... columnTypes ) {
+        return new CustomColumnTypingStrategy( columnTypes );
+    }
+}

--- a/core/src/main/java/org/apache/metamodel/schema/typing/ColumnTypingStrategy.java
+++ b/core/src/main/java/org/apache/metamodel/schema/typing/ColumnTypingStrategy.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.schema.typing;
+
+
+import java.io.Serializable;
+
+/**
+ * A strategy that defines the data types of columns. Such strategies are
+ * mostly used when a particular datastore is not itself intrinsically
+ * specifying the column type.
+ */
+public interface ColumnTypingStrategy extends Serializable {
+
+    ColumnTypingSession startColumnTypingSession();
+
+}

--- a/core/src/main/java/org/apache/metamodel/schema/typing/CustomColumnTypingStrategy.java
+++ b/core/src/main/java/org/apache/metamodel/schema/typing/CustomColumnTypingStrategy.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.schema.typing;
+
+import org.apache.metamodel.schema.ColumnType;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A {@link ColumnTypingStrategy} that allows the user to supply his own list of column types
+ */
+public class CustomColumnTypingStrategy implements ColumnTypingStrategy {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<ColumnType> columnTypes;
+
+
+    /**
+     * Creates the strategy based on the provided types.
+     *
+     * @param columnTypes a list of column types to be applied to a table.
+     */
+    public CustomColumnTypingStrategy( List<ColumnType> columnTypes ) {
+        this.columnTypes = columnTypes;
+    }
+
+
+    /**
+     * Creates the strategy based on the provided types.
+     *
+     * @param columnTypes a list of column types to be applied to a table.
+     */
+    public CustomColumnTypingStrategy( ColumnType... columnTypes ) {
+        this( Arrays.asList( columnTypes ) );
+    }
+
+
+    @Override
+    public ColumnTypingSession startColumnTypingSession() {
+        final Iterator<ColumnType> iterator = columnTypes.iterator();
+        return new ColumnTypingSession() {
+
+            @Override
+            public ColumnType getNextColumnType( ColumnTypingContext ctx ) {
+                if ( iterator.hasNext() ) {
+                    return iterator.next();
+                }
+                return null;
+            }
+
+
+            @Override
+            public void close() {
+            }
+        };
+    }
+}

--- a/core/src/main/java/org/apache/metamodel/schema/typing/DefaultColumnTypingStrategy.java
+++ b/core/src/main/java/org/apache/metamodel/schema/typing/DefaultColumnTypingStrategy.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.schema.typing;
+
+import org.apache.metamodel.schema.ColumnType;
+
+public class DefaultColumnTypingStrategy implements ColumnTypingStrategy {
+
+    private static final long serialVersionUID = 1L;
+
+
+    public DefaultColumnTypingStrategy() {
+    }
+
+
+    @Override
+    public ColumnTypingSession startColumnTypingSession() {
+        return new ColumnTypingSession() {
+
+            @Override
+            public ColumnType getNextColumnType( ColumnTypingContext ctx ) {
+                return ColumnType.STRING;
+            }
+
+
+            @Override
+            public void close() {
+            }
+        };
+    }
+}

--- a/core/src/main/java/org/apache/metamodel/schema/typing/package-info.java
+++ b/core/src/main/java/org/apache/metamodel/schema/typing/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * API for column data type configuration
+ */
+package org.apache.metamodel.schema.typing;
+

--- a/core/src/test/java/org/apache/metamodel/schema/typing/CustomColumnTypingStrategyTest.java
+++ b/core/src/test/java/org/apache/metamodel/schema/typing/CustomColumnTypingStrategyTest.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.schema.typing;
+
+import org.apache.metamodel.schema.ColumnType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CustomColumnTypingStrategyTest {
+
+    @Test
+    public void testTypeConfiguration() throws Exception {
+        ColumnTypingStrategy strategy = ColumnTypingStrategies.customTypes(ColumnType.STRING, ColumnType.NUMBER);
+        try ( final ColumnTypingSession session = strategy.startColumnTypingSession() ) {
+            assertEquals(ColumnType.STRING, session.getNextColumnType(new ColumnTypingContextImpl(0)));
+            assertEquals(ColumnType.NUMBER, session.getNextColumnType(new ColumnTypingContextImpl(1)));
+        }
+    }
+}

--- a/csv/src/main/java/org/apache/metamodel/csv/CsvConfiguration.java
+++ b/csv/src/main/java/org/apache/metamodel/csv/CsvConfiguration.java
@@ -23,6 +23,8 @@ import java.util.List;
 
 import org.apache.metamodel.schema.naming.ColumnNamingStrategies;
 import org.apache.metamodel.schema.naming.ColumnNamingStrategy;
+import org.apache.metamodel.schema.typing.ColumnTypingStrategies;
+import org.apache.metamodel.schema.typing.ColumnTypingStrategy;
 import org.apache.metamodel.util.BaseObject;
 import org.apache.metamodel.util.FileHelper;
 
@@ -53,6 +55,7 @@ public final class CsvConfiguration extends BaseObject implements Serializable {
     private final boolean failOnInconsistentRowLength;
     private final boolean multilineValues;
     private final ColumnNamingStrategy columnNamingStrategy;
+    private final ColumnTypingStrategy columnTypingStrategy;
 
     public CsvConfiguration() {
         this(DEFAULT_COLUMN_NAME_LINE);
@@ -80,13 +83,15 @@ public final class CsvConfiguration extends BaseObject implements Serializable {
     
     public CsvConfiguration(int columnNameLineNumber, String encoding, char separatorChar, char quoteChar,
             char escapeChar, boolean failOnInconsistentRowLength, boolean multilineValues) {
-        this(columnNameLineNumber, null, encoding, separatorChar, quoteChar, escapeChar, failOnInconsistentRowLength,
-                multilineValues);
+        this(columnNameLineNumber, null, null, encoding, separatorChar, quoteChar, escapeChar,
+                failOnInconsistentRowLength, multilineValues);
     }
 
-    public CsvConfiguration(int columnNameLineNumber, ColumnNamingStrategy columnNamingStrategy, String encoding,
-            char separatorChar, char quoteChar, char escapeChar, boolean failOnInconsistentRowLength,
-            boolean multilineValues) {
+
+    public CsvConfiguration(int columnNameLineNumber, ColumnNamingStrategy columnNamingStrategy,
+                             ColumnTypingStrategy columnTypingStrategy, String encoding, char separatorChar,
+                             char quoteChar, char escapeChar, boolean failOnInconsistentRowLength,
+                             boolean multilineValues) {
         this.columnNameLineNumber = columnNameLineNumber;
         this.encoding = encoding;
         this.separatorChar = separatorChar;
@@ -95,6 +100,7 @@ public final class CsvConfiguration extends BaseObject implements Serializable {
         this.failOnInconsistentRowLength = failOnInconsistentRowLength;
         this.multilineValues = multilineValues;
         this.columnNamingStrategy = columnNamingStrategy;
+        this.columnTypingStrategy = columnTypingStrategy;
     }
     
     /**
@@ -106,6 +112,17 @@ public final class CsvConfiguration extends BaseObject implements Serializable {
             return ColumnNamingStrategies.defaultStrategy();
         }
         return columnNamingStrategy;
+    }
+
+    /**
+     * Gets a {@link ColumnTypingStrategy} to use if needed.
+     * @return The configured strategy, or {@link ColumnTypingStrategies#defaultStrategy}.
+     */
+    public ColumnTypingStrategy getColumnTypingStrategy() {
+        if (columnTypingStrategy == null) {
+            return ColumnTypingStrategies.defaultStrategy();
+        }
+        return columnTypingStrategy;
     }
 
     /**

--- a/csv/src/main/java/org/apache/metamodel/csv/CsvDataContextFactory.java
+++ b/csv/src/main/java/org/apache/metamodel/csv/CsvDataContextFactory.java
@@ -22,8 +22,11 @@ import org.apache.metamodel.DataContext;
 import org.apache.metamodel.factory.AbstractDataContextFactory;
 import org.apache.metamodel.factory.DataContextProperties;
 import org.apache.metamodel.factory.ResourceFactoryRegistry;
+import org.apache.metamodel.schema.ColumnType;
 import org.apache.metamodel.schema.naming.ColumnNamingStrategy;
 import org.apache.metamodel.schema.naming.CustomColumnNamingStrategy;
+import org.apache.metamodel.schema.typing.ColumnTypingStrategy;
+import org.apache.metamodel.schema.typing.CustomColumnTypingStrategy;
 import org.apache.metamodel.util.FileHelper;
 import org.apache.metamodel.util.Resource;
 import org.apache.metamodel.util.SimpleTableDef;
@@ -59,7 +62,16 @@ public class CsvDataContextFactory extends AbstractDataContextFactory {
             columnNamingStrategy = new CustomColumnNamingStrategy(columnNames);
         }
 
-        final CsvConfiguration configuration = new CsvConfiguration(columnNameLineNumber, columnNamingStrategy,
+        final ColumnTypingStrategy columnTypingStrategy;
+        if (properties.getTableDefs() == null) {
+            columnTypingStrategy = null;
+        } else {
+            final SimpleTableDef firstTable = properties.getTableDefs()[0];
+            final ColumnType[] columnTypes = firstTable.getColumnTypes();
+            columnTypingStrategy = new CustomColumnTypingStrategy(columnTypes);
+        }
+
+        final CsvConfiguration configuration = new CsvConfiguration(columnNameLineNumber, columnNamingStrategy, columnTypingStrategy,
                 encoding, separatorChar, quoteChar, escapeChar, failOnInconsistentRowLength, multilineValuesEnabled);
         return new CsvDataContext(resource, configuration);
     }

--- a/csv/src/test/java/org/apache/metamodel/csv/CsvDataContextTest.java
+++ b/csv/src/test/java/org/apache/metamodel/csv/CsvDataContextTest.java
@@ -42,11 +42,9 @@ import org.apache.metamodel.query.FunctionType;
 import org.apache.metamodel.query.OperatorType;
 import org.apache.metamodel.query.Query;
 import org.apache.metamodel.query.SelectItem;
-import org.apache.metamodel.schema.Column;
-import org.apache.metamodel.schema.MutableColumn;
-import org.apache.metamodel.schema.Schema;
-import org.apache.metamodel.schema.Table;
+import org.apache.metamodel.schema.*;
 import org.apache.metamodel.schema.naming.CustomColumnNamingStrategy;
+import org.apache.metamodel.schema.typing.CustomColumnTypingStrategy;
 import org.apache.metamodel.util.FileHelper;
 import org.apache.metamodel.util.MutableRef;
 
@@ -492,7 +490,7 @@ public class CsvDataContextTest extends TestCase {
     public void testAlternativeDelimitors() throws Exception {
         File file = new File("src/test/resources/csv_semicolon_singlequote.csv");
         CsvDataContext dc = new CsvDataContext(file, semicolonConfiguration);
-        Table table = dc.getSchemas().get(0).getTables().get(0);
+        Table table = dc.getDefaultSchema().getTables().get(0);
         DataSet dataSet = dc.materializeMainSchemaTable(table, table.getColumns(), -1);
         assertTrue(dataSet.next());
         assertEquals("Row[values=[1, mike, male, 18]]", dataSet.getRow().toString());
@@ -833,8 +831,14 @@ public class CsvDataContextTest extends TestCase {
         final String thirdColumnName = "third";
         final String fourthColumnName = "fourth";
 
+        final ColumnType firstColumnType = ColumnType.STRING;
+        final ColumnType secondColumnType = ColumnType.STRING;
+        final ColumnType thirdColumnType = ColumnType.STRING;
+        final ColumnType fourthColumnType = ColumnType.NUMBER;
+
         final CsvConfiguration configuration = new CsvConfiguration(CsvConfiguration.DEFAULT_COLUMN_NAME_LINE,
                 new CustomColumnNamingStrategy(firstColumnName, secondColumnName, thirdColumnName, fourthColumnName),
+                new CustomColumnTypingStrategy(firstColumnType, secondColumnType, thirdColumnType, fourthColumnType),
                 FileHelper.DEFAULT_ENCODING, CsvConfiguration.DEFAULT_SEPARATOR_CHAR,
                 CsvConfiguration.DEFAULT_QUOTE_CHAR, CsvConfiguration.DEFAULT_ESCAPE_CHAR, false, true);
 

--- a/csv/src/test/java/org/apache/metamodel/csv/SingleLineCsvDataSetTest.java
+++ b/csv/src/test/java/org/apache/metamodel/csv/SingleLineCsvDataSetTest.java
@@ -19,12 +19,18 @@
 package org.apache.metamodel.csv;
 
 import java.io.File;
+import java.text.DateFormat;
 import java.util.Arrays;
 
+import org.apache.metamodel.DataContext;
 import org.apache.metamodel.data.DataSet;
+import org.apache.metamodel.schema.ColumnType;
 import org.apache.metamodel.schema.Table;
 
 import junit.framework.TestCase;
+import org.apache.metamodel.schema.typing.CustomColumnTypingStrategy;
+import org.apache.metamodel.util.DateUtils;
+import org.apache.metamodel.util.FileHelper;
 
 public class SingleLineCsvDataSetTest extends TestCase {
 
@@ -63,5 +69,85 @@ public class SingleLineCsvDataSetTest extends TestCase {
         assertEquals("[hello, there, world]", Arrays.toString(ds.getRow().getValues()));
         assertFalse(ds.next());
         ds.close();
+    }
+
+    public void testCustomTyping() throws Exception {
+        ColumnType columnType1 = ColumnType.DATE;
+        ColumnType columnType2 = ColumnType.TIME;
+        ColumnType columnType3 = ColumnType.STRING;
+        ColumnType columnType4 = ColumnType.NUMBER;
+        ColumnType columnType5 = ColumnType.BOOLEAN;
+
+        final CsvConfiguration configuration = new CsvConfiguration( CsvConfiguration.DEFAULT_COLUMN_NAME_LINE, null,
+                new CustomColumnTypingStrategy( columnType1, columnType2, columnType3, columnType4, columnType5 ),
+                FileHelper.DEFAULT_ENCODING, CsvConfiguration.DEFAULT_SEPARATOR_CHAR,
+                CsvConfiguration.DEFAULT_QUOTE_CHAR, CsvConfiguration.DEFAULT_ESCAPE_CHAR, false, true );
+
+        final DataContext dc = new CsvDataContext( new File( "src/test/resources/csv_various_types.csv" ), configuration );
+        final Table table = dc.getDefaultSchema().getTable(0);
+
+        DateFormat dateFormat = DateUtils.createDateFormat( "yyyy-MM-dd" );
+        DateFormat timeFormat = DateUtils.createDateFormat( "HH:mm" );
+
+        DataSet dataSet = dc.query().from(table).selectAll().execute();
+
+        assertTrue(dataSet.next());
+        assertEquals(dateFormat.parse("2008-11-04"), dataSet.getRow().getValues()[0]);
+        assertEquals(timeFormat.parse("12:00"), dataSet.getRow().getValues()[1]);
+        assertEquals("election day", dataSet.getRow().getValues()[2]);
+        assertEquals(8.8, (Double) dataSet.getRow().getValues()[3], Math.ulp( 8.8 ));
+        assertFalse((Boolean) dataSet.getRow().getValues()[4]);
+
+        assertTrue(dataSet.next());
+        assertEquals(dateFormat.parse("2008-12-24"), dataSet.getRow().getValues()[0]);
+        assertEquals(timeFormat.parse("00:00"), dataSet.getRow().getValues()[1]);
+        assertEquals("christmas day", dataSet.getRow().getValues()[2]);
+        assertEquals(9.0, (Double) dataSet.getRow().getValues()[3], Math.ulp( 9.0 ));
+        assertTrue((Boolean) dataSet.getRow().getValues()[4]);
+
+        assertTrue(dataSet.next());
+        assertEquals(dateFormat.parse( "2007-12-31"), dataSet.getRow().getValues()[0]);
+        assertEquals(timeFormat.parse( "23:59"), dataSet.getRow().getValues()[1]);
+        assertEquals("new years eve", dataSet.getRow().getValues()[2]);
+        assertEquals(6.4, (Double) dataSet.getRow().getValues()[3], Math.ulp( 6.4 ));
+        assertNull(dataSet.getRow().getValues()[4]);
+    }
+
+
+    public void testTypeBasedFiltering() throws Exception {
+        File dataFile = new File("src/test/resources/csv_various_types.csv");
+
+        ColumnType columnType1 = ColumnType.DATE;
+        ColumnType columnType2 = ColumnType.TIME;
+        ColumnType columnType3 = ColumnType.STRING;
+        ColumnType columnType4 = ColumnType.NUMBER;
+        ColumnType columnType5 = ColumnType.BOOLEAN;
+
+        final CsvConfiguration typedConfiguration = new CsvConfiguration(CsvConfiguration.DEFAULT_COLUMN_NAME_LINE,
+                null, new CustomColumnTypingStrategy(columnType1, columnType2, columnType3, columnType4, columnType5)
+                , FileHelper.DEFAULT_ENCODING, CsvConfiguration.DEFAULT_SEPARATOR_CHAR,
+                CsvConfiguration.DEFAULT_QUOTE_CHAR, CsvConfiguration.DEFAULT_ESCAPE_CHAR, false, true);
+        final DataContext typedDc = new CsvDataContext(dataFile,
+                typedConfiguration);
+        final Table typedTable = typedDc.getDefaultSchema().getTable(0);
+
+        DataSet typedDataSet =
+                typedDc.query().from(typedTable).selectCount().where("rating").greaterThan(10.0).execute();
+        assertTrue(typedDataSet.next());
+        assertEquals(0L, typedDataSet.getRow().getValue(0));
+
+        // Same query and data set as above, but force toString based comparisons of values for a different result.
+        final CsvConfiguration untypedConfiguration = new CsvConfiguration(CsvConfiguration.DEFAULT_COLUMN_NAME_LINE,
+                null, null, FileHelper.DEFAULT_ENCODING, CsvConfiguration.DEFAULT_SEPARATOR_CHAR,
+                CsvConfiguration.DEFAULT_QUOTE_CHAR, CsvConfiguration.DEFAULT_ESCAPE_CHAR, false, true);
+
+        final DataContext untypedDataContext =
+                new CsvDataContext(dataFile, untypedConfiguration);
+        final Table untypedTable = untypedDataContext.getDefaultSchema().getTable(0);
+
+        DataSet untypedDataSet =
+                untypedDataContext.query().from(untypedTable).selectCount().where("rating").greaterThan(10.0).execute();
+        assertTrue(untypedDataSet.next());
+        assertEquals(3L, untypedDataSet.getRow().getValue(0));
     }
 }


### PR DESCRIPTION
There are two strategies for column typing, all text and manual.
The CSV module can use manual typing to filter based on numerical
greater than and less than operations.