### PR TITLE
Build on Travis fails most of the time

### DIFF
--- a/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
+++ b/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
@@ -329,8 +329,7 @@ public class ElasticSearchUtils {
         if (subFieldName.contains(".")) {
             @SuppressWarnings("unchecked")
             final Map<String, Object> nestedValueMap = (Map<String, Object>) valueMap
-                    .computeIfAbsent(subFieldName.substring(0, subFieldName.indexOf('.')), key -> createNestedValueMap(
-                            valueMap, key));
+                    .computeIfAbsent(subFieldName.substring(0, subFieldName.indexOf('.')), key -> new HashMap<>());
 
             evaluateField(sourceMap, nestedValueMap, sourceFieldName, subFieldName
                     .substring(subFieldName.indexOf('.') + 1));
@@ -338,14 +337,5 @@ public class ElasticSearchUtils {
             valueMap.put(subFieldName, sourceMap.get(sourceFieldName));
         }
         logger.info("Done evaluating sourceField: " + sourceFieldName + ", with subFieldName: " + subFieldName);
-    }
-
-    private static Object createNestedValueMap(final Map<String, Object> valueMap, final String nestedFieldName) {
-        logger.info("Start creating nested value map for nestedFieldName: " + nestedFieldName);
-        final Map<String, Object> nestedValueMap = new HashMap<>();
-        valueMap.put(nestedFieldName, nestedValueMap);
-        logger.info("Done creating nested value map for nestedFieldName: " + nestedFieldName);
-
-        return nestedValueMap;
     }
 }

