### PR TITLE
MM-1229: FixedWidth works with UrlResource/HttpInputStream.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### Apache MetaModel [WIP]
 
+ * [METAMODEL-1229] - FixedWidth works with UrlResource/HttpInputStream.
  * [METAMODEL-1228] - Better handling of fieldnames with dots in Elasticsearch
  * [METAMODEL-1227] - Better handling of nested objects in Elasticsearch data
  * [METAMODEL-1224] - Ensured compatibility with newer versions of PostgreSQL

--- a/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthDataContext.java
+++ b/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthDataContext.java
@@ -153,18 +153,22 @@ public class FixedWidthDataContext extends QueryPostprocessDataContext {
     private FixedWidthReader createReader() {
         final InputStream inputStream = _resource.read();
         final FixedWidthReader reader;
-        
+
         if (_configuration instanceof EbcdicConfiguration) {
-            reader = new EbcdicReader((BufferedInputStream) inputStream, _configuration.getEncoding(),
-                    _configuration.getValueWidths(), _configuration.isFailOnInconsistentLineWidth(), 
-                    ((EbcdicConfiguration) _configuration).isSkipEbcdicHeader(), 
-                    ((EbcdicConfiguration) _configuration).isEolPresent());
+            final BufferedInputStream bufferedInputStream =
+                    inputStream instanceof BufferedInputStream ? (BufferedInputStream) inputStream
+                            : new BufferedInputStream(inputStream);
+            reader =
+                    new EbcdicReader(bufferedInputStream, _configuration.getEncoding(), _configuration.getValueWidths(),
+                            _configuration.isFailOnInconsistentLineWidth(),
+                            ((EbcdicConfiguration) _configuration).isSkipEbcdicHeader(),
+                            ((EbcdicConfiguration) _configuration).isEolPresent());
         } else {
             if (_configuration.isConstantValueWidth()) {
                 reader = new FixedWidthReader(inputStream, _configuration.getEncoding(),
                         _configuration.getFixedValueWidth(), _configuration.isFailOnInconsistentLineWidth());
             } else {
-                reader = new FixedWidthReader(inputStream, _configuration.getEncoding(), 
+                reader = new FixedWidthReader(inputStream, _configuration.getEncoding(),
                         _configuration.getValueWidths(), _configuration.isFailOnInconsistentLineWidth());
             }
         }

--- a/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthDataContext.java
+++ b/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthDataContext.java
@@ -19,8 +19,11 @@
 package org.apache.metamodel.fixedwidth;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.List;
 
 import org.apache.metamodel.MetaModelException;

--- a/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthDataContext.java
+++ b/fixedwidth/src/main/java/org/apache/metamodel/fixedwidth/FixedWidthDataContext.java
@@ -19,11 +19,8 @@
 package org.apache.metamodel.fixedwidth;
 
 import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.List;
 
 import org.apache.metamodel.MetaModelException;

--- a/fixedwidth/src/test/java/org/apache/metamodel/fixedwidth/FixedWidthDataContextTest.java
+++ b/fixedwidth/src/test/java/org/apache/metamodel/fixedwidth/FixedWidthDataContextTest.java
@@ -18,10 +18,12 @@
  */
 package org.apache.metamodel.fixedwidth;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Arrays;
-
-import junit.framework.TestCase;
 
 import org.apache.metamodel.DataContext;
 import org.apache.metamodel.data.DataSet;
@@ -29,6 +31,9 @@ import org.apache.metamodel.query.Query;
 import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
 import org.apache.metamodel.schema.naming.CustomColumnNamingStrategy;
+import org.apache.metamodel.util.UrlResource;
+
+import junit.framework.TestCase;
 
 public class FixedWidthDataContextTest extends TestCase {
 
@@ -237,5 +242,25 @@ public class FixedWidthDataContextTest extends TestCase {
 
         assertNotNull(table.getColumnByName(firstColumnName));
         assertNotNull(table.getColumnByName(secondColumnName));
+    }
+
+    public void testUrlResource() throws MalformedURLException {
+        final URL url = new URL("http://localhost:8080/fixed-width.txt");
+        final DataContext dataContext = new FixedWidthDataContext(new ByteUrlResource(url),
+                new EbcdicConfiguration(FixedWidthConfiguration.DEFAULT_COLUMN_NAME_LINE, "UTF8", 4, false, true,
+                        true));
+        assertNotNull(dataContext.getSchemaByName("localhost:8080"));
+    }
+
+    private static class ByteUrlResource extends UrlResource {
+        public ByteUrlResource(final URL url) {
+            super(url);
+        }
+
+        @Override
+        public InputStream read() {
+            // any InputStream that can not be cast to BufferedInputStream
+            return new ByteArrayInputStream("test-data".getBytes());
+        }
     }
 }


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/METAMODEL-1229. 

EbcdicReader in FixedWidthDataContext required BufferedInputStream, now other input streams are also supported (new BufferedInputStream(originalInputStream) is created). 
This enables using a URL (UrlResource) for a path in FixedWidth datastore. 