### PR TITLE
MM-1235: AbstractDataContext.searchColumn was fixed for situation when schema and column are equal strings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### Apache MetaModel [WIP]
+
+ * [METAMODEL-1236] - Elasticsearch: not/empty and is/not null do not work for text based columns
+ * [METAMODEL-1235] - Elasticsearch: "String index out of range" when schema name and column name are equal
+ * [METAMODEL-1232] - Improve stability of Travis CI builds
+
 ### Apache MetaModel 5.3.3
 
  * [METAMODEL-1233] - Elasticsearch: "term" query is used for text search.

--- a/core/src/main/java/org/apache/metamodel/AbstractDataContext.java
+++ b/core/src/main/java/org/apache/metamodel/AbstractDataContext.java
@@ -309,22 +309,21 @@ public abstract class AbstractDataContext implements DataContext {
      */
     private Column searchColumn(String schemaNameSearch, String columnNameOriginal, String columnNameSearch) {
         final Schema schema = getSchemaByName(schemaNameSearch);
-        if (schema == null) {
-            return null;
-        }
-        if (columnNameSearch.equals(schemaNameSearch)) {
-            return getColumn(schema, columnNameSearch);
-        } else if (columnNameSearch.startsWith(schemaNameSearch)) {
-            String tableAndColumnPath = columnNameOriginal.substring(schemaNameSearch.length());
-            if (tableAndColumnPath.charAt(0) == '.') {
-                tableAndColumnPath = tableAndColumnPath.substring(1);
-                return getColumn(schema, tableAndColumnPath);
+        if (schema != null) {
+            if (columnNameSearch.equals(schemaNameSearch)) {
+                return getColumn(schema, columnNameSearch);
+            } else if (columnNameSearch.startsWith(schemaNameSearch)) {
+                String tableAndColumnPath = columnNameOriginal.substring(schemaNameSearch.length());
+                if (tableAndColumnPath.charAt(0) == '.') {
+                    tableAndColumnPath = tableAndColumnPath.substring(1);
+                    return getColumn(schema, tableAndColumnPath);
+                }
             }
         }
         return null;
     }
 
-    private final Column getColumn(final Schema schema, final String tableAndColumnPath) {
+    private Column getColumn(final Schema schema, final String tableAndColumnPath) {
         Table table = null;
         String columnPath = tableAndColumnPath;
         final List<String> tableNames = schema.getTableNames();

--- a/core/src/main/java/org/apache/metamodel/AbstractDataContext.java
+++ b/core/src/main/java/org/apache/metamodel/AbstractDataContext.java
@@ -308,19 +308,17 @@ public abstract class AbstractDataContext implements DataContext {
      * @return
      */
     private Column searchColumn(String schemaNameSearch, String columnNameOriginal, String columnNameSearch) {
-        if (columnNameSearch.startsWith(schemaNameSearch)) {
-            Schema schema = getSchemaByName(schemaNameSearch);
-            if (schema != null) {
-                String tableAndColumnPath = columnNameOriginal.substring(schemaNameSearch.length());
-
-                if (tableAndColumnPath.charAt(0) == '.') {
-                    tableAndColumnPath = tableAndColumnPath.substring(1);
-
-                    Column column = getColumn(schema, tableAndColumnPath);
-                    if (column != null) {
-                        return column;
-                    }
-                }
+        final Schema schema = getSchemaByName(schemaNameSearch);
+        if (schema == null) {
+            return null;
+        }
+        if (columnNameSearch.equals(schemaNameSearch)) {
+            return getColumn(schema, columnNameSearch);
+        } else if (columnNameSearch.startsWith(schemaNameSearch)) {
+            String tableAndColumnPath = columnNameOriginal.substring(schemaNameSearch.length());
+            if (tableAndColumnPath.charAt(0) == '.') {
+                tableAndColumnPath = tableAndColumnPath.substring(1);
+                return getColumn(schema, tableAndColumnPath);
             }
         }
         return null;

--- a/core/src/main/java/org/apache/metamodel/AbstractDataContext.java
+++ b/core/src/main/java/org/apache/metamodel/AbstractDataContext.java
@@ -307,7 +307,8 @@ public abstract class AbstractDataContext implements DataContext {
      *            in case of case-insensitive search)
      * @return
      */
-    private Column searchColumn(String schemaNameSearch, String columnNameOriginal, String columnNameSearch) {
+    private Column searchColumn(final String schemaNameSearch, final String columnNameOriginal,
+            final String columnNameSearch) {
         final Schema schema = getSchemaByName(schemaNameSearch);
         if (schema != null) {
             if (columnNameSearch.equals(schemaNameSearch)) {


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/METAMODEL-1235. 

Problem in AbstractDataContext.searchColumn when schema name and column name are equal was fixed.
