### PR TITLE
Workaround for fieldnames with dots in elasticsearch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### Apache MetaModel [WIP]
 
+ * [METAMODEL-1228] - Better handling of fieldnames with dots in Elasticsearch
  * [METAMODEL-1227] - Better handling of nested objects in Elasticsearch data
  * [METAMODEL-1224] - Ensured compatibility with newer versions of PostgreSQL
 

--- a/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
+++ b/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
@@ -293,7 +293,7 @@ public class ElasticSearchUtils {
                     } else if (column.getType() == ColumnType.MAP && value == null) {
                         // Because of a bug in Elasticsearch, when field names contain dots, it's possible that the
                         // mapping of the index described a column to be of the type "MAP", while it's based on a number
-                        // of fields contains dots in their name. In this case we may have to work around that
+                        // of fields containing dots in their name. In this case we may have to work around that
                         // inconsistency by creating column names with dots ourselves, based on the schema.
                         final Map<String, Object> valueMap = new HashMap<>();
 

--- a/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
+++ b/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
@@ -290,6 +290,23 @@ public class ElasticSearchUtils {
                         } else {
                             values[i] = valueToDate;
                         }
+                    } else if (column.getType() == ColumnType.MAP && value == null) {
+                        // Because of a bug in Elasticsearch, when field names contain dots, it's possible that the
+                        // mapping of the index described a column to be of the type "MAP", while it's based on a number
+                        // of fields contains dots in their name. In this case we may have to work around that
+                        // inconsistency by creating column names with dots ourselves, based on the schema.
+                        final Map<String, Object> valueMap = new HashMap<>();
+
+                        sourceMap
+                                .keySet()
+                                .stream()
+                                .filter(fieldName -> fieldName.startsWith(column.getName() + "."))
+                                .forEach(fieldName -> evaluateField(sourceMap, valueMap, fieldName, fieldName
+                                        .substring(fieldName.indexOf('.') + 1)));
+
+                        if (!valueMap.isEmpty()) {
+                            values[i] = valueMap;
+                        }
                     } else {
                         values[i] = value;
                     }
@@ -298,5 +315,27 @@ public class ElasticSearchUtils {
         }
 
         return new DefaultRow(header, values);
+    }
+
+    private static void evaluateField(final Map<String, Object> sourceMap, final Map<String, Object> valueMap,
+            final String sourceFieldName, final String subFieldName) {
+        if (subFieldName.contains(".")) {
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> nestedValueMap = (Map<String, Object>) valueMap
+                    .computeIfAbsent(subFieldName.substring(0, subFieldName.indexOf('.')), key -> createNestedValueMap(
+                            valueMap, key));
+
+            evaluateField(sourceMap, nestedValueMap, sourceFieldName, subFieldName
+                    .substring(subFieldName.indexOf('.') + 1));
+        } else {
+            valueMap.put(subFieldName, sourceMap.get(sourceFieldName));
+        }
+    }
+
+    private static Object createNestedValueMap(final Map<String, Object> valueMap, final String nestedFieldName) {
+        final Map<String, Object> nestedValueMap = new HashMap<>();
+        valueMap.put(nestedFieldName, nestedValueMap);
+
+        return nestedValueMap;
     }
 }

--- a/elasticsearch/rest/src/test/java/org/apache/metamodel/elasticsearch/rest/ElasticSearchRestNestedDataIT.java
+++ b/elasticsearch/rest/src/test/java/org/apache/metamodel/elasticsearch/rest/ElasticSearchRestNestedDataIT.java
@@ -38,6 +38,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -109,6 +110,40 @@ public class ElasticSearchRestNestedDataIT {
             final Map userValueMap = (Map) userValue;
             assertEquals("John Doe", userValueMap.get("fullname"));
             assertEquals("Main street 1, Newville", userValueMap.get("address"));
+        }
+    }
+
+    @Test
+    public void testIndexOfDocumentWithDots() throws Exception {
+        final String document =
+                "{ \"user.fullname\": \"John Doe\", "
+                + "\"user.address\": \"Main street 1, Newville\", "
+                + "\"message\": \"This is what I have to say.\" }";
+
+        final IndexRequest indexRequest = new IndexRequest(INDEX_NAME).id("1");
+        indexRequest.source(document, XContentType.JSON);
+
+        client.index(indexRequest, RequestOptions.DEFAULT);
+
+        final Table table = dataContext.getDefaultSchema().getTableByName(DEFAULT_TABLE_NAME);
+
+        assertThat(table.getColumnNames(), containsInAnyOrder("_id", "message", "user"));
+
+        dataContext.refreshSchemas();
+
+        try (final DataSet dataSet = dataContext
+                .query()
+                .from(DEFAULT_TABLE_NAME)
+                .select("user")
+                .and("message")
+                .execute()) {
+            assertEquals(ElasticSearchRestDataSet.class, dataSet.getClass());
+
+            assertTrue(dataSet.next());
+            final Row row = dataSet.getRow();
+            assertEquals("This is what I have to say.", row.getValue(table.getColumnByName("message")));
+
+            assertNotNull(row.getValue(table.getColumnByName("user")));
         }
     }
 }


### PR DESCRIPTION
MetaModel is unable to work with a document indexed by Elasticsearch which contains dots in its field names. Note that this is actually caused by Elasticsearch, because the mapping returned for such a document by Elasticsearch doesn't match the source returned by Elasticsearch when getting the source of a search hit. (see https://github.com/elastic/elasticsearch-hadoop/issues/853 and related issues for more info on this).

Note that the branch for this PR is branch off of the branch for https://github.com/apache/metamodel/pull/242, because it extends the Integration Test which is introduced in that PR.