--- a/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
+++ b/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
@@ -45,6 +45,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 
 public class ElasticSearchUtils {
+
     public static final String FIELD_ID = "_id";
     public static final String SYSTEM_PROPERTY_STRIP_INVALID_FIELD_CHARS = "metamodel.elasticsearch.strip_invalid_field_chars";
 

--- a/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
+++ b/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
@@ -43,12 +43,8 @@ import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ElasticSearchUtils {
-    private static final Logger logger = LoggerFactory.getLogger(ElasticSearchUtils.class);
-
     public static final String FIELD_ID = "_id";
     public static final String SYSTEM_PROPERTY_STRIP_INVALID_FIELD_CHARS = "metamodel.elasticsearch.strip_invalid_field_chars";
 
@@ -298,7 +294,6 @@ public class ElasticSearchUtils {
                         // mapping of the index described a column to be of the type "MAP", while it's based on a number
                         // of fields containing dots in their name. In this case we may have to work around that
                         // inconsistency by creating column names with dots ourselves, based on the schema.
-                        logger.info("Start creating valueMap.");
                         final Map<String, Object> valueMap = new HashMap<>();
 
                         sourceMap
@@ -307,8 +302,6 @@ public class ElasticSearchUtils {
                                 .filter(fieldName -> fieldName.startsWith(column.getName() + "."))
                                 .forEach(fieldName -> evaluateField(sourceMap, valueMap, fieldName, fieldName
                                         .substring(fieldName.indexOf('.') + 1)));
-
-                        logger.info("Done creating valueMap.");
 
                         if (!valueMap.isEmpty()) {
                             values[i] = valueMap;
@@ -325,7 +318,6 @@ public class ElasticSearchUtils {
 
     private static void evaluateField(final Map<String, Object> sourceMap, final Map<String, Object> valueMap,
             final String sourceFieldName, final String subFieldName) {
-        logger.info("Start evaluating sourceField: " + sourceFieldName + ", with subFieldName: " + subFieldName);
         if (subFieldName.contains(".")) {
             @SuppressWarnings("unchecked")
             final Map<String, Object> nestedValueMap = (Map<String, Object>) valueMap
@@ -336,6 +328,5 @@ public class ElasticSearchUtils {
         } else {
             valueMap.put(subFieldName, sourceMap.get(sourceFieldName));
         }
-        logger.info("Done evaluating sourceField: " + sourceFieldName + ", with subFieldName: " + subFieldName);
     }
 }

--- a/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
+++ b/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
@@ -43,8 +43,11 @@ import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ElasticSearchUtils {
+    private static final Logger logger = LoggerFactory.getLogger(ElasticSearchUtils.class);
 
     public static final String FIELD_ID = "_id";
     public static final String SYSTEM_PROPERTY_STRIP_INVALID_FIELD_CHARS = "metamodel.elasticsearch.strip_invalid_field_chars";
@@ -295,6 +298,7 @@ public class ElasticSearchUtils {
                         // mapping of the index described a column to be of the type "MAP", while it's based on a number
                         // of fields containing dots in their name. In this case we may have to work around that
                         // inconsistency by creating column names with dots ourselves, based on the schema.
+                        logger.info("Start creating valueMap.");
                         final Map<String, Object> valueMap = new HashMap<>();
 
                         sourceMap
@@ -303,6 +307,8 @@ public class ElasticSearchUtils {
                                 .filter(fieldName -> fieldName.startsWith(column.getName() + "."))
                                 .forEach(fieldName -> evaluateField(sourceMap, valueMap, fieldName, fieldName
                                         .substring(fieldName.indexOf('.') + 1)));
+
+                        logger.info("Done creating valueMap.");
 
                         if (!valueMap.isEmpty()) {
                             values[i] = valueMap;
@@ -319,6 +325,7 @@ public class ElasticSearchUtils {
 
     private static void evaluateField(final Map<String, Object> sourceMap, final Map<String, Object> valueMap,
             final String sourceFieldName, final String subFieldName) {
+        logger.info("Start evaluating sourceField: " + sourceFieldName + ", with subFieldName: " + subFieldName);
         if (subFieldName.contains(".")) {
             @SuppressWarnings("unchecked")
             final Map<String, Object> nestedValueMap = (Map<String, Object>) valueMap
@@ -330,11 +337,14 @@ public class ElasticSearchUtils {
         } else {
             valueMap.put(subFieldName, sourceMap.get(sourceFieldName));
         }
+        logger.info("Done evaluating sourceField: " + sourceFieldName + ", with subFieldName: " + subFieldName);
     }
 
     private static Object createNestedValueMap(final Map<String, Object> valueMap, final String nestedFieldName) {
+        logger.info("Start creating nested value map for nestedFieldName: " + nestedFieldName);
         final Map<String, Object> nestedValueMap = new HashMap<>();
         valueMap.put(nestedFieldName, nestedValueMap);
+        logger.info("Done creating nested value map for nestedFieldName: " + nestedFieldName);
 
         return nestedValueMap;
     }

--- a/excel/src/test/java/org/apache/metamodel/excel/ExcelDataContextTest.java
+++ b/excel/src/test/java/org/apache/metamodel/excel/ExcelDataContextTest.java
@@ -21,7 +21,6 @@ package org.apache.metamodel.excel;
 import static org.junit.Assert.*;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -64,7 +63,6 @@ public class ExcelDataContextTest {
      * 
      * @param path
      * @return
-     * @throws IOException 
      */
     private File copyOf(String path) {
         final File srcFile = new File(path);

--- a/excel/src/test/java/org/apache/metamodel/excel/ExcelDataContextTest.java
+++ b/excel/src/test/java/org/apache/metamodel/excel/ExcelDataContextTest.java
@@ -18,13 +18,15 @@
  */
 package org.apache.metamodel.excel;
 
+import static org.junit.Assert.*;
+
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 
 import org.apache.metamodel.DataContext;
-import org.apache.metamodel.MetaModelException;
 import org.apache.metamodel.MetaModelHelper;
 import org.apache.metamodel.UpdateCallback;
 import org.apache.metamodel.UpdateScript;
@@ -44,26 +46,34 @@ import org.apache.metamodel.util.DateUtils;
 import org.apache.metamodel.util.FileHelper;
 import org.apache.metamodel.util.FileResource;
 import org.apache.metamodel.util.Month;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
 
-import junit.framework.TestCase;
+public class ExcelDataContextTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
-public class ExcelDataContextTest extends TestCase {
-
+    @Rule
+    public TestName testName = new TestName();
+    
     /**
      * Creates a copy of a particular file - to avoid changing of Excel files
      * under source control
      * 
      * @param path
      * @return
+     * @throws IOException 
      */
     private File copyOf(String path) {
         final File srcFile = new File(path);
-        final File destFile = new File("target/" + getName() + "-" + srcFile.getName());
+        final File destFile = new File(folder.getRoot(), testName.getMethodName() + "-" + srcFile.getName());
         FileHelper.copy(srcFile, destFile);
         return destFile;
     }
 
+    @Test
     public void testErroneousConstructors() throws Exception {
         try {
             new ExcelDataContext(null);
@@ -81,6 +91,7 @@ public class ExcelDataContextTest extends TestCase {
         }
     }
 
+    @Test
     public void testEmptyFile() throws Exception {
         File file = copyOf("src/test/resources/empty_file.xls");
         ExcelDataContext dc = new ExcelDataContext(file);
@@ -95,6 +106,7 @@ public class ExcelDataContextTest extends TestCase {
         assertSame(file, ((FileResource) dc.getResource()).getFile());
     }
 
+    @Test
     public void testEmptyFileNoHeaderLine() throws Exception {
         DataContext dc = new ExcelDataContext(copyOf("src/test/resources/empty_file.xls"), new ExcelConfiguration(
                 ExcelConfiguration.NO_COLUMN_NAME_LINE, false, false));
@@ -105,6 +117,7 @@ public class ExcelDataContextTest extends TestCase {
         assertEquals(0, table.getColumnCount());
     }
 
+    @Test
     public void testUnexistingHeaderLine() throws Exception {
         DataContext dc = new ExcelDataContext(copyOf("src/test/resources/xls_people.xls"), new ExcelConfiguration(20,
                 true, false));
@@ -115,6 +128,7 @@ public class ExcelDataContextTest extends TestCase {
         assertEquals(0, table.getColumnCount());
     }
 
+    @Test
     public void testSkipEmptyColumns() throws Exception {
         ExcelConfiguration conf = new ExcelConfiguration(ExcelConfiguration.DEFAULT_COLUMN_NAME_LINE, true, true);
         ExcelDataContext dc = new ExcelDataContext(copyOf("src/test/resources/skipped_lines.xlsx"), conf);
@@ -126,6 +140,7 @@ public class ExcelDataContextTest extends TestCase {
         assertEquals("1", ds.getRow().getValue(0));
     }
 
+    @Test
     public void testDontSkipEmptyLinesNoHeader() throws Exception {
         ExcelConfiguration conf = new ExcelConfiguration(ExcelConfiguration.NO_COLUMN_NAME_LINE, false, true);
         ExcelDataContext dc = new ExcelDataContext(copyOf("src/test/resources/skipped_lines.xlsx"), conf);
@@ -150,6 +165,7 @@ public class ExcelDataContextTest extends TestCase {
         assertEquals("1", ds.getRow().getValue(0));
     }
 
+    @Test
     public void testDontSkipEmptyLinesAbsoluteHeader() throws Exception {
         ExcelConfiguration conf = new ExcelConfiguration(6, false, true);
         ExcelDataContext dc = new ExcelDataContext(copyOf("src/test/resources/skipped_lines.xlsx"), conf);
@@ -163,6 +179,7 @@ public class ExcelDataContextTest extends TestCase {
         assertEquals("1", ds.getRow().getValue(0));
     }
 
+    @Test
     public void testInvalidFormula() throws Exception {
         ExcelDataContext dc = new ExcelDataContext(copyOf("src/test/resources/invalid_formula.xls"));
         Table table = dc.getDefaultSchema().getTables().get(0);
@@ -200,6 +217,7 @@ public class ExcelDataContextTest extends TestCase {
         ds.close();
     }
 
+    @Test
     public void testEvaluateFormula() throws Exception {
         ExcelDataContext dc = new ExcelDataContext(copyOf("src/test/resources/xls_formulas.xls"));
 
@@ -276,6 +294,7 @@ public class ExcelDataContextTest extends TestCase {
         assertFalse(ds.next());
     }
 
+    @Test
     public void testSingleCellSheet() throws Exception {
         ExcelDataContext dc = new ExcelDataContext(copyOf("src/test/resources/xls_single_cell_sheet.xls"));
 
@@ -290,6 +309,7 @@ public class ExcelDataContextTest extends TestCase {
         assertFalse(ds.next());
     }
 
+    @Test
     public void testOpenXlsxFormat() throws Exception {
         ExcelDataContext dc = new ExcelDataContext(copyOf("src/test/resources/Spreadsheet2007.xlsx"));
         Schema schema = dc.getDefaultSchema();
@@ -314,6 +334,7 @@ public class ExcelDataContextTest extends TestCase {
         assertEquals("[bar, 4, 2010-01-04 00:00:00]", Arrays.toString(objectArrays.get(3)));
     }
 
+    @Test
     public void testConfigurationWithoutHeader() throws Exception {
         File file = copyOf("src/test/resources/xls_people.xls");
         DataContext dc = new ExcelDataContext(file, new ExcelConfiguration(ExcelConfiguration.NO_COLUMN_NAME_LINE,
@@ -337,6 +358,7 @@ public class ExcelDataContextTest extends TestCase {
         assertFalse(dataSet.next());
     }
 
+    @Test
     public void testConfigurationNonDefaultColumnNameLineNumber() throws Exception {
         File file = copyOf("src/test/resources/xls_people.xls");
         DataContext dc = new ExcelDataContext(file, new ExcelConfiguration(2, true, true));
@@ -358,6 +380,7 @@ public class ExcelDataContextTest extends TestCase {
         assertFalse(dataSet.next());
     }
 
+    @Test
     public void testGetSchemas() throws Exception {
         File file = copyOf("src/test/resources/xls_people.xls");
         DataContext dc = new ExcelDataContext(file);
@@ -379,6 +402,7 @@ public class ExcelDataContextTest extends TestCase {
         assertEquals("age", columns[3].getName());
     }
 
+    @Test
     public void testMaterializeTable() throws Exception {
         File file = copyOf("src/test/resources/xls_people.xls");
         ExcelDataContext dc = new ExcelDataContext(file);
@@ -401,6 +425,7 @@ public class ExcelDataContextTest extends TestCase {
         assertNull(dataSet.getRow());
     }
 
+    @Test
     public void testMissingValues() throws Exception {
         File file = copyOf("src/test/resources/xls_missing_values.xls");
         DataContext dc = new ExcelDataContext(file);
@@ -425,6 +450,7 @@ public class ExcelDataContextTest extends TestCase {
         assertFalse(ds.next());
     }
 
+    @Test
     public void testMissingColumnHeader() throws Exception {
         File file = copyOf("src/test/resources/xls_missing_column_header.xls");
         DataContext dc = new ExcelDataContext(file);
@@ -449,6 +475,7 @@ public class ExcelDataContextTest extends TestCase {
         assertFalse(ds.next());
     }
 
+    @Test
     public void testXlsxFormulas() throws Exception {
         File file = copyOf("src/test/resources/formulas.xlsx");
         ExcelDataContext dc = new ExcelDataContext(file);
@@ -525,6 +552,7 @@ public class ExcelDataContextTest extends TestCase {
         assertFalse(ds.next());
     }
 
+    @Test
     public void testTicket99defect() throws Exception {
         File file = copyOf("src/test/resources/ticket_199_inventory.xls");
         DataContext dc = new ExcelDataContext(file);
@@ -546,6 +574,7 @@ public class ExcelDataContextTest extends TestCase {
                 Arrays.toString(table.getColumns().toArray()));
     }
 
+    @Test
     public void testInsertInto() throws Exception {
         final File file = copyOf("src/test/resources/xls_people.xls");
 
@@ -600,12 +629,14 @@ public class ExcelDataContextTest extends TestCase {
         assertFalse(ds.next());
     }
 
+    @Test
     public void testCreateTableXls() throws Exception {
         // run the same test with both XLS and XLSX (because of different
         // workbook implementations)
         runCreateTableTest(new File("target/xls_people_created.xls"));
     }
 
+    @Test
     public void testCreateTableXlsx() throws Exception {
         // run the same test with both XLS and XLSX (because of different
         // workbook implementations)
@@ -703,6 +734,7 @@ public class ExcelDataContextTest extends TestCase {
         assertEquals(2, dc.getDefaultSchema().getTableCount());
     }
 
+    @Test
     public void testGetStyles() throws Exception {
         DataContext dc = new ExcelDataContext(copyOf("src/test/resources/styles.xlsx"));
         Table table = dc.getDefaultSchema().getTables().get(0);
@@ -766,6 +798,7 @@ public class ExcelDataContextTest extends TestCase {
      * Tests that you can execute a query on a ExcelDataContext even though the
      * schema has not yet been (explicitly) loaded.
      */
+    @Test
     public void testExecuteQueryBeforeLoadingSchema() throws Exception {
         // first use one DataContext to retreive the schema/table/column objects
         ExcelDataContext dc1 = new ExcelDataContext(copyOf("src/test/resources/Spreadsheet2007.xlsx"));
@@ -783,6 +816,7 @@ public class ExcelDataContextTest extends TestCase {
         ds.close();
     }
 
+    @Test
     public void testCustomColumnNames() throws Exception {
         final String firstColumnName = "first";
         final String secondColumnName = "second";
@@ -799,10 +833,12 @@ public class ExcelDataContextTest extends TestCase {
         assertNotNull(table.getColumnByName(thirdColumnName));
     }
 
+    @Test
     public void testDetectingDifferentDataTypesInXls() throws Exception {
         detectingDataTypes("src/test/resources/different_datatypes.xls");
     }
 
+    @Test
     public void testDifferentDataTypesInXlsx() throws Exception {
         detectingDataTypes("src/test/resources/different_datatypes.xlsx");
     }
@@ -831,6 +867,7 @@ public class ExcelDataContextTest extends TestCase {
         assertFalse(countDataSet.next());
     }
 
+    @Test
     public void testCellValueWithWrongDatatypeIsSetToNull() {
         // Unless Integers and Doubles are mixed all other incorrect values will be converted to null with a warning
         final DataContext dataContext = new ExcelDataContext(copyOf("src/test/resources/different_datatypes.xls"),
@@ -850,6 +887,7 @@ public class ExcelDataContextTest extends TestCase {
         assertFalse(testWrongDatatypeDataSet.next());
     }
 
+    @Test
     public void testDetectingDataTypeNotSkippingLinesAndColumnsUsingNameLine() {
         final ExcelDataContext dataContext = new ExcelDataContext(copyOf("src/test/resources/skipped_lines.xlsx"),
                 new ExcelConfiguration(6, null, false, false, true, 3));
@@ -859,6 +897,7 @@ public class ExcelDataContextTest extends TestCase {
         assertEquals(ColumnType.INTEGER, table.getColumns().get(7).getType());
     }
 
+    @Test
     public void testDetectingDataTypeNotSkippingLinesAndColumnsNoNameLine() {
         final ExcelDataContext dataContext = new ExcelDataContext(copyOf("src/test/resources/skipped_lines.xlsx"),
                 new ExcelConfiguration(ExcelConfiguration.NO_COLUMN_NAME_LINE, null, false, false, true, 3));
@@ -868,6 +907,7 @@ public class ExcelDataContextTest extends TestCase {
         assertEquals(ColumnType.INTEGER, table.getColumns().get(7).getType());
     }
 
+    @Test
     public void testDetectingDataTypeSkippingLinesAndColumnsUsingNameLine() {
         final ExcelDataContext dataContext = new ExcelDataContext(copyOf("src/test/resources/skipped_lines.xlsx"),
                 new ExcelConfiguration(ExcelConfiguration.DEFAULT_COLUMN_NAME_LINE, null, true, true, true, 3));
@@ -876,6 +916,7 @@ public class ExcelDataContextTest extends TestCase {
         assertEquals(ColumnType.INTEGER, table.getColumns().get(1).getType());
     }
 
+    @Test
     public void testDetectingDataTypeSkippingLinesAndColumnsNoNameLine() {
         final ExcelDataContext dataContext = new ExcelDataContext(copyOf("src/test/resources/skipped_lines.xlsx"),
                 new ExcelConfiguration(ExcelConfiguration.NO_COLUMN_NAME_LINE, null, true, true, true, 3));
@@ -884,6 +925,7 @@ public class ExcelDataContextTest extends TestCase {
         assertEquals(ColumnType.INTEGER, table.getColumns().get(1).getType());
     }
 
+    @Test
     public void testToMuchNumberOfLinesToScan() throws Exception {
         final ExcelDataContext dataContext = new ExcelDataContext(copyOf("src/test/resources/skipped_lines.xlsx"),
                 new ExcelConfiguration(ExcelConfiguration.DEFAULT_COLUMN_NAME_LINE, null, true, true, true, 4));
@@ -898,6 +940,7 @@ public class ExcelDataContextTest extends TestCase {
         assertEquals(3L, dataSet.getRow().getValue(0));
     }
 
+    @Test
     public void testToMissingValueDoesntEffectDetectedType() throws Exception {
         final ExcelDataContext dataContext = new ExcelDataContext(copyOf("src/test/resources/xls_missing_values.xls"),
                 new ExcelConfiguration(ExcelConfiguration.DEFAULT_COLUMN_NAME_LINE, null, true, false, true, 3));
@@ -919,6 +962,7 @@ public class ExcelDataContextTest extends TestCase {
         assertEquals(12, dataSetColumnD.getRow().getValue(0));
     }
 
+    @Test
     public void testInsertingValueOfValidColumnType() {
         final ExcelDataContext dataContext = new ExcelDataContext(copyOf("src/test/resources/different_datatypes.xls"),
                 new ExcelConfiguration(ExcelConfiguration.DEFAULT_COLUMN_NAME_LINE, null, true, false, true, 19));
@@ -928,7 +972,7 @@ public class ExcelDataContextTest extends TestCase {
         assertTrue(dataSet.next());
     }
 
-    @Test(expected = MetaModelException.class)
+    @Test
     public void testInsertingValueOfInvalidColumnType() {
         final ExcelDataContext dataContext = new ExcelDataContext(copyOf("src/test/resources/different_datatypes.xls"),
                 new ExcelConfiguration(ExcelConfiguration.DEFAULT_COLUMN_NAME_LINE, null, true, false, true, 19));
@@ -936,6 +980,7 @@ public class ExcelDataContextTest extends TestCase {
         dataContext.executeUpdate(new InsertInto(table).value("INTEGER", "this is not an integer"));
     }
 
+    @Test
     public void testUpdatingValueOfValidColumnType() {
         final ExcelDataContext dataContext = new ExcelDataContext(copyOf("src/test/resources/different_datatypes.xls"),
                 new ExcelConfiguration(ExcelConfiguration.DEFAULT_COLUMN_NAME_LINE, null, true, false, true, 19));
@@ -945,7 +990,7 @@ public class ExcelDataContextTest extends TestCase {
         assertTrue(dataSet.next());
     }
 
-    @Test(expected = MetaModelException.class)
+    @Test
     public void testUpdatingValueOfInvalidColumnType() {
         final ExcelDataContext dataContext = new ExcelDataContext(copyOf("src/test/resources/different_datatypes.xls"),
                 new ExcelConfiguration(ExcelConfiguration.DEFAULT_COLUMN_NAME_LINE, null, true, false, true, 19));


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/METAMODEL-1232.

- I refactored the `ExcelDataContextTest` from using JUnit 3 to JUnit 4, so it can use the ` TemporaryFolder` rule for copying files when using them it tests. It seems this works better than when copying them to the target folder.
- I refactored the logic used by `ElasticSearchUtils#createRow(...)`  for creating a row based on a MAP column type. It uses `computeIfAbsent` to put a `HashMap`  in a `Map`, but then within the method that created that `HashMap`, it would already add the created `HashMap` to the `Map`, which is something that should be handled by the `computeIfAbsent` itself, which apparently can lead to `ConcurrentModificationExpection`s being thrown.