### PR TITLE
Updated getSchemas to directly call internal method

### DIFF
--- a/core/src/main/java/org/apache/metamodel/AbstractDataContext.java
+++ b/core/src/main/java/org/apache/metamodel/AbstractDataContext.java
@@ -77,7 +77,7 @@ public abstract class AbstractDataContext implements DataContext {
         for (final String name : schemaNames) {
             final Schema schema = _schemaCache.get(getSchemaCacheKey(name));
             if (schema == null) {
-                final Schema newSchema = getSchemaByName(name);
+                final Schema newSchema = getSchemaByNameInternal(name);
                 if (newSchema == null) {
                     throw new MetaModelException("Declared schema does not exist: " + name);
                 }


### PR DESCRIPTION
Currently the time complexity for getSchemas method is O(n^2) considering n number of schemas.
The getSchemaByName call in it can be replaced with getSchemaByNameInternal to reduce the complexity to O(n)