### PR TITLE
Better handling of nested objects in Elasticsearch data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### Apache MetaModel [WIP]
 
+ * [METAMODEL-1227] - Better handling of nested objects in Elasticsearch data
  * [METAMODEL-1224] - Ensured compatibility with newer versions of PostgreSQL
 
 ### Apache MetaModel 5.3.2

--- a/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchMetaDataParser.java
+++ b/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchMetaDataParser.java
@@ -62,7 +62,13 @@ public class ElasticSearchMetaDataParser {
         final String metaDataFieldType = getMetaDataFieldTypeFromMetaDataField(fieldMetadata);
 
         if (metaDataFieldType == null) {
-            return ColumnType.STRING;
+            // When we're dealing with a field with nested values, it doesn't have a "type", but it has "properties". In
+            // that case we should handle it as a field with the type "Map".
+            if (fieldMetadata.get("properties") != null) {
+                return ColumnType.MAP;
+            } else {
+                return ColumnType.STRING;
+            }
         }
 
         return ElasticSearchUtils.getColumnTypeFromElasticSearchType(metaDataFieldType);

--- a/elasticsearch/rest/src/test/java/org/apache/metamodel/elasticsearch/rest/ElasticSearchRestNestedDataIT.java
+++ b/elasticsearch/rest/src/test/java/org/apache/metamodel/elasticsearch/rest/ElasticSearchRestNestedDataIT.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.metamodel.elasticsearch.rest;
+
+import static org.apache.metamodel.elasticsearch.rest.ElasticSearchRestDataContext.DEFAULT_TABLE_NAME;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.http.HttpHost;
+import org.apache.metamodel.UpdateableDataContext;
+import org.apache.metamodel.data.DataSet;
+import org.apache.metamodel.data.Row;
+import org.apache.metamodel.schema.ColumnType;
+import org.apache.metamodel.schema.Table;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ElasticSearchRestNestedDataIT {
+    private static final String INDEX_NAME = "nesteddata";
+
+    private static RestHighLevelClient client;
+
+    private static UpdateableDataContext dataContext;
+
+    @Before
+    public void setUp() throws Exception {
+        final String dockerHostAddress = ElasticSearchRestDataContextIT.determineHostName();
+
+        client = ElasticSearchRestUtil
+                .createClient(new HttpHost(dockerHostAddress, ElasticSearchRestDataContextIT.DEFAULT_REST_CLIENT_PORT),
+                        null, null);
+        client.indices().create(new CreateIndexRequest(INDEX_NAME), RequestOptions.DEFAULT);
+
+        dataContext = new ElasticSearchRestDataContext(client, INDEX_NAME);
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        client.indices().delete(new DeleteIndexRequest(INDEX_NAME), RequestOptions.DEFAULT);
+    }
+
+    @Test
+    public void testNestedData() throws Exception {
+        final Map<String, Object> user = new HashMap<>();
+        user.put("fullname", "John Doe");
+        user.put("address", "Main street 1, Newville");
+
+        final Map<String, Object> userMessage = new LinkedHashMap<>();
+        userMessage.put("user", user);
+        userMessage.put("message", "This is what I have to say.");
+
+        final IndexRequest indexRequest = new IndexRequest(INDEX_NAME).id("1");
+        indexRequest.source(userMessage);
+
+        client.index(indexRequest, RequestOptions.DEFAULT);
+
+        final Table table = dataContext.getDefaultSchema().getTableByName(DEFAULT_TABLE_NAME);
+
+        assertThat(table.getColumnNames(), containsInAnyOrder("_id", "message", "user"));
+
+        assertEquals(ColumnType.MAP, table.getColumnByName("user").getType());
+        assertEquals(ColumnType.STRING, table.getColumnByName("message").getType());
+    }
+
+    @Test
+    public void testIndexOfDocumentWithDots() throws Exception {
+        final String document =
+                "{ \"user.fullname\": \"John Doe\", "
+                + "\"user.address\": \"Main street 1, Newville\", "
+                + "\"message\": \"This is what I have to say.\" }";
+
+        final IndexRequest indexRequest = new IndexRequest(INDEX_NAME).id("1");
+        indexRequest.source(document, XContentType.JSON);
+
+        client.index(indexRequest, RequestOptions.DEFAULT);
+
+        final Table table = dataContext.getDefaultSchema().getTableByName(DEFAULT_TABLE_NAME);
+
+        assertThat(table.getColumnNames(), containsInAnyOrder("_id", "message", "user"));
+
+        dataContext.refreshSchemas();
+
+        try (final DataSet dataSet = dataContext
+                .query()
+                .from(DEFAULT_TABLE_NAME)
+                .select("user")
+                .and("message")
+                .execute()) {
+            assertEquals(ElasticSearchRestDataSet.class, dataSet.getClass());
+
+            assertTrue(dataSet.next());
+            final Row row = dataSet.getRow();
+            assertEquals("This is what I have to say.", row.getValue(table.getColumnByName("message")));
+
+            assertNotNull(row.getValue(table.getColumnByName("user")));
+        }
+    }
+
+}

--- a/elasticsearch/rest/src/test/java/org/apache/metamodel/elasticsearch/rest/ElasticSearchRestNestedDataIT.java
+++ b/elasticsearch/rest/src/test/java/org/apache/metamodel/elasticsearch/rest/ElasticSearchRestNestedDataIT.java
@@ -46,7 +46,6 @@ public class ElasticSearchRestNestedDataIT {
     private static final String INDEX_NAME = "nesteddata";
 
     private static RestHighLevelClient client;
-
     private static UpdateableDataContext dataContext;
 
     @Before

--- a/elasticsearch/rest/src/test/java/org/apache/metamodel/elasticsearch/rest/ElasticSearchRestNestedDataIT.java
+++ b/elasticsearch/rest/src/test/java/org/apache/metamodel/elasticsearch/rest/ElasticSearchRestNestedDataIT.java
@@ -86,8 +86,25 @@ public class ElasticSearchRestNestedDataIT {
 
         assertThat(table.getColumnNames(), containsInAnyOrder("_id", "message", "user"));
 
-        assertEquals(ColumnType.MAP, table.getColumnByName("user").getType());
+        dataContext.refreshSchemas();
+        
+        try (final DataSet dataSet = dataContext
+                .query()
+                .from(DEFAULT_TABLE_NAME)
+                .select("user")
+                .and("message")
+                .execute()) {
+            assertEquals(ElasticSearchRestDataSet.class, dataSet.getClass());
+
+            assertTrue(dataSet.next());
+            final Row row = dataSet.getRow();
+            assertEquals("This is what I have to say.", row.getValue(table.getColumnByName("message")));
+            
+            assertTrue(row.getValue(table.getColumnByName("user")) instanceof Map);
+        }
+
         assertEquals(ColumnType.STRING, table.getColumnByName("message").getType());
+        assertEquals(ColumnType.MAP, table.getColumnByName("user").getType());
     }
 
     @Test


### PR DESCRIPTION
Fixes METAMODEL-1227.

In case an Elasticsearch document contains nested objects, these should be designated the `ColumnType.MAP`,  because they're resolved to `Map` objects, not to `String` objects.