### PR TITLE
METAMODEL-1231 PostgreSQL integration test errors

### DIFF
--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/AbstractJdbIntegrationTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/AbstractJdbIntegrationTest.java
@@ -28,12 +28,13 @@ import org.apache.commons.dbcp.BasicDataSource;
 import org.apache.metamodel.jdbc.JdbcDataContext;
 import org.apache.metamodel.util.FileHelper;
 
-import junit.framework.TestCase;
+import org.junit.After;
+import org.junit.Before;
 
 /**
  * Convenience super class for integration {@link TestCase}s.
  */
-public abstract class AbstractJdbIntegrationTest extends TestCase {
+public abstract class AbstractJdbIntegrationTest {
 
     private Properties _properties;
     private boolean _configured;
@@ -43,10 +44,8 @@ public abstract class AbstractJdbIntegrationTest extends TestCase {
     private String _driver;
     private Connection _connection;
 
-    @Override
-    protected final void setUp() throws Exception {
-        super.setUp();
-
+    @Before
+    public final void setUp() throws Exception {
         // create property prefix of the form "jdbc.databasetype.property"
         final String propertyPrefix = "jdbc." + getPropertyPrefix();
 
@@ -84,8 +83,8 @@ public abstract class AbstractJdbIntegrationTest extends TestCase {
         return _url;
     }
 
-    @Override
-    protected final void tearDown() throws Exception {
+    @After
+    public final void tearDown() throws Exception {
         FileHelper.safeClose(_connection);
         _connection = null;
     }

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/DB2Test.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/DB2Test.java
@@ -18,6 +18,8 @@
  */
 package org.apache.metamodel.jdbc.integrationtests;
 
+import static org.junit.Assert.*;
+
 import java.util.Arrays;
 
 import org.apache.metamodel.data.DataSet;
@@ -27,7 +29,6 @@ import org.apache.metamodel.query.Query;
 import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 /**
  * DB2 integration test. This is a read-only integration test, meant to be

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/DB2Test.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/DB2Test.java
@@ -26,6 +26,8 @@ import org.apache.metamodel.jdbc.JdbcTestTemplates;
 import org.apache.metamodel.query.Query;
 import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
+import org.junit.Test;
+import static org.junit.Assert.*;
 
 /**
  * DB2 integration test. This is a read-only integration test, meant to be
@@ -38,6 +40,7 @@ public class DB2Test extends AbstractJdbIntegrationTest {
         return "db2";
     }
 
+    @Test
     public void testCreateInsertAndUpdate() throws Exception {
         if (!isConfigured()) {
             return;
@@ -46,6 +49,7 @@ public class DB2Test extends AbstractJdbIntegrationTest {
         JdbcTestTemplates.simpleCreateInsertUpdateAndDrop(getDataContext(), "metamodel_db2_test");
     }
 
+    @Test
     public void testCompositePrimaryKeyCreation() throws Exception {
         if (!isConfigured()) {
             return;
@@ -54,6 +58,7 @@ public class DB2Test extends AbstractJdbIntegrationTest {
         JdbcTestTemplates.compositeKeyCreation(getDataContext(), "metamodel_test_composite_keys");
     }
 
+    @Test
     public void testInterpretationOfNull() throws Exception {
         if (!isConfigured()) {
             return;
@@ -61,6 +66,7 @@ public class DB2Test extends AbstractJdbIntegrationTest {
         JdbcTestTemplates.interpretationOfNulls(getConnection());
     }
 
+    @Test
     public void testDefaultSchema() throws Exception {
         if (!isConfigured()) {
             return;
@@ -79,6 +85,7 @@ public class DB2Test extends AbstractJdbIntegrationTest {
         ds.close();
     }
 
+    @Test
     public void testMaxRowsOnly() throws Exception {
         if (!isConfigured()) {
             return;
@@ -103,6 +110,7 @@ public class DB2Test extends AbstractJdbIntegrationTest {
         ds.close();
     }
 
+    @Test
     public void testMaxRowsAndOffset() throws Exception {
         if (!isConfigured()) {
             return;

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/FirebirdTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/FirebirdTest.java
@@ -18,14 +18,10 @@
  */
 package org.apache.metamodel.jdbc.integrationtests;
 
-import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Set;
-import java.util.stream.Collectors;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
-import javax.swing.table.TableModel;
-
+import com.google.common.collect.Sets;
 import org.apache.metamodel.data.DataSet;
 import org.apache.metamodel.data.DataSetTableModel;
 import org.apache.metamodel.jdbc.JdbcDataContext;
@@ -35,11 +31,14 @@ import org.apache.metamodel.query.Query;
 import org.apache.metamodel.query.SelectItem;
 import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
-
-import com.google.common.collect.Sets;
-
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import javax.swing.table.TableModel;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Integrationtests for Firebird SQL.

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/FirebirdTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/FirebirdTest.java
@@ -38,6 +38,9 @@ import org.apache.metamodel.schema.Table;
 
 import com.google.common.collect.Sets;
 
+import org.junit.Test;
+import static org.junit.Assert.*;
+
 /**
  * Integrationtests for Firebird SQL.
  * 
@@ -55,6 +58,7 @@ public class FirebirdTest extends AbstractJdbIntegrationTest {
         return "firebird";
     }
 
+    @Test
 	public void testGetSchemas() throws Exception {
 	    if (!isConfigured()) {
 	        return;
@@ -97,6 +101,7 @@ public class FirebirdTest extends AbstractJdbIntegrationTest {
 		assertEquals(relationStrings,referenceRelationStrings);
 	}
 
+	@Test
 	public void testExecuteQuery() throws Exception {
 	    if (!isConfigured()) {
             return;

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/HiveIntegrationTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/HiveIntegrationTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.metamodel.jdbc.integrationtests;
 
+import static org.junit.Assert.*;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -36,7 +38,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 public class HiveIntegrationTest extends AbstractJdbIntegrationTest {
     private static final Logger logger = LoggerFactory.getLogger(HiveIntegrationTest.class);

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/HiveIntegrationTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/HiveIntegrationTest.java
@@ -35,6 +35,9 @@ import org.apache.metamodel.schema.Table;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.junit.Test;
+import static org.junit.Assert.*;
+
 public class HiveIntegrationTest extends AbstractJdbIntegrationTest {
     private static final Logger logger = LoggerFactory.getLogger(HiveIntegrationTest.class);
 
@@ -61,6 +64,7 @@ public class HiveIntegrationTest extends AbstractJdbIntegrationTest {
         logger.info("SQL updated fired (return {}): {}", st.executeUpdate(deleteLastSql), deleteLastSql);
     }
 
+    @Test
     public void testDefaultGetSchema() throws Exception {
         if (!isConfigured()) {
             return;
@@ -87,6 +91,7 @@ public class HiveIntegrationTest extends AbstractJdbIntegrationTest {
         }
     }
 
+    @Test
     public void testGetSchema() throws Exception {
         if (!isConfigured()) {
             return;
@@ -97,6 +102,7 @@ public class HiveIntegrationTest extends AbstractJdbIntegrationTest {
         assertEquals("Schema[name=default]", schema.toString());
     }
 
+    @Test
     public void testUseCorrectRewriter() throws Exception {
         if (!isConfigured()) {
             return;
@@ -106,6 +112,7 @@ public class HiveIntegrationTest extends AbstractJdbIntegrationTest {
         assertTrue(dataContext.getQueryRewriter() instanceof HiveQueryRewriter);
     }
 
+    @Test
     public void testCreateInsertQueryAndDrop() throws Exception {
         if (!isConfigured()) {
             return;
@@ -155,6 +162,7 @@ public class HiveIntegrationTest extends AbstractJdbIntegrationTest {
      * MetaModel should ignore that for Hive datastores when creating a table.
      * @throws Exception
      */
+    @Test
     public void testCreateTableWithPrimaryKey() throws Exception {
         if (!isConfigured()) {
             return;

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/MysqlTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/MysqlTest.java
@@ -50,6 +50,8 @@ import org.apache.metamodel.schema.ColumnType;
 import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
 import org.apache.metamodel.schema.TableType;
+import org.junit.Test;
+import static org.junit.Assert.*;
 
 /**
  * Test case that tests mysql interaction. The test requires the "sakila" sample
@@ -64,6 +66,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
         return "mysql";
     }
 
+    @Test
     public void testCreateInsertAndUpdate() throws Exception {
         if (!isConfigured()) {
             return;
@@ -72,6 +75,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
         JdbcTestTemplates.simpleCreateInsertUpdateAndDrop(getDataContext(), "metamodel_test_simple");
     }
 
+    @Test
     public void testCompositePrimaryKeyCreation() throws Exception {
         if (!isConfigured()) {
             return;
@@ -80,6 +84,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
         JdbcTestTemplates.compositeKeyCreation(getDataContext(), "metamodel_test_composite_keys");
     }
 
+    @Test
     public void testTimestampValueInsertSelect() throws Exception {
         if (!isConfigured()) {
             return;
@@ -89,6 +94,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
         JdbcTestTemplates.timestampValueInsertSelect(connection, TimeUnit.MICROSECONDS, "TIMESTAMP(6)");
     }
 
+    @Test
     public void testInterpretationOfNull() throws Exception {
         if (!isConfigured()) {
             return;
@@ -97,6 +103,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
         JdbcTestTemplates.interpretationOfNulls(getConnection());
     }
 
+    @Test
     public void testDatabaseProductName() throws Exception {
         if (!isConfigured()) {
             return;
@@ -106,6 +113,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
         assertEquals(JdbcDataContext.DATABASE_PRODUCT_MYSQL, databaseProductName);
     }
 
+    @Test
     public void testCreateInsertAndUpdateDateTypes() throws Exception {
         if (!isConfigured()) {
             return;
@@ -116,6 +124,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
                 "metamodel_mysql_test");
     }
 
+    @Test
     public void testAutomaticConversionWhenInsertingString() throws Exception {
         if (!isConfigured()) {
             return;
@@ -170,6 +179,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
         });
     }
 
+    @Test
     public void testCharOfSizeOne() throws Exception {
         if (!isConfigured()) {
             return;
@@ -178,6 +188,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
         JdbcTestTemplates.meaningOfOneSizeChar(getConnection());
     }
 
+    @Test
     public void testAlternativeConnectionString() throws Exception {
         if (!isConfigured()) {
             return;
@@ -195,6 +206,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
         assertEquals(1000, tableModel.getRowCount());
     }
 
+    @Test
     public void testGetCatalogNames() throws Exception {
         if (!isConfigured()) {
             return;
@@ -207,6 +219,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
         assertNotNull(dataContext.getSchemaByName("sakila"));
     }
 
+    @Test
     public void testGetDefaultSchema() throws Exception {
         if (!isConfigured()) {
             return;
@@ -217,6 +230,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
         assertEquals("sakila", schema.getName());
     }
 
+    @Test
     public void testExecuteQuery() throws Exception {
         if (!isConfigured()) {
             return;
@@ -282,6 +296,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
     }
 
     // Test to query the film table (caused troubles in DataCleaner)
+    @Test
     public void testFilmQuery() throws Exception {
         if (!isConfigured()) {
             return;
@@ -293,6 +308,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
         dc.executeQuery(q);
     }
 
+    @Test
     public void testGetSchema() throws Exception {
         if (!isConfigured()) {
             return;
@@ -364,6 +380,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
                 Arrays.toString(staffView.getColumns().toArray()));
     }
 
+    @Test
     public void testSplitQuery() throws Exception {
         if (!isConfigured()) {
             return;
@@ -400,6 +417,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
         assertEquals(32098, count);
     }
 
+    @Test
     public void testQueryWithSingleQuote() throws Exception {
         if (!isConfigured()) {
             return;
@@ -413,6 +431,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
         assertFalse(ds.next());
     }
 
+    @Test
     public void testCompiledQueries() throws Exception {
         if (!isConfigured()) {
             return;
@@ -444,6 +463,7 @@ public class MysqlTest extends AbstractJdbIntegrationTest {
         }
     }
 
+    @Test
     public void testWhiteSpaceColumns() throws Exception {
         if (!isConfigured()) {
             return;

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/MysqlTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/MysqlTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.metamodel.jdbc.integrationtests;
 
+import static org.junit.Assert.*;
+
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
@@ -51,7 +53,6 @@ import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
 import org.apache.metamodel.schema.TableType;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 /**
  * Test case that tests mysql interaction. The test requires the "sakila" sample

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/OracleTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/OracleTest.java
@@ -12,6 +12,8 @@
  */
 package org.apache.metamodel.jdbc.integrationtests;
 
+import static org.junit.Assert.*;
+
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -44,7 +46,6 @@ import org.apache.metamodel.schema.TableType;
 import com.google.common.collect.Sets;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 /**
  * Test case that tests oracle interaction. An express edition of the oracle

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/OracleTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/OracleTest.java
@@ -43,6 +43,9 @@ import org.apache.metamodel.schema.TableType;
 
 import com.google.common.collect.Sets;
 
+import org.junit.Test;
+import static org.junit.Assert.*;
+
 /**
  * Test case that tests oracle interaction. An express edition of the oracle
  * database can be used to run these tests.
@@ -76,6 +79,7 @@ public class OracleTest extends AbstractJdbIntegrationTest {
         return "oracle";
     }
 
+    @Test
     public void testGetQueryRewriter() throws Exception {
         if (!isConfigured()) {
             return;
@@ -85,6 +89,7 @@ public class OracleTest extends AbstractJdbIntegrationTest {
         assertEquals(OracleQueryRewriter.class, queryRewriter.getClass());
     }
 
+    @Test
     public void testCreateInsertAndUpdate() throws Exception {
         if (!isConfigured()) {
             return;
@@ -93,6 +98,7 @@ public class OracleTest extends AbstractJdbIntegrationTest {
         JdbcTestTemplates.simpleCreateInsertUpdateAndDrop(getDataContext(), "metamodel_test_simple");
     }
 
+    @Test
     public void testTimestampValueInsertSelect() throws Exception {
         if (!isConfigured()) {
             return;
@@ -102,6 +108,7 @@ public class OracleTest extends AbstractJdbIntegrationTest {
         JdbcTestTemplates.timestampValueInsertSelect(connection, TimeUnit.MICROSECONDS, null);
     }
 
+    @Test
     public void testCompositePrimaryKeyCreation() throws Exception {
         if (!isConfigured()) {
             return;
@@ -114,6 +121,7 @@ public class OracleTest extends AbstractJdbIntegrationTest {
      * Ticket #170: getIndexInfo causes SQLException. We test that resultsets
      * are closed properly.
      */
+    @Test
     public void testIndexInfo() throws Exception {
         if (!isConfigured()) {
             return;
@@ -126,6 +134,7 @@ public class OracleTest extends AbstractJdbIntegrationTest {
         assertTrue(schema.getTableCount() > 0);
     }
 
+    @Test
     public void testGetSchemaNames() throws Exception {
         if (!isConfigured()) {
             return;
@@ -153,6 +162,7 @@ public class OracleTest extends AbstractJdbIntegrationTest {
      * Really only tests the JDBC implementation, used to help localize the
      * cause for Ticket #144
      */
+    @Test
     public void testGetImportedKeys() throws Exception {
         if (!isConfigured()) {
             return;
@@ -192,6 +202,7 @@ public class OracleTest extends AbstractJdbIntegrationTest {
         assertEquals(2, count);
     }
 
+    @Test
     public void testGetSchema() throws Exception {
         if (!isConfigured()) {
             return;
@@ -240,6 +251,7 @@ public class OracleTest extends AbstractJdbIntegrationTest {
                 Arrays.toString(schema.getTableByName("DEPARTMENTS").getColumns().toArray()));
     }
 
+    @Test
     public void testExecuteQuery() throws Exception {
         if (!isConfigured()) {
             return;
@@ -278,6 +290,7 @@ public class OracleTest extends AbstractJdbIntegrationTest {
         assertTrue(found);
     }
 
+    @Test
     public void testMaxAndOffset() throws Exception {
         if (!isConfigured()) {
             return;

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
@@ -21,6 +21,7 @@ package org.apache.metamodel.jdbc.integrationtests;
 import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
@@ -757,9 +758,11 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
                             "Column[name=age,columnNumber=2,type=INTEGER,nullable=true,nativeType=int4,columnSize=10]",
                             table.getColumnByName("age").toString());
 
-                    cb.insertInto(table).value("person name", "John Doe").value("age", 42).execute();
+                    cb.insertInto(table).value("person name", "John Doe").value("age", "42").execute();
                 }
             });
+
+            fail("No expected java.sql.BatchUpdateException occurred at case.");
 
         } catch (Exception e) {
             String message = e.getMessage().replaceAll("\n", " ");

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
@@ -18,10 +18,11 @@
  */
 package org.apache.metamodel.jdbc.integrationtests;
 
+import static org.junit.Assert.*;
+
 import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
-import java.sql.SQLException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
@@ -52,8 +53,6 @@ import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
 import org.junit.Ignore;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 /**
  * Test case that tests postgresql interaction. The test requires the
@@ -106,7 +105,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         }
         JdbcTestTemplates.interpretationOfNulls(getConnection());
     }
-    
+
     private JdbcDataContext createLimitAndOffsetTestData() {
         final JdbcDataContext dc = new JdbcDataContext(getConnection());
 

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
@@ -736,7 +736,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
                             "Column[name=age,columnNumber=2,type=INTEGER,nullable=true,nativeType=int4,columnSize=10]",
                             table.getColumnByName("age").toString());
 
-                    cb.insertInto(table).value("person name", "John Doe").value("age", "42").execute();
+                    cb.insertInto(table).value("person name", "John Doe").value("age", 42).execute();
                 }
             });
 

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/PostgresqlTest.java
@@ -50,6 +50,9 @@ import org.apache.metamodel.schema.Relationship;
 import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
 import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * Test case that tests postgresql interaction. The test requires the
@@ -67,6 +70,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         return "postgresql";
     }
 
+    @Test
     public void testTimestampValueInsertSelect() throws Exception {
         if (!isConfigured()) {
             return;
@@ -76,6 +80,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         JdbcTestTemplates.timestampValueInsertSelect(connection, TimeUnit.MICROSECONDS);
     }
 
+    @Test
     public void testCreateInsertAndUpdate() throws Exception {
         if (!isConfigured()) {
             return;
@@ -84,6 +89,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         JdbcTestTemplates.simpleCreateInsertUpdateAndDrop(getDataContext(), "metamodel_test_simple");
     }
 
+    @Test
     public void testCompositePrimaryKeyCreation() throws Exception {
         if (!isConfigured()) {
             return;
@@ -92,13 +98,14 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         JdbcTestTemplates.compositeKeyCreation(getDataContext(), "metamodel_test_composite_keys");
     }
 
+    @Test
     public void testInterpretationOfNull() throws Exception {
         if (!isConfigured()) {
             return;
         }
         JdbcTestTemplates.interpretationOfNulls(getConnection());
     }
-
+    
     private JdbcDataContext createLimitAndOffsetTestData() {
         final JdbcDataContext dc = new JdbcDataContext(getConnection());
 
@@ -127,6 +134,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         return dc;
     }
 
+    @Test
     public void testLimit() throws Exception {
         if (!isConfigured()) {
             return;
@@ -145,6 +153,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         ds.close();
     }
 
+    @Test
     public void testOffset() throws Exception {
         if (!isConfigured()) {
             return;
@@ -163,6 +172,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         ds.close();
     }
 
+    @Test
     public void testLimitAndOffset() throws Exception {
         if (!isConfigured()) {
             return;
@@ -179,6 +189,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         ds.close();
     }
 
+    @Test
     public void testQuotedInsertSyntax() throws Exception {
         if (!isConfigured()) {
             return;
@@ -248,6 +259,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         });
     }
 
+    @Test
     public void testInsertOfDifferentTypes() throws Exception {
         if (!isConfigured()) {
             return;
@@ -330,6 +342,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         }
     }
 
+    @Test
     public void testJsonAndJsonbDatatypes() throws Exception {
         if (!isConfigured()) {
             return;
@@ -380,6 +393,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
      * 
      * @see http://eobjects.org/trac/ticket/829
      */
+    @Test
     public void testBoolean() throws Exception {
         if (!isConfigured()) {
             return;
@@ -423,6 +437,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
      * 
      * @see https://issues.apache.org/jira/browse/METAMODEL-151
      */
+    @Test
     public void testDouble() throws Exception {
         if (!isConfigured()) {
             return;
@@ -477,6 +492,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         }
     }
 
+    @Test
     public void testGetGeneratedKeys() throws Exception {
         if (!isConfigured()) {
             return;
@@ -519,6 +535,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         }
     }
 
+    @Test
     public void testBlob() throws Exception {
         if (!isConfigured()) {
             return;
@@ -582,6 +599,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         }
     }
 
+    @Test
     public void testCreateInsertAndUpdateDateTypes() throws Exception {
         if (!isConfigured()) {
             return;
@@ -592,6 +610,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
                 "metamodel_postgresql_test");
     }
 
+    @Test
     public void testCreateTableAndWriteRecords() throws Exception {
         if (!isConfigured()) {
             return;
@@ -658,6 +677,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         }
     }
 
+    @Test
     public void testCreateTableInsertValueFloatForIntColumn() throws Exception {
         if (!isConfigured()) {
             return;
@@ -711,6 +731,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         }
     }
 
+    @Test
     public void testInsertFailureForStringValueForIntegerColumn() throws Exception {
         if (!isConfigured()) {
             return;
@@ -758,6 +779,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         }
     }
 
+    @Test
     public void testDatabaseProductName() throws Exception {
         if (!isConfigured()) {
             return;
@@ -767,6 +789,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         assertEquals(JdbcDataContext.DATABASE_PRODUCT_POSTGRESQL, databaseProductName);
     }
 
+    @Test
     public void testGetDefaultSchema() throws Exception {
         if (!isConfigured()) {
             return;
@@ -777,6 +800,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         assertEquals("public", schema.getName());
     }
 
+    @Test
     public void testGetSchema() throws Exception {
         if (!isConfigured()) {
             return;
@@ -854,6 +878,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
                 Arrays.toString(ordersTable.getColumns().toArray()));
     }
 
+    @Test
     public void testExecuteQueryInPublicSchema() throws Exception {
         if (!isConfigured()) {
             return;
@@ -922,6 +947,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         assertEquals("27", tableModel.getValueAt(135, 1).toString());
     }
 
+    @Test
     public void testWhiteSpaceColumns() throws Exception {
         if (!isConfigured()) {
             return;
@@ -931,6 +957,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         assertEquals("\"", metaData.getIdentifierQuoteString());
     }
 
+    @Test
     public void testCreateTableAndInsert1MRecords() throws Exception {
         if (!isConfigured()) {
             return;
@@ -984,6 +1011,7 @@ public class PostgresqlTest extends AbstractJdbIntegrationTest {
         }
     }
 
+    @Test
     public void testCharOfSizeOne() throws Exception {
         if (!isConfigured()) {
             return;

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/SQLServerJtdsDriverTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/SQLServerJtdsDriverTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.metamodel.jdbc.integrationtests;
 
+import static org.junit.Assert.*;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Arrays;
@@ -42,7 +44,6 @@ import org.apache.metamodel.schema.Table;
 import org.apache.metamodel.schema.TableType;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 /**
  * Test case that tests MS SQL Server interaction. The test uses the

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/SQLServerJtdsDriverTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/SQLServerJtdsDriverTest.java
@@ -41,6 +41,9 @@ import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
 import org.apache.metamodel.schema.TableType;
 
+import org.junit.Test;
+import static org.junit.Assert.*;
+
 /**
  * Test case that tests MS SQL Server interaction. The test uses the
  * "AdventureWorks 2012" sample database which can be downloaded from codeplex.
@@ -58,6 +61,7 @@ public class SQLServerJtdsDriverTest extends AbstractJdbIntegrationTest {
         return "sqlserver.jtds_driver";
     }
 
+    @Test
     public void testCreateInsertAndUpdate() throws Exception {
         if (!isConfigured()) {
             return;
@@ -66,6 +70,7 @@ public class SQLServerJtdsDriverTest extends AbstractJdbIntegrationTest {
     }
 
     // This test is pretty useless. It assumes way too much, and fails due to SQL Server not using timestamp as assumed.
+    @Test
     public void ignoreTestTimestampValueInsertSelect() throws Exception {
         if (!isConfigured()) {
             return;
@@ -75,6 +80,7 @@ public class SQLServerJtdsDriverTest extends AbstractJdbIntegrationTest {
         JdbcTestTemplates.timestampValueInsertSelect(connection, TimeUnit.NANOSECONDS, "datetime");
     }
 
+    @Test
     public void testCreateTableInUpdateScript() throws Exception {
         if (!isConfigured()) {
             return;
@@ -104,6 +110,7 @@ public class SQLServerJtdsDriverTest extends AbstractJdbIntegrationTest {
         dc.executeUpdate(new DropTable(schema, tableName));
     }
 
+    @Test
     public void testCompositePrimaryKeyCreation() throws Exception {
         if (!isConfigured()) {
             return;
@@ -112,6 +119,7 @@ public class SQLServerJtdsDriverTest extends AbstractJdbIntegrationTest {
         JdbcTestTemplates.compositeKeyCreation(getDataContext(), "metamodel_test_composite_keys");
     }
 
+    @Test
     public void testWorkingWithDates() throws Exception {
         if (!isConfigured()) {
             return;
@@ -125,6 +133,7 @@ public class SQLServerJtdsDriverTest extends AbstractJdbIntegrationTest {
         JdbcTestTemplates.createInsertAndUpdateDateTypes(dc, schema, "test_table");
     }
 
+    @Test
     public void testAutomaticConversionWhenInsertingString() throws Exception {
         if (!isConfigured()) {
             return;
@@ -179,6 +188,7 @@ public class SQLServerJtdsDriverTest extends AbstractJdbIntegrationTest {
         connection.createStatement().execute("DROP TABLE Person.test_table");
     }
 
+    @Test
     public void testQueryUsingExpressions() throws Exception {
         if (!isConfigured()) {
             return;
@@ -199,6 +209,7 @@ public class SQLServerJtdsDriverTest extends AbstractJdbIntegrationTest {
         assertFalse(dataSet.next());
     }
 
+    @Test
     public void testGetSchemaNormalTableTypes() throws Exception {
         if (!isConfigured()) {
             return;
@@ -234,6 +245,7 @@ public class SQLServerJtdsDriverTest extends AbstractJdbIntegrationTest {
         assertEquals(26, salesSchema.getTableCount());
     }
 
+    @Test
     public void testGetSchemaAllTableTypes() throws Exception {
         if (!isConfigured()) {
             return;
@@ -249,6 +261,7 @@ public class SQLServerJtdsDriverTest extends AbstractJdbIntegrationTest {
         assertTrue(strategy.getSchemaNames().containsAll(expectedSchemaNames));
     }
 
+    @Test
     public void testQueryRewriterQuoteAliases() throws Exception {
         if (!isConfigured()) {
             return;
@@ -288,6 +301,7 @@ public class SQLServerJtdsDriverTest extends AbstractJdbIntegrationTest {
         data.close();
     }
 
+    @Test
     public void testQuotedString() throws Exception {
         if (!isConfigured()) {
             return;
@@ -308,6 +322,7 @@ public class SQLServerJtdsDriverTest extends AbstractJdbIntegrationTest {
                 queryRewriter.rewriteQuery(q));
     }
 
+    @Test
     public void testMaxAndOffset() throws Exception {
         if (!isConfigured()) {
             return;

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/SQLServerMicrosoftDriverTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/SQLServerMicrosoftDriverTest.java
@@ -30,6 +30,9 @@ import org.apache.metamodel.schema.Schema;
 import org.apache.metamodel.schema.Table;
 import org.apache.metamodel.schema.TableType;
 
+import org.junit.Test;
+import static org.junit.Assert.*;
+
 /**
  * Test case that tests MS SQL Server interaction. The test uses the
  * "AdventureWorks" sample database which can be downloaded from codeplex.
@@ -47,6 +50,7 @@ public class SQLServerMicrosoftDriverTest extends AbstractJdbIntegrationTest {
         return "sqlserver.microsoft_driver";
     }
 
+    @Test
     public void testQueryUsingExpressions() throws Exception {
         if (!isConfigured()) {
             return;
@@ -66,6 +70,7 @@ public class SQLServerMicrosoftDriverTest extends AbstractJdbIntegrationTest {
         assertFalse(dataSet.next());
     }
 
+    @Test
     public void testGetSchemaNormalTableTypes() throws Exception {
         if (!isConfigured()) {
             return;
@@ -91,6 +96,7 @@ public class SQLServerMicrosoftDriverTest extends AbstractJdbIntegrationTest {
 
     }
 
+    @Test
     public void testGetSchemaAllTableTypes() throws Exception {
         if (!isConfigured()) {
             return;
@@ -105,6 +111,7 @@ public class SQLServerMicrosoftDriverTest extends AbstractJdbIntegrationTest {
         assertEquals("Schema[name=dbo]", strategy.getDefaultSchema().toString());
     }
 
+    @Test
     public void testQueryRewriterQuoteAliases() throws Exception {
         if (!isConfigured()) {
             return;
@@ -145,6 +152,7 @@ public class SQLServerMicrosoftDriverTest extends AbstractJdbIntegrationTest {
         data.close();
     }
 
+    @Test
     public void testQuotedString() throws Exception {
         if (!isConfigured()) {
             return;

--- a/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/SQLServerMicrosoftDriverTest.java
+++ b/jdbc/src/test/java/org/apache/metamodel/jdbc/integrationtests/SQLServerMicrosoftDriverTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.metamodel.jdbc.integrationtests;
 
+import static org.junit.Assert.*;
+
 import java.util.Arrays;
 
 import org.apache.metamodel.data.DataSet;
@@ -31,7 +33,6 @@ import org.apache.metamodel.schema.Table;
 import org.apache.metamodel.schema.TableType;
 
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 /**
  * Test case that tests MS SQL Server interaction. The test uses the


### PR DESCRIPTION
Fixes the following error when running the JDBC integration test:

```
ERROR 17:38:56 JdbcUtils - Could not execute batch: INSERT INTO "public"."my_table" ("person name",age) VALUES ('John Doe','42'): Batch entry 0 INSERT INTO "public"."my_table" ("person name",age) VALUES ('John Doe','42') was aborted: ERROR: column
 "age" is of type integer but expression is of type character varying
 ```