### PR TITLE
Elasticsearch: not/empty and is/not null

### DIFF
--- a/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
+++ b/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
@@ -225,8 +225,6 @@ public class ElasticSearchUtils {
         if (OperatorType.EQUALS_TO.equals(filterItem.getOperator())) {
             if (filterItem.getOperand() == null) {
                 return getMissingQuery(column.getName());
-            } else if (filterItem.getOperand().equals("")) {
-                return QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery(column.getName()));
             } else {
                 return matchOrTermQuery(column, filterItem.getOperand());
             }
@@ -250,7 +248,7 @@ public class ElasticSearchUtils {
     }
 
     private static QueryBuilder matchOrTermQuery(final Column column, final Object operand) {
-        if (column.getType().isLiteral()) {
+        if (column.getType().isLiteral() && operand != null && !operand.equals("")) {
             return QueryBuilders.matchQuery(column.getName(), operand);
         } else {
             return QueryBuilders.termQuery(column.getName(), operand);

--- a/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
+++ b/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
@@ -225,6 +225,8 @@ public class ElasticSearchUtils {
         if (OperatorType.EQUALS_TO.equals(filterItem.getOperator())) {
             if (filterItem.getOperand() == null) {
                 return getMissingQuery(column.getName());
+            } else if (filterItem.getOperand().equals("")) {
+                return QueryBuilders.boolQuery().mustNot(QueryBuilders.wildcardQuery(column.getName(), "?*"));
             } else {
                 return matchOrTermQuery(column, filterItem.getOperand());
             }

--- a/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
+++ b/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
@@ -226,7 +226,7 @@ public class ElasticSearchUtils {
             if (filterItem.getOperand() == null) {
                 return getMissingQuery(column.getName());
             } else if (filterItem.getOperand().equals("")) {
-                return QueryBuilders.boolQuery().mustNot(QueryBuilders.wildcardQuery(column.getName(), "?*"));
+                return QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery(column.getName()));
             } else {
                 return matchOrTermQuery(column, filterItem.getOperand());
             }

--- a/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
+++ b/elasticsearch/common/src/main/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtils.java
@@ -225,7 +225,7 @@ public class ElasticSearchUtils {
         if (OperatorType.EQUALS_TO.equals(filterItem.getOperator())) {
             if (filterItem.getOperand() == null) {
                 return getMissingQuery(column.getName());
-            } else if (filterItem.getOperand().equals("")) {
+            } else if (column.getType().isLiteral() && filterItem.getOperand().equals("")) {
                 return QueryBuilders.boolQuery().mustNot(QueryBuilders.wildcardQuery(column.getName(), "?*"));
             } else {
                 return matchOrTermQuery(column, filterItem.getOperand());
@@ -233,6 +233,8 @@ public class ElasticSearchUtils {
         } else if (OperatorType.DIFFERENT_FROM.equals(filterItem.getOperator())) {
             if (filterItem.getOperand() == null) {
                 return getExistsQuery(column.getName());
+            } else if (column.getType().isLiteral() && filterItem.getOperand().equals("")) {
+                return QueryBuilders.boolQuery().must(QueryBuilders.wildcardQuery(column.getName(), "?*"));
             } else {
                 return QueryBuilders.boolQuery().mustNot(matchOrTermQuery(column, filterItem.getOperand()));
             }

--- a/elasticsearch/common/src/test/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtilsTest.java
+++ b/elasticsearch/common/src/test/java/org/apache/metamodel/elasticsearch/common/ElasticSearchUtilsTest.java
@@ -41,7 +41,7 @@ import junit.framework.TestCase;
 
 public class ElasticSearchUtilsTest extends TestCase {
 
-    public void testAssignDocumentIdForPrimaryKeys() throws Exception {
+    public void testAssignDocumentIdForPrimaryKeys() {
         MutableColumn primaryKeyColumn = new MutableColumn("value1", ColumnType.STRING).setPrimaryKey(true);
         SelectItem primaryKeyItem = new SelectItem(primaryKeyColumn);
         List<SelectItem> selectItems1 = Collections.singletonList(primaryKeyItem);
@@ -55,7 +55,7 @@ public class ElasticSearchUtilsTest extends TestCase {
         assertEquals(primaryKeyValue, documentId);
     }
 
-    public void testCreateRowWithParsableDates() throws Exception {
+    public void testCreateRowWithParsableDates() {
         SelectItem item1 = new SelectItem(new MutableColumn("value1", ColumnType.STRING));
         SelectItem item2 = new SelectItem(new MutableColumn("value2", ColumnType.DATE));
         List<SelectItem> selectItems1 = Arrays.asList(item1, item2);

--- a/elasticsearch/rest/src/test/java/org/apache/metamodel/elasticsearch/rest/ElasticSearchRestDataContextIT.java
+++ b/elasticsearch/rest/src/test/java/org/apache/metamodel/elasticsearch/rest/ElasticSearchRestDataContextIT.java
@@ -155,6 +155,7 @@ public class ElasticSearchRestDataContextIT {
         final int allCount =
                 ((Number) MetaModelHelper.executeSingleRowQuery(dataContext, allQuery).getValue(0)).intValue();
 
+        assertEquals(nullCount, 1);
         assertEquals(allCount, nullCount + notNullCount);
     }
 
@@ -180,6 +181,7 @@ public class ElasticSearchRestDataContextIT {
         final int allCount =
                 ((Number) MetaModelHelper.executeSingleRowQuery(dataContext, allQuery).getValue(0)).intValue();
 
+        assertEquals(emptyCount, 1);
         assertEquals(allCount, emptyCount + notEmptyCount);
     }
 


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/METAMODEL-1236. 

This PR fixes following operations in Elasticsearch: 

- new FilterItem(new SelectItem(column), OperatorType.EQUALS_TO, null)
- new FilterItem(new SelectItem(column), OperatorType.DIFFERENT_FROM, null)
- new FilterItem(new SelectItem(column), OperatorType.EQUALS_TO, "")
- new FilterItem(new SelectItem(column), OperatorType.DIFFERENT_FROM, "")