### PR TITLE
METAMODEL-1233: Elasticsearch uses 'match' query for text based columns conditions in WHERE clause

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### Apache MetaModel [WIP]
 
+ * [METAMODEL-1233] - Elasticsearch: "term" query is used for text search.
  * [METAMODEL-1229] - FixedWidth works with UrlResource/HttpInputStream.
  * [METAMODEL-1228] - Better handling of fieldnames with dots in Elasticsearch
  * [METAMODEL-1227] - Better handling of nested objects in Elasticsearch data

--- a/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
+++ b/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
@@ -202,6 +202,8 @@ public class ElasticSearchUtils {
                 if (OperatorType.EQUALS_TO.equals(operator)) {
                     if (operand == null) {
                         itemQueryBuilder = getMissingQuery(fieldName);
+                    } else if (column.getType().isLiteral()) {
+                        itemQueryBuilder = QueryBuilders.matchQuery(fieldName, operand);
                     } else {
                         itemQueryBuilder = QueryBuilders.termQuery(fieldName, operand);
                     }

--- a/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
+++ b/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
@@ -216,7 +216,11 @@ public class ElasticSearchUtils {
                     }
                 } else if (OperatorType.IN.equals(operator)) {
                     final List<?> operands = CollectionUtils.toList(operand);
-                    itemQueryBuilder = QueryBuilders.termsQuery(fieldName, operands);
+                    if (column.getType().isLiteral()) {
+                        itemQueryBuilder = QueryBuilders.termQuery(fieldName, operand);
+                    } else {
+                        itemQueryBuilder = QueryBuilders.termsQuery(fieldName, operands);
+                    }
                 } else {
                     // not (yet) support operator types
                     return null;

--- a/elasticsearch/common/src/test/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtilsTest.java
+++ b/elasticsearch/common/src/test/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtilsTest.java
@@ -18,15 +18,24 @@
  */
 package org.apache.metamodel.elasticsearch.common;
 
-import junit.framework.TestCase;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.metamodel.data.DataSetHeader;
 import org.apache.metamodel.data.Row;
 import org.apache.metamodel.data.SimpleDataSetHeader;
+import org.apache.metamodel.query.FilterItem;
+import org.apache.metamodel.query.OperatorType;
 import org.apache.metamodel.query.SelectItem;
 import org.apache.metamodel.schema.ColumnType;
 import org.apache.metamodel.schema.MutableColumn;
+import org.elasticsearch.index.query.QueryBuilder;
 
-import java.util.*;
+import junit.framework.TestCase;
 
 public class ElasticSearchUtilsTest extends TestCase {
 
@@ -59,5 +68,16 @@ public class ElasticSearchUtilsTest extends TestCase {
 
         assertTrue(stringValue instanceof String);
         assertTrue(dateValue instanceof Date);
+    }
+
+    /**
+     * For text-based conditions a 'match' query is recommended (instead of 'term' query).
+     */
+    public void testMatchQueryIsCreatedForTextFilter() {
+        final SelectItem selectItem = new SelectItem(new MutableColumn("column_name", ColumnType.STRING));
+        final FilterItem filterItem = new FilterItem(selectItem, OperatorType.EQUALS_TO, "text-value");
+        final QueryBuilder queryBuilder =
+                ElasticSearchUtils.createQueryBuilderForSimpleWhere(Collections.singletonList(filterItem), null);
+        assertEquals("match", queryBuilder.getName());
     }
 }

--- a/elasticsearch/common/src/test/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtilsTest.java
+++ b/elasticsearch/common/src/test/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtilsTest.java
@@ -73,11 +73,36 @@ public class ElasticSearchUtilsTest extends TestCase {
     /**
      * For text-based conditions a 'match' query is recommended (instead of 'term' query).
      */
-    public void testMatchQueryIsCreatedForTextFilter() {
+    public void testMatchQueryIsCreatedForTextEqualTo() {
         final SelectItem selectItem = new SelectItem(new MutableColumn("column_name", ColumnType.STRING));
         final FilterItem filterItem = new FilterItem(selectItem, OperatorType.EQUALS_TO, "text-value");
         final QueryBuilder queryBuilder =
                 ElasticSearchUtils.createQueryBuilderForSimpleWhere(Collections.singletonList(filterItem), null);
         assertEquals("match", queryBuilder.getName());
+    }
+
+    /**
+     * For text-based conditions a 'match' query is recommended (instead of 'term' query).
+     * In case of 'DIFFERENT_FROM', we need a 'bool' query with 'must not' and 'match' query.
+     */
+    public void testBoolQueryIsCreatedForTextDifferentFrom() {
+        final SelectItem selectItem = new SelectItem(new MutableColumn("column_name", ColumnType.STRING));
+        final FilterItem filterItem = new FilterItem(selectItem, OperatorType.DIFFERENT_FROM, "text-value");
+        final QueryBuilder queryBuilder =
+                ElasticSearchUtils.createQueryBuilderForSimpleWhere(Collections.singletonList(filterItem), null);
+        assertEquals("bool", queryBuilder.getName());
+    }
+
+    /**
+     * For text-based conditions a 'match' query is recommended (instead of 'term' query).
+     * To simulate 'IN' operator, we need a 'bool' query with multiple 'match' queries combined with 'OR'.
+     */
+    public void testBoolQueryIsCreatedForTextIn() {
+        final SelectItem selectItem = new SelectItem(new MutableColumn("column_name", ColumnType.STRING));
+        final FilterItem filterItem =
+                new FilterItem(selectItem, OperatorType.IN, Arrays.asList("text-value-a", "text-value-b"));
+        final QueryBuilder queryBuilder =
+                ElasticSearchUtils.createQueryBuilderForSimpleWhere(Collections.singletonList(filterItem), null);
+        assertEquals("bool", queryBuilder.getName());
     }
 }


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/METAMODEL-1233 

Elasticsearch used a 'term' query for `WHERE text_based_column = 'text-value'` situations. This PR introduces a new condition covering this scenario and creating a 'match' query instead. 