### PR TITLE
Remove redundant dependencies

### DIFF
--- a/hadoop/pom.xml
+++ b/hadoop/pom.xml
@@ -28,6 +28,36 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-client</artifactId>
+			<exclusions>
+				<exclusion>
+				    <groupId>com.sun.jersey</groupId>
+				    <artifactId>jersey-core</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>com.sun.jersey</groupId>
+				    <artifactId>jersey-servlet</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>javax.servlet.jsp</groupId>
+				    <artifactId>jsp-api</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>javax.servlet</groupId>
+				    <artifactId>javax.servlet-api</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>com.sun.jersey</groupId>
+				    <artifactId>jersey-client</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>org.apache.kerby</groupId>
+				    <artifactId>kerby-xdr</artifactId>
+				</exclusion>
+				<exclusion>
+				    <groupId>com.fasterxml.jackson.jaxrs</groupId>
+				    <artifactId>jackson-jaxrs-json-provider</artifactId>
+				</exclusion>
+            		</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>


### PR DESCRIPTION
@arjansh Hi, I am a user of project **_org.apache.metamodel:MetaModel-hadoop:5.3.3-SNAPSHOT_**. I found that its pom file introduced **_93_** dependencies. However, among them, **_9_** libraries (**_9%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. Finally, it can help enable advanced scenarios for users of your package. 
This PR helps **_org.apache.metamodel:MetaModel-hadoop:5.3.3-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
javax.servlet.jsp:jsp-api:jar:2.1:runtime
com.sun.jersey:jersey-servlet:jar:1.19:compile
org.apache.kerby:kerby-xdr:jar:1.0.1:compile
javax.servlet:javax.servlet-api:jar:3.1.0:compile
com.sun.jersey:jersey-core:jar:1.19:compile
javax.ws.rs:jsr311-api:jar:1.1.1:compile
com.sun.jersey:jersey-client:jar:1.19:compile
com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.7.8:compile
com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.7.8:compile
</code></pre>